### PR TITLE
fix: remove unused parameter name in default case of shouldUseCPU function

### DIFF
--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -97,7 +97,7 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 			}
 			fallbackNumProcPerNode = intstr.FromInt(1)
 		default:
-			shouldUseCPU = func(resources corev1.ResourceList) bool { return false }
+			shouldUseCPU = func(corev1.ResourceList) bool { return false }
 			fallbackNumProcPerNode = numProcPerNode
 		}
 		nppNode, usedCPU := calculateNumProcPerNode(fallbackNumProcPerNode, jobTrainer.ResourcesPerNode.Limits, shouldUseCPU)


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR fixes a minor issue in the `shouldUseCPU` function definition in the `pkg/runtime/framework/plugins/torch/torch.go` file.  
This fix is based on code review feedback from PR #2492.


