### PR TITLE
feat: add replicatedJobs.replicas validations in validateReplicatedJobs function.

### DIFF
--- a/pkg/util/testing/wrapper.go
+++ b/pkg/util/testing/wrapper.go
@@ -331,6 +331,20 @@ func (j *JobSetWrapper) ControllerReference(gvk schema.GroupVersionKind, name, u
 	return j
 }
 
+func (j *JobSetWrapper) ReplicatedJobLabel(key, value string, rJobNames ...string) *JobSetWrapper {
+	for i, rJob := range j.Spec.ReplicatedJobs {
+		if !slices.Contains(rJobNames, rJob.Name) {
+			continue
+		}
+
+		if rJob.Template.Labels == nil {
+			j.Spec.ReplicatedJobs[i].Template.Labels = make(map[string]string, 1)
+		}
+		j.Spec.ReplicatedJobs[i].Template.Labels[key] = value
+	}
+	return j
+}
+
 func (j *JobSetWrapper) PodLabel(key, value string) *JobSetWrapper {
 	for i, rJob := range j.Spec.ReplicatedJobs {
 		if rJob.Template.Spec.Template.Labels == nil {

--- a/pkg/webhooks/trainingruntime_webhook_test.go
+++ b/pkg/webhooks/trainingruntime_webhook_test.go
@@ -35,12 +35,20 @@ func TestValidateReplicatedJobs(t *testing.T) {
 	}{
 		"valid replicatedJobs": {
 			rJobs: testingutil.MakeJobSetWrapper("ns", "valid").
-				Replicas(1, constants.Node, constants.DatasetInitializer, constants.ModelInitializer).
+				LauncherReplica().
+				Replicas(1, constants.Launcher, constants.Node, constants.DatasetInitializer, constants.ModelInitializer).
+				Obj().Spec.ReplicatedJobs,
+		},
+		"valid replicatedJobs with unknown user-specified ancestor": {
+			rJobs: testingutil.MakeJobSetWrapper("ns", "valid").
+				ReplicatedJobLabel(constants.LabelTrainJobAncestor, "user-specified", constants.Node, constants.DatasetInitializer, constants.ModelInitializer).
+				Replicas(2, constants.Node, constants.DatasetInitializer, constants.ModelInitializer).
 				Obj().Spec.ReplicatedJobs,
 		},
 		"invalid replicas": {
 			rJobs: testingutil.MakeJobSetWrapper("ns", "valid").
-				Replicas(2, constants.Node, constants.DatasetInitializer, constants.ModelInitializer).
+				LauncherReplica().
+				Replicas(2, constants.Launcher, constants.Node, constants.DatasetInitializer, constants.ModelInitializer).
 				Obj().Spec.ReplicatedJobs,
 			wantError: field.ErrorList{
 				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(0).Child("replicas"),
@@ -48,6 +56,8 @@ func TestValidateReplicatedJobs(t *testing.T) {
 				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(1).Child("replicas"),
 					"2", ""),
 				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(2).Child("replicas"),
+					"2", ""),
+				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(3).Child("replicas"),
 					"2", ""),
 			},
 		},


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

We would like to add webhook validations against `.spec.template.spec.replicatedJobs[*].replicas` to the TrainingRuntime and ClusterTrainingRuntime Webhook Validations. It must be 1 if replica name (`.spec.template.spec.replicatedJobs[*].name`) is Trainer, Initializer, or Launcher.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2502 

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
