### PR TITLE
Fix read permission denied on train script when run as non-root

### DIFF
--- a/manifests/v2/base/runtimes/pre-training/torch-distributed.yaml
+++ b/manifests/v2/base/runtimes/pre-training/torch-distributed.yaml
@@ -31,3 +31,9 @@ spec:
                           env | grep PET_
 
                           pip list
+                      volumeMounts:
+                        - name: workspace
+                          mountPath: /workspace
+                  volumes:
+                    - name: workspace
+                      emptyDir: {}

--- a/sdk_v2/kubeflow/training/utils/utils.py
+++ b/sdk_v2/kubeflow/training/utils/utils.py
@@ -162,7 +162,6 @@ def get_args_using_train_func(
     # That allows to execute the training script with the entrypoint.
     exec_script = textwrap.dedent(
         """
-                program_path=$(mktemp -d)
                 read -r -d '' SCRIPT << EOM\n
                 {func_code}
                 EOM


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR writes the train function script into a tmp directory so it can be read when TrainJob containers run as non-root.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #2372.

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
