### PR TITLE
Add MPIMLPolicySource CRD defaulters

### DIFF
--- a/manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
@@ -68,6 +68,7 @@ spec:
                           Defaults to false.
                         type: boolean
                       sshAuthMountPath:
+                        default: /root/.ssh
                         description: |-
                           Directory where SSH keys are mounted.
                           Defaults to /root/.ssh.

--- a/manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
@@ -68,6 +68,7 @@ spec:
                           Defaults to false.
                         type: boolean
                       sshAuthMountPath:
+                        default: /root/.ssh
                         description: |-
                           Directory where SSH keys are mounted.
                           Defaults to /root/.ssh.

--- a/pkg/apis/trainer/v1alpha1/trainingruntime_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainingruntime_types.go
@@ -220,6 +220,7 @@ type MPIMLPolicySource struct {
 
 	// Directory where SSH keys are mounted.
 	// Defaults to /root/.ssh.
+	// +kubebuilder:default=/root/.ssh
 	SSHAuthMountPath *string `json:"sshAuthMountPath,omitempty"`
 
 	// Whether to run training process on the launcher Job.

--- a/pkg/runtime/framework/plugins/plainml/plainml_test.go
+++ b/pkg/runtime/framework/plugins/plainml/plainml_test.go
@@ -78,7 +78,7 @@ func TestPlainML(t *testing.T) {
 				runtime.WithMLPolicy(
 					utiltesting.MakeMLPolicyWrapper().
 						WithNumNodes(100).
-						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), nil, false).
+						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), nil, ptr.To(false)).
 						Obj(),
 				),
 			),
@@ -87,7 +87,7 @@ func TestPlainML(t *testing.T) {
 				runtime.WithMLPolicy(
 					utiltesting.MakeMLPolicyWrapper().
 						WithNumNodes(100).
-						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), nil, false).
+						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), nil, ptr.To(false)).
 						Obj(),
 				),
 			),

--- a/pkg/util/testing/wrapper.go
+++ b/pkg/util/testing/wrapper.go
@@ -680,6 +680,11 @@ func MakeTrainingRuntimeSpecWrapper(spec trainer.TrainingRuntimeSpec) *TrainingR
 	}
 }
 
+func (s *TrainingRuntimeSpecWrapper) JobSetSpec(spec jobsetv1alpha2.JobSetSpec) *TrainingRuntimeSpecWrapper {
+	s.Template.Spec = spec
+	return s
+}
+
 func (s *TrainingRuntimeSpecWrapper) WithMLPolicy(mlPolicy *trainer.MLPolicy) *TrainingRuntimeSpecWrapper {
 	s.MLPolicy = mlPolicy
 	return s
@@ -779,14 +784,14 @@ func (m *MLPolicyWrapper) TorchPolicy(numProcPerNode string, elasticPolicy *trai
 	return m
 }
 
-func (m *MLPolicyWrapper) MPIPolicy(numProcPerNode *int32, MPImplementation *trainer.MPIImplementation, sshAuthMountPath *string, runLauncherAsWorker bool) *MLPolicyWrapper {
+func (m *MLPolicyWrapper) MPIPolicy(numProcPerNode *int32, MPImplementation *trainer.MPIImplementation, sshAuthMountPath *string, runLauncherAsWorker *bool) *MLPolicyWrapper {
 	if m.MLPolicySource.MPI == nil {
 		m.MLPolicySource.MPI = &trainer.MPIMLPolicySource{}
 	}
 	m.MLPolicySource.MPI.NumProcPerNode = numProcPerNode
 	m.MLPolicySource.MPI.MPIImplementation = MPImplementation
 	m.MLPolicySource.MPI.SSHAuthMountPath = sshAuthMountPath
-	m.MLPolicySource.MPI.RunLauncherAsNode = &runLauncherAsWorker
+	m.MLPolicySource.MPI.RunLauncherAsNode = runLauncherAsWorker
 	return m
 }
 

--- a/test/integration/webhooks/trainingruntime_webhook_test.go
+++ b/test/integration/webhooks/trainingruntime_webhook_test.go
@@ -173,30 +173,122 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 						Replicas(1).Obj().Spec
 					return runtime
 				}),
