### PR TITLE
Updated base image to Debian image and changed install commands compatible with Debian image

### DIFF
--- a/cmd/initializer/dataset/Dockerfile
+++ b/cmd/initializer/dataset/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM python:3.11-slim-bookworm
 
 WORKDIR /workspace
 
@@ -10,7 +10,7 @@ COPY pkg/initializer pkg/initializer
 RUN pip install -r requirements.txt
 
 # Git is needed for the Kubeflow SDK to download JobSet Python models.
-RUN apk update && apk add --no-cache git
+RUN apt update && apt install -y git
 
 # Copy and install the Kubeflow SDK for the configs.
 COPY sdk sdk

--- a/cmd/initializer/model/Dockerfile
+++ b/cmd/initializer/model/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM python:3.11-slim-bookworm
 
 WORKDIR /workspace
 
@@ -10,7 +10,7 @@ COPY pkg/initializer pkg/initializer
 RUN pip install -r requirements.txt
 
 # Git is needed for the Kubeflow SDK to download JobSet Python models.
-RUN apk update && apk add --no-cache git
+RUN apt update && apt install -y git
 
 # Copy and install the Kubeflow SDK for the configs.
 COPY sdk sdk


### PR DESCRIPTION

What this PR does / why we need it: This PR replaces the docker image from "python:3.11-alpine" to "python:3.11-slim-bookworm" and install command which are compatible with Debian image.  As per the comment https://github.com/kubeflow/trainer/pull/2303.

Which issue(s) this PR fixes This PR Fixes #2311  issue and #2312 issue