### PR TITLE
Update Dockerfile with python debian image in cmd/initializer_v2/dataset/Dockerfile

### DIFF
--- a/cmd/initializer_v2/dataset/Dockerfile
+++ b/cmd/initializer_v2/dataset/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM python:3.11-slim-bookworm
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Updated Dockerfile with python debian image for resolving issue :- "Use Debian images for Python components in the Training Operator V2 #2311" in this dockerfile - **cmd/initializer_v2/dataset/Dockerfile**

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: This PR replaces the docker image from "_python:3.11-alpine_" to "_python:3.11-slim-bookworm_". As per the comment #2303.

**Which issue(s) this PR fixes** This PR  Fixes #2311 issue.