### PR TITLE
Migrate InfoOptions.podSpecReplias and info.Scheduler.TotalRequests to info.TemplateSpec.PodSet

### DIFF
--- a/pkg/runtime/core/trainingruntime.go
+++ b/pkg/runtime/core/trainingruntime.go
@@ -21,11 +21,9 @@ import (
 	"errors"
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	resourcehelpers "k8s.io/component-helpers/resource"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -144,7 +142,7 @@ func (r *TrainingRuntime) runtimeInfo(
 		runtime.WithAnnotations(propagationAnnotations),
 		runtime.WithMLPolicy(mlPolicy),
 		runtime.WithPodGroupPolicy(podGroupPolicy),
-		runtime.WithTemplateSpec(jobSetSpecApply),
+		runtime.WithTemplateSpecObjApply(jobSetSpecApply),
 		runtime.WithPodSetSyncer(syncPodSets),
 	}
 
@@ -155,10 +153,10 @@ func (r *TrainingRuntime) runtimeInfo(
 		if *rJob.Name == constants.JobTrainerNode && mlPolicy != nil {
 			count = ptr.Deref(mlPolicy.NumNodes, 1)
 		}
-		opts = append(opts, runtime.WithPodSpecReplicas(
+		opts = append(opts, runtime.WithPodSet(
 			*rJob.Name,
 			count,
-			resourcehelpers.PodRequests(&corev1.Pod{Spec: *jobSetTemplateSpec.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.DeepCopy()}, resourcehelpers.PodResourcesOptions{}),
+			*jobSetTemplateSpec.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.DeepCopy(),
 			rJob.Template.Spec.Template.Spec),
 		)
 	}

--- a/pkg/runtime/framework/plugins/coscheduling/coscheduling.go
+++ b/pkg/runtime/framework/plugins/coscheduling/coscheduling.go
@@ -45,6 +45,7 @@ import (
 	schedulerpluginsv1alpha1ac "sigs.k8s.io/scheduler-plugins/pkg/generated/applyconfiguration/scheduling/v1alpha1"
 
 	trainer "github.com/kubeflow/trainer/pkg/apis/trainer/v1alpha1"
+	"github.com/kubeflow/trainer/pkg/constants"
 	"github.com/kubeflow/trainer/pkg/runtime"
 	"github.com/kubeflow/trainer/pkg/runtime/framework"
 	runtimeindexer "github.com/kubeflow/trainer/pkg/runtime/indexer"
@@ -121,10 +122,17 @@ func (c *CoScheduling) Build(ctx context.Context, info *runtime.Info, trainJob *
 
 	var totalMembers int32
 	totalResources := make(corev1.ResourceList)
-	for _, resourceRequests := range info.TotalRequests {
-		totalMembers += resourceRequests.Replicas
-		for resName, quantity := range resourceRequests.PodRequests {
-			quantity.Mul(int64(resourceRequests.Replicas))
+	for _, ps := range info.TemplateSpec.PodSets {
+		var count int32
+		switch ps.Name {
+		case constants.JobTrainerNode:
+			count = *info.RuntimePolicy.MLPolicy.NumNodes
+		default:
+			count = *ps.CountForNonTrainer
+		}
+		totalMembers += count
+		for resName, quantity := range ps.SinglePodRequests {
+			quantity.Mul(int64(count))
 			current := totalResources[resName]
 			current.Add(quantity)
 			totalResources[resName] = current

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -197,7 +197,7 @@ func (j *JobSet) Build(ctx context.Context, info *runtime.Info, trainJob *traine
 		Initializer(trainJob).
 		Launcher().
 		Trainer(info, trainJob).
-		PodLabels(info.PodLabels).
+		PodLabels(info.Scheduler.PodLabels).
 		Suspend(trainJob.Spec.Suspend).
 		Build().
 		WithOwnerReferences(metav1ac.OwnerReference().

--- a/pkg/runtime/framework/plugins/mpi/mpi.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi.go
@@ -197,18 +197,6 @@ func (m *MPI) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) er
 			}
 		}
 	}
-
-	// Update total Pod requests for the PodGroupPolicy plugin.
-	for rName := range info.TotalRequests {
-		// For other Jobs like the Initializer, replica is always equal to 1.
-		// TODO (andreyvelich): Add support for total requests from the TrainJob's ResourcesPerNode.
-		if rName == constants.JobTrainerNode {
-			info.TotalRequests[rName] = runtime.TotalResourceRequest{
-				Replicas:    ptr.Deref(info.RuntimePolicy.MLPolicy.NumNodes, constants.DefaultJobReplicas),
-				PodRequests: info.TotalRequests[rName].PodRequests,
-			}
-		}
-	}
 	info.SyncPodSetsToTemplateSpec()
 	return nil
 }

--- a/pkg/runtime/framework/plugins/plainml/plainml.go
+++ b/pkg/runtime/framework/plugins/plainml/plainml.go
@@ -19,7 +19,6 @@ package plainml
 import (
 	"context"
 
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	trainer "github.com/kubeflow/trainer/pkg/apis/trainer/v1alpha1"
@@ -63,19 +62,6 @@ func (p *PlainML) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob
 			apply.UpsertEnvVars(&trainerContainer.Env, apply.EnvVars(trainJob.Spec.Trainer.Env...)...)
 		}
 	}
-
-	// Update total Pod requests for the PodGroupPolicy plugin.
-	for rName := range info.TotalRequests {
-		// For other Jobs like the Initializer, replica is always equal to 1.
-		// TODO (andreyvelich): Add support for total requests from the TrainJob's ResourcesPerNode.
-		if rName == constants.JobTrainerNode {
-			info.Scheduler.TotalRequests[rName] = runtime.TotalResourceRequest{
-				Replicas:    ptr.Deref(numNodes, constants.DefaultJobReplicas),
-				PodRequests: info.TotalRequests[rName].PodRequests,
-			}
-		}
-	}
-
 	info.SyncPodSetsToTemplateSpec()
 	return nil
 }

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -170,19 +170,6 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 		// Add container port for the headless service.
 		apply.UpsertPort(&trainerContainer.Ports, *corev1ac.ContainerPort().WithContainerPort(constants.ContainerTrainerPort))
 	}
-
-	// Update total Pod requests for the PodGroupPolicy plugin.
-	for rName := range info.TotalRequests {
-		// For other Jobs like the Initializer, replica is always equal to 1.
-		// TODO (andreyvelich): Add support for total requests from the TrainJob's ResourcesPerNode.
-		if rName == constants.JobTrainerNode {
-			info.TotalRequests[rName] = runtime.TotalResourceRequest{
-				Replicas:    ptr.Deref(numNodes, constants.DefaultJobReplicas),
-				PodRequests: info.TotalRequests[rName].PodRequests,
-			}
-		}
-	}
-
 	info.SyncPodSetsToTemplateSpec()
 	return nil
 }

--- a/pkg/runtime/framework/plugins/torch/torch_test.go
+++ b/pkg/runtime/framework/plugins/torch/torch_test.go
@@ -72,7 +72,7 @@ func TestTorch(t *testing.T) {
 						TorchPolicy("auto", nil).
 						Obj(),
 				),
-				runtime.WithPodSpecReplicas(constants.JobTrainerNode, 1, nil, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(
 						corev1ac.Container().WithName(constants.ContainerTrainer),
 					),
@@ -95,7 +95,8 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name: constants.JobTrainerNode,
+						Name:              constants.JobTrainerNode,
+						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
@@ -130,9 +131,7 @@ func TestTorch(t *testing.T) {
 						}},
 					}},
 				},
