### PR TITLE
Use large runner for building container image

### DIFF
--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -7,7 +7,8 @@ on:
 jobs:
   build-and-publish:
     name: Build and Publish Images
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ubuntu-latest-16-cores
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
The builder launch multiple VMs in a single runner. Especially, for trainer-controller-manager, we launch 3 VMs. So I think we can justify using the large runner.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
