### PR TITLE
fix(test): Update images for DockerHub publish

### DIFF
--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -79,10 +79,10 @@ jobs:
             dockerfile: cmd/trainer-controller-manager/Dockerfile
             platforms: linux/amd64,linux/arm64,linux/ppc64le
           - component-name: model-initializer
-            dockerfile: cmd/initializer/model/Dockerfile
+            dockerfile: cmd/initializers/model/Dockerfile
             platforms: linux/amd64,linux/arm64
           - component-name: dataset-initializer
-            dockerfile: cmd/initializer/dataset/Dockerfile
+            dockerfile: cmd/initializers/dataset/Dockerfile
             platforms: linux/amd64,linux/arm64
           - component-name: torchtune-trainer
             dockerfile: cmd/trainers/torchtune/Dockerfile
@@ -109,7 +109,7 @@ jobs:
         id: publish-dockerhub
         uses: ./.github/workflows/template-publish-image
         with:
-          image: docker.io/kubeflow/trainer/${{ matrix.component-name }}
+          image: docker.io/kubeflow/${{ matrix.component-name }}
           dockerfile: ${{ matrix.dockerfile }}
           platforms: ${{ matrix.platforms }}
           context: ${{ matrix.context }}
@@ -119,7 +119,7 @@ jobs:
         if: steps.publish.outcome == 'skipped'
         uses: ./.github/workflows/template-publish-image
         with:
-          image: docker.io/kubeflow/trainer/${{ matrix.component-name }}
+          image: docker.io/kubeflow/${{ matrix.component-name }}
           dockerfile: ${{ matrix.dockerfile }}
           platforms: ${{ matrix.platforms }}
           context: ${{ matrix.context }}


### PR DESCRIPTION
We should have correct names for DockerHub images.


/assign @kubeflow/wg-training-leads @Electronic-Waste @astefanutti @mahdikhashan 