-				Scheduler: &runtime.Scheduler{TotalRequests: map[string]runtime.TotalResourceRequest{
-					constants.JobTrainerNode: {Replicas: 2},
-				}},
+				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
 		"nproc_per_node=auto with CPU limit": {
@@ -153,7 +152,7 @@ func TestTorch(t *testing.T) {
 						TorchPolicy("auto", nil).
 						Obj(),
 				),
-				runtime.WithPodSpecReplicas(constants.JobTrainerNode, 1, nil, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
 				),
 			),
@@ -168,7 +167,8 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name: constants.JobTrainerNode,
+						Name:              constants.JobTrainerNode,
+						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
@@ -203,9 +203,7 @@ func TestTorch(t *testing.T) {
 						}},
 					}},
 				},
-				Scheduler: &runtime.Scheduler{TotalRequests: map[string]runtime.TotalResourceRequest{
-					constants.JobTrainerNode: {Replicas: 1},
-				}},
+				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
 		"nproc_per_node=auto with no CPU resources": {
@@ -224,7 +222,7 @@ func TestTorch(t *testing.T) {
 						TorchPolicy("auto", nil).
 						Obj(),
 				),
-				runtime.WithPodSpecReplicas(constants.JobTrainerNode, 1, nil, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
 				),
 			),