-
 			ginkgo.Entry("Should succeed to default mpi.mpiImplementation=OpenMPI",
 				func() *trainer.TrainingRuntime {
-					runtime := testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj()
-					runtime.Spec.MLPolicy = &trainer.MLPolicy{
-						MLPolicySource: trainer.MLPolicySource{
-							MPI: &trainer.MPIMLPolicySource{},
-						},
-					}
-					return runtime
+					return testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(
+							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
+							WithMLPolicy(
+								testingutil.MakeMLPolicyWrapper().
+									MPIPolicy(nil, nil, ptr.To("/usr/dir"), ptr.To(false)).
+									Obj(),
+							).
+							JobSetSpec(
+								testingutil.MakeJobSetWrapper(ns.Name, "jobset").
+									Replicas(1).
+									Obj().
+									Spec,
+							).
+							Obj(),
+						).
+						Obj()
 				},
 				func() *trainer.TrainingRuntime {
-					runtime := testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj()
-					runtime.Spec.MLPolicy = &trainer.MLPolicy{
-						MLPolicySource: trainer.MLPolicySource{
-							MPI: &trainer.MPIMLPolicySource{
-								MPIImplementation: ptr.To(trainer.MPIImplementationOpenMPI),
-								RunLauncherAsNode: ptr.To(false),
-							},
-						},
-					}
-					runtime.Spec.Template.Spec = testingutil.MakeJobSetWrapper(ns.Name, "runtime").
-						Replicas(1).Obj().Spec
-					return runtime
+					return testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(
+							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
+							WithMLPolicy(
+								testingutil.MakeMLPolicyWrapper().
+									MPIPolicy(nil, ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), ptr.To(false)).
+									Obj(),
+							).
+							JobSetSpec(
+								testingutil.MakeJobSetWrapper(ns.Name, "jobset").
+									Replicas(1).
+									Obj().
+									Spec,
+							).
+							Obj(),
+						).
+						Obj()
+				}),
+			ginkgo.Entry("Should succeed to default mpi.sshAuthMountPath=/root/.ssh",
+				func() *trainer.TrainingRuntime {
+					return testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(
+							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
+							WithMLPolicy(
+								testingutil.MakeMLPolicyWrapper().
+									MPIPolicy(nil, ptr.To(trainer.MPIImplementationOpenMPI), nil, ptr.To(false)).
+									Obj(),
+							).
+							JobSetSpec(
+								testingutil.MakeJobSetWrapper(ns.Name, "jobset").
+									Replicas(1).
+									Obj().
+									Spec,
+							).
+							Obj(),
+						).
+						Obj()
+				},
+				func() *trainer.TrainingRuntime {
+					return testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(
+							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
+							WithMLPolicy(
+								testingutil.MakeMLPolicyWrapper().
+									MPIPolicy(nil, ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(false)).
+									Obj(),
+							).
+							JobSetSpec(
+								testingutil.MakeJobSetWrapper(ns.Name, "jobset").
+									Replicas(1).
+									Obj().
+									Spec,
+							).
+							Obj(),
+						).
+						Obj()
+				}),
+			ginkgo.Entry("Should succeed to default mpi.runLauncherAsNode=false",
+				func() *trainer.TrainingRuntime {
+					return testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(
+							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
+							WithMLPolicy(
+								testingutil.MakeMLPolicyWrapper().
+									MPIPolicy(nil, ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), nil).
+									Obj(),
+							).
+							JobSetSpec(
+								testingutil.MakeJobSetWrapper(ns.Name, "jobset").
+									Replicas(1).
+									Obj().
+									Spec,
+							).
+							Obj(),
+						).
+						Obj()
+				},
+				func() *trainer.TrainingRuntime {
+					return testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(
+							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
+							WithMLPolicy(
+								testingutil.MakeMLPolicyWrapper().
+									MPIPolicy(nil, ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), ptr.To(false)).
+									Obj(),
+							).
+							JobSetSpec(
+								testingutil.MakeJobSetWrapper(ns.Name, "jobset").
+									Replicas(1).
+									Obj().
+									Spec,
+							).
+							Obj(),
+						).
+						Obj()
 				}),
 		)
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I added the missing `sshAuthMountPath` defaulter and related integration tests.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
