### PR TITLE
Implement MPI numProcPerNode defaulter

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -293,7 +293,7 @@
           "type": "string"
         },
         "numProcPerNode": {
-          "description": "Number of processes per node. This value is equal to the number of slots for each node in the hostfile.",
+          "description": "Number of processes per node. This value is equal to the number of slots for each node in the hostfile. Defaults to 1.",
           "type": "integer",
           "format": "int32"
         },

--- a/manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
@@ -56,9 +56,11 @@ spec:
                           Defaults to OpenMPI.
                         type: string
                       numProcPerNode:
+                        default: 1
                         description: |-
                           Number of processes per node.
                           This value is equal to the number of slots for each node in the hostfile.
+                          Defaults to 1.
                         format: int32
                         type: integer
                       runLauncherAsNode:

--- a/manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
@@ -56,9 +56,11 @@ spec:
                           Defaults to OpenMPI.
                         type: string
                       numProcPerNode:
+                        default: 1
                         description: |-
                           Number of processes per node.
                           This value is equal to the number of slots for each node in the hostfile.
+                          Defaults to 1.
                         format: int32
                         type: integer
                       runLauncherAsNode:

--- a/pkg/apis/trainer/v1alpha1/trainingruntime_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainingruntime_types.go
@@ -211,6 +211,8 @@ type TorchElasticPolicy struct {
 type MPIMLPolicySource struct {
 	// Number of processes per node.
 	// This value is equal to the number of slots for each node in the hostfile.
+	// Defaults to 1.
+	// +kubebuilder:default=1
 	NumProcPerNode *int32 `json:"numProcPerNode,omitempty"`
 
 	// Implementation name for the MPI to create the appropriate hostfile.

--- a/pkg/apis/trainer/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/trainer/v1alpha1/zz_generated.openapi.go
@@ -558,7 +558,7 @@ func schema_pkg_apis_trainer_v1alpha1_MPIMLPolicySource(ref common.ReferenceCall
 				Properties: map[string]spec.Schema{
 					"numProcPerNode": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Number of processes per node. This value is equal to the number of slots for each node in the hostfile.",
+							Description: "Number of processes per node. This value is equal to the number of slots for each node in the hostfile. Defaults to 1.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/sdk/kubeflow/trainer/models/trainer_v1alpha1_mpiml_policy_source.py
+++ b/sdk/kubeflow/trainer/models/trainer_v1alpha1_mpiml_policy_source.py
@@ -27,7 +27,7 @@ class TrainerV1alpha1MPIMLPolicySource(BaseModel):
     MPIMLPolicySource represents a MPI runtime configuration.
     """ # noqa: E501
     mpi_implementation: Optional[StrictStr] = Field(default=None, description="Implementation name for the MPI to create the appropriate hostfile. Defaults to OpenMPI.", alias="mpiImplementation")
-    num_proc_per_node: Optional[StrictInt] = Field(default=None, description="Number of processes per node. This value is equal to the number of slots for each node in the hostfile.", alias="numProcPerNode")
+    num_proc_per_node: Optional[StrictInt] = Field(default=None, description="Number of processes per node. This value is equal to the number of slots for each node in the hostfile. Defaults to 1.", alias="numProcPerNode")
     run_launcher_as_node: Optional[StrictBool] = Field(default=None, description="Whether to run training process on the launcher Job. Defaults to false.", alias="runLauncherAsNode")
     ssh_auth_mount_path: Optional[StrictStr] = Field(default=None, description="Directory where SSH keys are mounted. Defaults to /root/.ssh.", alias="sshAuthMountPath")
     __properties: ClassVar[List[str]] = ["mpiImplementation", "numProcPerNode", "runLauncherAsNode", "sshAuthMountPath"]

--- a/test/integration/webhooks/trainingruntime_webhook_test.go
+++ b/test/integration/webhooks/trainingruntime_webhook_test.go
@@ -180,7 +180,7 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
-									MPIPolicy(nil, nil, ptr.To("/usr/dir"), ptr.To(false)).
+									MPIPolicy(ptr.To[int32](1), nil, ptr.To("/usr/dir"), ptr.To(false)).
 									Obj(),
 							).
 							JobSetSpec(
@@ -199,7 +199,7 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
-									MPIPolicy(nil, ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), ptr.To(false)).
+									MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), ptr.To(false)).
 									Obj(),
 							).
 							JobSetSpec(
@@ -219,7 +219,7 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
-									MPIPolicy(nil, ptr.To(trainer.MPIImplementationOpenMPI), nil, ptr.To(false)).
+									MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), nil, ptr.To(false)).
 									Obj(),
 							).
 							JobSetSpec(
@@ -238,7 +238,7 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
-									MPIPolicy(nil, ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(false)).
+									MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(false)).
 									Obj(),
 							).
 							JobSetSpec(
@@ -258,7 +258,7 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
-									MPIPolicy(nil, ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), nil).
+									MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), nil).
 									Obj(),
 							).
 							JobSetSpec(
@@ -277,7 +277,46 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
+									MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), ptr.To(false)).
+									Obj(),
+							).
+							JobSetSpec(
+								testingutil.MakeJobSetWrapper(ns.Name, "jobset").
+									Replicas(1).
+									Obj().
+									Spec,
+							).
+							Obj(),
+						).
+						Obj()
+				}),
+			ginkgo.Entry("Should succeed to default mpi.numProcPerNode=1",
+				func() *trainer.TrainingRuntime {
+					return testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(
+							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
+							WithMLPolicy(
+								testingutil.MakeMLPolicyWrapper().
 									MPIPolicy(nil, ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), ptr.To(false)).
+									Obj(),
+							).
+							JobSetSpec(
+								testingutil.MakeJobSetWrapper(ns.Name, "jobset").
+									Replicas(1).
+									Obj().
+									Spec,
+							).
+							Obj(),
+						).
+						Obj()
+				},
+				func() *trainer.TrainingRuntime {
+					return testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(
+							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
+							WithMLPolicy(
+								testingutil.MakeMLPolicyWrapper().
+									MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), ptr.To(false)).
 									Obj(),
 							).
 							JobSetSpec(


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I added a MPI numProcPerNode defaulter since the MPI slots should be `1` as a default.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
