### PR TITLE
Use dictionary unpacking to pass trainer function arguments

### DIFF
--- a/sdk_v2/kubeflow/training/utils/utils.py
+++ b/sdk_v2/kubeflow/training/utils/utils.py
@@ -149,13 +149,17 @@ def get_args_using_train_func(
 
     # Wrap function code to execute it from the file. For example:
     # TODO (andreyvelich): Find a better way to run users' scripts.
-    # def train(parameters):
+    # def train(lr=0.001):
     #     print('Start Training...')
     # train({'lr': 0.01})
     if train_func_parameters is None:
         func_code = f"{func_code}\n{train_func.__name__}()\n"
     else:
-        func_code = f"{func_code}\n{train_func.__name__}({train_func_parameters})\n"
+        func_code = (
+            f"{func_code}\n"
+            f"kwargs={train_func_parameters}\n"
+            f"{train_func.__name__}(**kwargs)\n"
+        )
 
     # Prepare the template to execute script.
     # Currently, we override the file where the training function is defined.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Training Operator, check the developer guide:
    https://github.com/kubeflow/training-operator/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

It makes it possible to pass the training function argument unpacked, e.g.:

```
def train_func(batch_size=64,
               test_batch_size=1000,
               epochs=10,
               lr=1.0,
               gamma=0.7,
               dry_run=False,
               seed=1,
               log_interval=10,
               save_model=False):
...

client.train(
    trainer=Trainer(
        func=train_func,
        func_args={
            "batch_size": 64,
            "test_batch_size": 1000,
            "epochs": 10,
            "lr": 1.0,
            "gamma": 0.7,
            "dry_run": False,
            "seed": 1,
            "log_interval": 10,
            "save_model": False,
        },
    ),
)
```

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #2383

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/training/) included if any changes are user facing
