### PR TITLE
Add dependencies to RuntimeRegistrar

### DIFF
--- a/pkg/runtime/core/registry.go
+++ b/pkg/runtime/core/registry.go
@@ -24,11 +24,20 @@ import (
 	"github.com/kubeflow/trainer/pkg/runtime"
 )
 
-type Registry map[string]func(ctx context.Context, client client.Client, indexer client.FieldIndexer) (runtime.Runtime, error)
+type Registry map[string]RuntimeRegistrar
+type RuntimeRegistrar struct {
+	factory      func(ctx context.Context, client client.Client, indexer client.FieldIndexer) (runtime.Runtime, error)
+	dependencies []string
+}
 
 func NewRuntimeRegistry() Registry {
 	return Registry{
-		TrainingRuntimeGroupKind:        NewTrainingRuntime,
-		ClusterTrainingRuntimeGroupKind: NewClusterTrainingRuntime,
+		TrainingRuntimeGroupKind: RuntimeRegistrar{
+			factory: NewTrainingRuntime,
+		},
+		ClusterTrainingRuntimeGroupKind: RuntimeRegistrar{
+			factory:      NewClusterTrainingRuntime,
+			dependencies: []string{TrainingRuntimeGroupKind},
+		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I refactored `Registry` typed from 

```go
type Registry map[string]func(ctx context.Context, client client.Client, indexer client.FieldIndexer) (runtime.Runtime, error)
``` 

to 

```go
type RuntimeRegistrar struct {
	factory      func(ctx context.Context, client client.Client, indexer client.FieldIndexer) (runtime.Runtime, error)
	dependencies []string
}
```

so that we can represent dependencies on each runtimes and initialize dependencies first.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2477

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
