### PR TITLE
Migrate to controller-runtime logger in mpi job controller

### DIFF
--- a/pkg/controller.v1/mpi/mpijob_controller.go
+++ b/pkg/controller.v1/mpi/mpijob_controller.go
@@ -167,7 +167,7 @@ func (jc *MPIJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	t, err := util.DurationUntilExpireTime(&mpijob.Spec.RunPolicy, mpijob.Status)
 	if err != nil {
-		logger.Info("Reconcile MPIJob Job error", "error", err)
+		logger.Error(err, "Reconcile MPIJob Job error")
 		return ctrl.Result{}, err
 	}
 	if t >= 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/docs/development/developer_guide.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
As mentioned at #2048, we should migrate to Controller Runtime Logger while there are some types of logger currently. First, I modified it only in the MPI Job Controller since I want to determine a course of action. (I'm going to implement the remaining modifications in the next PR)

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2048

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