@@ -239,7 +237,8 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name: constants.JobTrainerNode,
+						Name:              constants.JobTrainerNode,
+						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
@@ -274,9 +273,7 @@ func TestTorch(t *testing.T) {
 						}},
 					}},
 				},
-				Scheduler: &runtime.Scheduler{TotalRequests: map[string]runtime.TotalResourceRequest{
-					constants.JobTrainerNode: {Replicas: 1},
-				}},
+				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
 		"nproc_per_node=auto with low CPU limit": {
@@ -297,7 +294,7 @@ func TestTorch(t *testing.T) {
 						TorchPolicy("auto", nil).
 						Obj(),
 				),
-				runtime.WithPodSpecReplicas(constants.JobTrainerNode, 1, nil, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
 				),
 			),
@@ -312,7 +309,8 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name: constants.JobTrainerNode,
+						Name:              constants.JobTrainerNode,
+						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
@@ -347,9 +345,7 @@ func TestTorch(t *testing.T) {
 						}},
 					}},
 				},
-				Scheduler: &runtime.Scheduler{TotalRequests: map[string]runtime.TotalResourceRequest{
-					constants.JobTrainerNode: {Replicas: 1},
-				}},
+				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
 		"nproc_per_node=auto with CPU request but no limit": {
@@ -370,7 +366,7 @@ func TestTorch(t *testing.T) {
 						TorchPolicy("auto", nil).
 						Obj(),
 				),
-				runtime.WithPodSpecReplicas(constants.JobTrainerNode, 1, nil, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
 				),
 			),
@@ -385,7 +381,8 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name: constants.JobTrainerNode,
+						Name:              constants.JobTrainerNode,
+						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
@@ -420,9 +417,7 @@ func TestTorch(t *testing.T) {
 						}},
 					}},
 				},
-				Scheduler: &runtime.Scheduler{TotalRequests: map[string]runtime.TotalResourceRequest{
-					constants.JobTrainerNode: {Replicas: 1},
-				}},
+				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
 		"nproc_per_node=auto with millicore CPU limit": {
@@ -443,7 +438,7 @@ func TestTorch(t *testing.T) {
 						TorchPolicy("auto", nil).
 						Obj(),
 				),
-				runtime.WithPodSpecReplicas(constants.JobTrainerNode, 1, nil, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
 				),
 			),
@@ -458,7 +453,8 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name: constants.JobTrainerNode,
+						Name:              constants.JobTrainerNode,
+						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
@@ -493,9 +489,7 @@ func TestTorch(t *testing.T) {
 						}},
 					}},
 				},
-				Scheduler: &runtime.Scheduler{TotalRequests: map[string]runtime.TotalResourceRequest{
-					constants.JobTrainerNode: {Replicas: 1},
-				}},
+				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
 		"nproc_per_node=auto with fractional CPU limit": {
@@ -516,7 +510,7 @@ func TestTorch(t *testing.T) {
 						TorchPolicy("auto", nil).
 						Obj(),
 				),
-				runtime.WithPodSpecReplicas(constants.JobTrainerNode, 1, nil, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
 				),
 			),
@@ -531,7 +525,8 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name: constants.JobTrainerNode,
+						Name:              constants.JobTrainerNode,
+						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
@@ -566,9 +561,7 @@ func TestTorch(t *testing.T) {
 						}},
 					}},
 				},
-				Scheduler: &runtime.Scheduler{TotalRequests: map[string]runtime.TotalResourceRequest{
-					constants.JobTrainerNode: {Replicas: 1},
-				}},
+				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
 		"nproc_per_node=auto with GPU request should remain auto": {
@@ -589,7 +582,7 @@ func TestTorch(t *testing.T) {
 						TorchPolicy("auto", nil).
 						Obj(),
 				),
-				runtime.WithPodSpecReplicas(constants.JobTrainerNode, 1, nil, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
 				),
 			),
@@ -604,7 +597,8 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name: constants.JobTrainerNode,
+						Name:              constants.JobTrainerNode,
+						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
@@ -639,16 +633,14 @@ func TestTorch(t *testing.T) {
 						}},
 					}},
 				},
