### PR TITLE
[feature] merge GHCR and DockerHub CI jobs

### DIFF
--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -5,8 +5,8 @@ on:
   - pull_request
 
 jobs:
-  build-and-publish-to-ghcr:
-    name: Build and Publish Images to Github Container Registry
+  build-and-publish:
+    name: Build and Publish Images
     runs-on:
       labels: ubuntu-latest-16-cores
 
@@ -31,95 +31,55 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set publish condition
+        id: publish-condition
+        shell: bash
+        run: |
+          if [[ "${{ github.repository }}" == 'kubeflow/trainer' && \
+                ( "${{ github.ref }}" == 'refs/heads/master' || \
+                  "${{ github.ref }}" =~ ^refs/heads/release- || \
+                  "${{ github.ref }}" =~ ^refs/tags/v ) ]]; then
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: GHCR Login
-        # Trigger workflow only for kubeflow/trainer repository with specific branch (master, release-*) or tag (v.*).
-        if: >-
-          github.repository == 'kubeflow/trainer' &&
-          (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/tags/v'))
+        if: steps.publish-condition.outputs.should_publish == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish Component ${{ matrix.component-name }} to GHCR
-        # Trigger workflow only for kubeflow/trainer repository with specific branch (master, release-*) or tag (v.*).
-        if: >-
-          github.repository == 'kubeflow/trainer' &&
-          (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/tags/v'))
-        id: publish
-        uses: ./.github/workflows/template-publish-image
-        with:
-          image: ghcr.io/kubeflow/trainer/${{ matrix.component-name }}
-          dockerfile: ${{ matrix.dockerfile }}
-          platforms: ${{ matrix.platforms }}
-          context: ${{ matrix.context }}
-          push: true
-
-      - name: Test Build For Component ${{ matrix.component-name }}
-        if: steps.publish.outcome == 'skipped'
-        uses: ./.github/workflows/template-publish-image
-        with:
-          image: ghcr.io/kubeflow/trainer/${{ matrix.component-name }}
-          dockerfile: ${{ matrix.dockerfile }}
-          platforms: ${{ matrix.platforms }}
-          context: ${{ matrix.context }}
-          push: false
-
-  build-and-publish-to-dockerhub:
-    name: Build and Publish Images to DockerHub
-    runs-on:
-      labels: ubuntu-latest-16-cores
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - component-name: trainer-controller-manager
-            dockerfile: cmd/trainer-controller-manager/Dockerfile
-            platforms: linux/amd64,linux/arm64,linux/ppc64le
-          - component-name: model-initializer
-            dockerfile: cmd/initializers/model/Dockerfile
-            platforms: linux/amd64,linux/arm64
-          - component-name: dataset-initializer
-            dockerfile: cmd/initializers/dataset/Dockerfile
-            platforms: linux/amd64,linux/arm64
-          - component-name: torchtune-trainer
-            dockerfile: cmd/trainers/torchtune/Dockerfile
-            platforms: linux/amd64,linux/arm64
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Docker Hub Login
-        if: >-
-          github.repository == 'kubeflow/trainer' &&
-          (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/tags/v'))
+        if: steps.publish-condition.outputs.should_publish == 'true'
         uses: docker/login-action@v3
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Publish Component ${{ matrix.component-name }} to Docker Hub
-        if: >-
-          github.repository == 'kubeflow/trainer' &&
-          (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/tags/v'))
-        id: publish-dockerhub
+      - name: Publish Component ${{ matrix.component-name }}
+        if: steps.publish-condition.outputs.should_publish == 'true'
+        id: publish
         uses: ./.github/workflows/template-publish-image
         with:
-          image: docker.io/kubeflow/${{ matrix.component-name }}
+          image: |
+            ghcr.io/kubeflow/trainer/${{ matrix.component-name }}
+            docker.io/kubeflow/${{ matrix.component-name }}
           dockerfile: ${{ matrix.dockerfile }}
           platforms: ${{ matrix.platforms }}
           context: ${{ matrix.context }}
           push: true
 
       - name: Test Build For Component ${{ matrix.component-name }}
-        if: steps.publish.outcome == 'skipped'
+        if: steps.publish-condition.outputs.should_publish != 'true'
         uses: ./.github/workflows/template-publish-image
         with:
-          image: docker.io/kubeflow/${{ matrix.component-name }}
+          image: |
+            ghcr.io/kubeflow/trainer/${{ matrix.component-name }}
+            docker.io/kubeflow/${{ matrix.component-name }}
           dockerfile: ${{ matrix.dockerfile }}
           platforms: ${{ matrix.platforms }}
           context: ${{ matrix.context }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This commit optimizes the container image build and publishes workflow by:
* Merging the previously separate GHCR and DockerHub publishing jobs into a single job
* Creating a unified publish condition to determine when images should be published

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2532

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
