### PR TITLE
Migrate Info.Trainer to Info.TemplateSpec.PodSet

### DIFF
--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -151,32 +151,20 @@ func (j *JobSet) Build(ctx context.Context, info *runtime.Info, trainJob *traine
 	// TODO (andreyvelich): Add support for the PodSpecOverride.
 	// TODO (andreyvelich): Refactor the builder with wrappers for PodSpec.
 	// TODO: Once we remove deprecated runtime.Info.Trainer, we should remove JobSet Builder with DeprecatedTrainer().
-	var jobSet *jobsetv1alpha2ac.JobSetApplyConfiguration
-	if info.RuntimePolicy.MLPolicy != nil && info.RuntimePolicy.MLPolicy.MPI != nil {
-		jobSet = jobSetBuilder.
-			Initializer(trainJob).
-			Launcher().
-			Trainer(info, trainJob).
-			PodLabels(info.PodLabels).
-			Suspend(trainJob.Spec.Suspend).
-			Build()
-	} else {
-		jobSet = jobSetBuilder.
-			Initializer(trainJob).
-			DeprecatedTrainer(info, trainJob).
-			PodLabels(info.PodLabels).
-			Suspend(trainJob.Spec.Suspend).
-			Build()
-	}
-
-	// Set the TrainJob as owner
-	jobSet.WithOwnerReferences(metav1ac.OwnerReference().
-		WithAPIVersion(trainer.GroupVersion.String()).
-		WithKind(trainer.TrainJobKind).
-		WithName(trainJob.Name).
-		WithUID(trainJob.UID).
-		WithController(true).
-		WithBlockOwnerDeletion(true))
+	jobSet := jobSetBuilder.
+		Initializer(trainJob).
+		Launcher().
+		Trainer(info, trainJob).
+		PodLabels(info.PodLabels).
+		Suspend(trainJob.Spec.Suspend).
+		Build().
+		WithOwnerReferences(metav1ac.OwnerReference().
+			WithAPIVersion(trainer.GroupVersion.String()).
+			WithKind(trainer.TrainJobKind).
+			WithName(trainJob.Name).
+			WithUID(trainJob.UID).
+			WithController(true).
+			WithBlockOwnerDeletion(true))
 
 	return []any{jobSet}, nil
 }

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -67,7 +67,7 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 	if trainJob.Spec.Trainer != nil && trainJob.Spec.Trainer.NumNodes != nil {
 		numNodes = trainJob.Spec.Trainer.NumNodes
 	}
-	info.Trainer.NumNodes = numNodes
+	info.RuntimePolicy.MLPolicy.NumNodes = numNodes
 
 	numProcPerNode := ptr.Deref(info.RuntimePolicy.MLPolicy.Torch.NumProcPerNode, intstr.FromString("auto"))
 	if trainJob.Spec.Trainer != nil && trainJob.Spec.Trainer.NumProcPerNode != nil {
@@ -95,7 +95,7 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 				_, ok := resources[corev1.ResourceCPU]
 				return ok
 			}
-			fallbackNumProcPerNode = intstr.FromInt(1)
+			fallbackNumProcPerNode = intstr.FromInt32(1)
 		default:
 			shouldUseCPU = func(resources corev1.ResourceList) bool { return false }
 			fallbackNumProcPerNode = numProcPerNode
@@ -112,33 +112,35 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 	// TODO (andreyvelich): Add validation to check that TrainJob doesn't have "PET_" envs.
 	// TODO (andreyvelich): We should validate that envs from different plugins don't conflict with each other.
 	// Ref: https://github.com/kubeflow/trainer/pull/2308#discussion_r1823229940
+	var trainerContainer *runtime.Container
 	if trainJob.Spec.Trainer != nil {
-		info.Trainer.Env = apply.EnvVars(trainJob.Spec.Trainer.Env...)
+		if trainerContainer = info.FindContainerByPodSetContainerName(constants.JobTrainerNode, constants.ContainerTrainer); trainerContainer != nil {
+			apply.UpsertEnvVars(&trainerContainer.Env, apply.EnvVars(trainJob.Spec.Trainer.Env...)...)
+		}
 	}
-
-	apply.UpsertEnvVar(&info.Trainer.Env,
-		*corev1ac.EnvVar().
-			WithName(constants.TorchEnvNumNodes).
-			WithValue(fmt.Sprintf("%d", ptr.Deref(numNodes, 1))),
-		*corev1ac.EnvVar().
-			WithName(constants.TorchEnvNumProcPerNode).
-			WithValue(numProcPerNode.String()),
-		*corev1ac.EnvVar().
-			WithName(constants.TorchEnvNodeRank).
-			WithValueFrom(corev1ac.EnvVarSource().
-				WithFieldRef(corev1ac.ObjectFieldSelector().
-					WithFieldPath(constants.JobCompletionIndexFieldPath))),
-		*corev1ac.EnvVar().
-			WithName(constants.TorchEnvMasterAddr).
-			WithValue(fmt.Sprintf("%s-%s-0-0.%s", trainJob.Name, constants.JobTrainerNode, trainJob.Name)),
-		*corev1ac.EnvVar().
-			WithName(constants.TorchEnvMasterPort).
-			WithValue(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
-	)
-
-	// Add container port for the headless service.
-	info.Trainer.ContainerPort = corev1ac.ContainerPort().
-		WithContainerPort(constants.ContainerTrainerPort)
+	if trainerContainer != nil {
+		apply.UpsertEnvVar(&trainerContainer.Env,
+			*corev1ac.EnvVar().
+				WithName(constants.TorchEnvNumNodes).
+				WithValue(fmt.Sprintf("%d", ptr.Deref(numNodes, 1))),
+			*corev1ac.EnvVar().
+				WithName(constants.TorchEnvNumProcPerNode).
+				WithValue(numProcPerNode.String()),
+			*corev1ac.EnvVar().
+				WithName(constants.TorchEnvNodeRank).
+				WithValueFrom(corev1ac.EnvVarSource().
+					WithFieldRef(corev1ac.ObjectFieldSelector().
+						WithFieldPath(constants.JobCompletionIndexFieldPath))),
+			*corev1ac.EnvVar().
+				WithName(constants.TorchEnvMasterAddr).
+				WithValue(fmt.Sprintf("%s-%s-0-0.%s", trainJob.Name, constants.JobTrainerNode, trainJob.Name)),
+			*corev1ac.EnvVar().
+				WithName(constants.TorchEnvMasterPort).
+				WithValue(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
+		)
+		// Add container port for the headless service.
+		apply.UpsertPort(&trainerContainer.Ports, *corev1ac.ContainerPort().WithContainerPort(constants.ContainerTrainerPort))
+	}
 
 	// Update total Pod requests for the PodGroupPolicy plugin.
 	for rName := range info.TotalRequests {
@@ -152,6 +154,7 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 		}
 	}
 
+	info.SyncPodSetsToTemplateSpec()
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I migrated `runtime.Info.Trainer` to `runtime.Info.TemplateSpec.PodSet`, and then I removed the outdated `DeprecatedTrainer` from the JobSet builder.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Part-of https://github.com/kubeflow/trainer/issues/2495

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