-				Scheduler: &runtime.Scheduler{TotalRequests: map[string]runtime.TotalResourceRequest{
-					constants.JobTrainerNode: {Replicas: 1},
-				}},
+				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
 		"explicitly set nproc_per_node should be preserved": {
 			trainJob: utiltesting.MakeTrainJobWrapper("default", "test-job").
 				Trainer(
 					utiltesting.MakeTrainJobTrainerWrapper().
-						NumProcPerNode(intstr.FromInt(3)).
+						NumProcPerNode(intstr.FromInt32(3)).
 						Container("test:image", []string{}, []string{}, corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("8"),
 						}).
@@ -662,7 +654,7 @@ func TestTorch(t *testing.T) {
 						TorchPolicy("auto", nil).
 						Obj(),
 				),
-				runtime.WithPodSpecReplicas(constants.JobTrainerNode, 1, nil, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
 				),
 			),
@@ -677,7 +669,8 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name: constants.JobTrainerNode,
+						Name:              constants.JobTrainerNode,
+						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
@@ -712,9 +705,7 @@ func TestTorch(t *testing.T) {
 						}},
 					}},
 				},
-				Scheduler: &runtime.Scheduler{TotalRequests: map[string]runtime.TotalResourceRequest{
-					constants.JobTrainerNode: {Replicas: 1},
-				}},
+				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
 		"nproc_per_node=auto with millicore CPU limit in m format": {
@@ -735,7 +726,7 @@ func TestTorch(t *testing.T) {
 						TorchPolicy("auto", nil).
 						Obj(),
 				),
-				runtime.WithPodSpecReplicas(constants.JobTrainerNode, 1, nil, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
 				),
 			),
@@ -750,7 +741,8 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name: constants.JobTrainerNode,
+						Name:              constants.JobTrainerNode,
+						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
@@ -785,9 +777,7 @@ func TestTorch(t *testing.T) {
 						}},
 					}},
 				},
-				Scheduler: &runtime.Scheduler{TotalRequests: map[string]runtime.TotalResourceRequest{
-					constants.JobTrainerNode: {Replicas: 1},
-				}},
+				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
 		"nproc_per_node=cpu with CPU limit": {
@@ -808,7 +798,7 @@ func TestTorch(t *testing.T) {
 						TorchPolicy("auto", nil).
 						Obj(),
 				),
-				runtime.WithPodSpecReplicas(constants.JobTrainerNode, 1, nil, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
 				),
 			),
@@ -823,7 +813,8 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name: constants.JobTrainerNode,
+						Name:              constants.JobTrainerNode,
+						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
@@ -858,9 +849,7 @@ func TestTorch(t *testing.T) {
 						}},
 					}},
 				},
-				Scheduler: &runtime.Scheduler{TotalRequests: map[string]runtime.TotalResourceRequest{
-					constants.JobTrainerNode: {Replicas: 1},
-				}},
+				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
 		"nproc_per_node=cpu with GPU resources": {
@@ -882,7 +871,7 @@ func TestTorch(t *testing.T) {
 						TorchPolicy("auto", nil).
 						Obj(),
 				),
-				runtime.WithPodSpecReplicas(constants.JobTrainerNode, 1, nil, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
 				),
 			),
@@ -897,7 +886,8 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name: constants.JobTrainerNode,
+						Name:              constants.JobTrainerNode,
+						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
@@ -932,9 +922,7 @@ func TestTorch(t *testing.T) {
 						}},
 					}},
 				},
-				Scheduler: &runtime.Scheduler{TotalRequests: map[string]runtime.TotalResourceRequest{
-					constants.JobTrainerNode: {Replicas: 1},
-				}},
+				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
 		"nproc_per_node=cpu with fractional CPU": {
@@ -955,7 +943,7 @@ func TestTorch(t *testing.T) {
 						TorchPolicy("auto", nil).
 						Obj(),
 				),
-				runtime.WithPodSpecReplicas(constants.JobTrainerNode, 1, nil, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
 				),
 			),
@@ -970,7 +958,8 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name: constants.JobTrainerNode,
+						Name:              constants.JobTrainerNode,
+						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
@@ -1005,9 +994,7 @@ func TestTorch(t *testing.T) {
 						}},
 					}},
 				},
-				Scheduler: &runtime.Scheduler{TotalRequests: map[string]runtime.TotalResourceRequest{
-					constants.JobTrainerNode: {Replicas: 1},
-				}},
+				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
 		"multi-node multi-GPU training with complete info": {
@@ -1035,7 +1022,7 @@ func TestTorch(t *testing.T) {
 					"app": "pytorch-training",
 					"env": "production",
 				}),
