### PR TITLE
update migration url on readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Please refer to the [CHANGELOG](CHANGELOG.md).
 ## Kubeflow Training Operator V1
 
 Kubeflow Trainer project is currently in <strong>alpha</strong> status, and APIs may change.
-If you are using Kubeflow Training Operator V1, please refer [to this migration document](/docs/components/trainer/operator-guides/migration).
+If you are using Kubeflow Training Operator V1, please refer [to this migration document](https://www.kubeflow.org/docs/components/trainer/operator-guides/migration/).
 
 Kubeflow Community will maintain the Training Operator V1 source code at
 [the `release-1.9` branch](https://github.com/kubeflow/training-operator/tree/release-1.9).


### PR DESCRIPTION
Updating the link to the migration webpage in the README file.

**What this PR does / why we need it**:

The link to the migration content  in the README file is not working. 

