### PR TITLE
KEP-2170: Add manifest overlays for standalone installation

### DIFF
--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Namespace where all resources are deployed.
+namespace: kubeflow-system
+
+resources:
+  - namespace.yaml
+  - ../../third-party/jobset  # Comment this line if JobSet is installed on the Kubernetes cluster.
+  - ../../base/crds
+  - ../../base/manager
+  - ../../base/rbac
+  - ../../base/runtimes/pretraining
+  - ../../base/webhook
+
+# Update the Kubeflow Trainer controller manager image tag.
+images:
+  - name: kubeflow/trainer-controller-manager
+    newTag: latest
+
+# Secret for the Kubeflow Training webhook.
+secretGenerator:
+  - name: kubeflow-trainer-webhook-cert
+    namespace: kubeflow-system
+    options:
+      disableNameSuffixHash: true

--- a/manifests/overlays/standalone/namespace.yaml
+++ b/manifests/overlays/standalone/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeflow-system


### PR DESCRIPTION
**What this PR does / why we need it**:
As discussed in https://github.com/kubeflow/trainer/pull/2382, we can use `fifo` sortOption to provide a streamlined setup process, eliminating the need for separate overlays.

**Which issue(s) this PR fixes**:
Fixes #2526 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