-				runtime.WithPodSpecReplicas(constants.JobTrainerNode, 2, nil, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.JobTrainerNode, 2, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
 				),
 			),
@@ -1053,7 +1040,8 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name: constants.JobTrainerNode,
+						Name:              constants.JobTrainerNode,
+						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
@@ -1088,9 +1076,7 @@ func TestTorch(t *testing.T) {
 						}},
 					}},
 				},
-				Scheduler: &runtime.Scheduler{TotalRequests: map[string]runtime.TotalResourceRequest{
-					constants.JobTrainerNode: {Replicas: 4},
-				}},
+				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -19,10 +19,12 @@ package runtime
 import (
 	"iter"
 	"maps"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	resourcehelpers "k8s.io/component-helpers/resource"
 	"k8s.io/utils/ptr"
 
 	trainer "github.com/kubeflow/trainer/pkg/apis/trainer/v1alpha1"
@@ -41,7 +43,7 @@ type Info struct {
 	// Original policy values from the runtime.
 	RuntimePolicy RuntimePolicy
 	// Scheduler parameters to add to the RuntimeJobTemplate.
-	*Scheduler
+	Scheduler *Scheduler
 	// TemplateSpec is TrainingRuntime Template object.
 	// ObjApply podSpecs and this PodSets should be kept in sync by info.SyncPodSetsToTemplateSpec().
 	TemplateSpec TemplateSpec
@@ -56,17 +58,24 @@ type TemplateSpec struct {
 	// ObjApply is ApplyConfiguration for the TrainingRuntimes Template field.
 	ObjApply any
 	// PodSets is a set of Pod extracted from ObjApply.
+	// This is abstract concept to represent multiple PodSpec as a unit.
 	PodSets []PodSet
 }
 
 type PodSet struct {
+	// PodSet name is the name to identify PodSpec.
+	// This typically has the name stored in each PodSpec.
 	Name string
 	// If Name is trainer-node, CountForNonTrainer is null.
 	// For Trainer, PodSet Count should be stored in Info.RuntimePolicy.MLPolicy.NumNodes.
 	CountForNonTrainer *int32
+	InitContainers     []Container
 	Containers         []Container
 	Volumes            []corev1ac.VolumeApplyConfiguration
 	Endpoints          iter.Seq[string]
+	// The total PodSet requests can be calculated with
+	// SinglePodRequests x [CountForNonTrainer|RuntimePolicy.MLPolicy.NumNodes].
+	SinglePodRequests corev1.ResourceList
 }
 
 type Container struct {
@@ -78,38 +87,19 @@ type Container struct {
 
 // TODO (andreyvelich): Potentially, we can add ScheduleTimeoutSeconds to the Scheduler for consistency.
 type Scheduler struct {
-	PodLabels     map[string]string
-	TotalRequests map[string]TotalResourceRequest
-}
-
-// DEPRECATED: Replace all TotalResourceRequest usage with PodSet.
-
-type TotalResourceRequest struct {
-	Replicas    int32
-	PodRequests corev1.ResourceList
+	PodLabels map[string]string
 }
 
 type InfoOptions struct {
-	labels          map[string]string
-	annotations     map[string]string
-	runtimePolicy   RuntimePolicy
-	podSpecReplicas []podSpecReplica
-	templateSpec    TemplateSpec
+	labels        map[string]string
+	annotations   map[string]string
+	runtimePolicy RuntimePolicy
+	templateSpec  TemplateSpec
 }
 
 type InfoOption func(options *InfoOptions)
 
 var defaultOptions = InfoOptions{}
-
-// DEPRECATED: Replace all podSpecReplica usage with PodSet
-// once we remove TotalResourceRequest.
-
-type podSpecReplica struct {
-	count             int32
-	name              string
-	podSpecApply      *corev1ac.PodSpecApplyConfiguration
-	singlePodRequests corev1.ResourceList
-}
 
 func WithLabels(labels map[string]string) InfoOption {
 	return func(o *InfoOptions) {
@@ -135,25 +125,45 @@ func WithPodGroupPolicy(pgPolicy *trainer.PodGroupPolicy) InfoOption {
 	}
 }
 
-// DEPRECATED: Replace WithPodSpecReplicas with WithTemplateSpec
-// once we remove TotalResourceRequest.
-
-func WithPodSpecReplicas(
-	replicaName string, count int32, singlePodRequest corev1.ResourceList, podSpecApply *corev1ac.PodSpecApplyConfiguration,
-) InfoOption {
+func WithTemplateSpecObjApply(objApply any) InfoOption {
 	return func(o *InfoOptions) {
-		o.podSpecReplicas = append(o.podSpecReplicas, podSpecReplica{
-			name:              replicaName,
-			count:             max(count, 1),
-			podSpecApply:      podSpecApply,
-			singlePodRequests: singlePodRequest,
-		})
+		o.templateSpec.ObjApply = objApply
 	}
 }
 
-func WithTemplateSpec(objApply any) InfoOption {
+// WithPodSet construct Info.TemplateSpec.PodSet from PodSpec.
+// The third argument, 'typedPodSpec' is used only to calculate requested resources.
+func WithPodSet(
+	psName string, count int32, typedPodSpec corev1.PodSpec, podSpecApply *corev1ac.PodSpecApplyConfiguration,
+) InfoOption {
 	return func(o *InfoOptions) {
-		o.templateSpec.ObjApply = objApply
+		ps := PodSet{
+			Name:              psName,
+			Volumes:           podSpecApply.Volumes,
+			SinglePodRequests: resourcehelpers.PodRequests(&corev1.Pod{Spec: typedPodSpec}, resourcehelpers.PodResourcesOptions{}),
+			InitContainers:    slices.Collect(toPodSetContainer(podSpecApply.InitContainers...)),
+			Containers:        slices.Collect(toPodSetContainer(podSpecApply.Containers...)),
+		}
+		if psName != constants.JobTrainerNode {
+			ps.CountForNonTrainer = ptr.To(max(count, 1))
+		}
+		o.templateSpec.PodSets = append(o.templateSpec.PodSets, ps)
+	}
+}
+
+func toPodSetContainer(containerApply ...corev1ac.ContainerApplyConfiguration) iter.Seq[Container] {
+	return func(yield func(Container) bool) {
+		for _, cApply := range containerApply {
+			container := Container{
+				Name:         ptr.Deref(cApply.Name, ""),
+				Env:          cApply.Env,
+				Ports:        cApply.Ports,
+				VolumeMounts: cApply.VolumeMounts,
+			}
+			if !yield(container) {
+				return
+			}
+		}
 	}
 }
 
@@ -174,32 +184,9 @@ func NewInfo(opts ...InfoOption) *Info {
 		Annotations:   make(map[string]string),
 		RuntimePolicy: options.runtimePolicy,
 		Scheduler: &Scheduler{
-			TotalRequests: make(map[string]TotalResourceRequest, len(options.podSpecReplicas)),
+			PodLabels: make(map[string]string),
 		},
 		TemplateSpec: options.templateSpec,
-	}
-
-	for _, spec := range options.podSpecReplicas {
-		info.TotalRequests[spec.name] = TotalResourceRequest{
-			Replicas:    spec.count,
-			PodRequests: spec.singlePodRequests,
-		}
-		ps := PodSet{
-			Name:    spec.name,
-			Volumes: spec.podSpecApply.Volumes,
-		}
-		if spec.name != constants.JobTrainerNode {
-			ps.CountForNonTrainer = &spec.count
-		}
-		for _, container := range spec.podSpecApply.Containers {
-			ps.Containers = append(ps.Containers, Container{
-				Name:         *container.Name,
-				Env:          container.Env,
-				Ports:        container.Ports,
-				VolumeMounts: container.VolumeMounts,
-			})
-		}
-		info.TemplateSpec.PodSets = append(info.TemplateSpec.PodSets, ps)
 	}
 	if options.labels != nil {
 		info.Labels = options.labels
@@ -219,6 +206,7 @@ func TemplateSpecApply[A any](info *Info) (*A, bool) {
 	return spec, ok
 }
 
+// FindContainerByPodSetContainerName finds runtime.Container from Info.TemplateSpec.PodSet by PodSet and Container name.
 func (i *Info) FindContainerByPodSetContainerName(psName, containerName string) *Container {
 	for psIdx, ps := range i.TemplateSpec.PodSets {
 		if ps.Name == psName {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I removed duplicated internal data structure, `InfoOptions.podSpecReplicas` and `Info.Scheduler.TotalRequests` 
 and migrate its usage to `Info.TemplateSpec.PodSet`.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Part-of https://github.com/kubeflow/trainer/issues/2495

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
