### PR TITLE
Use cncf-hosted gha runners

### DIFF
--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -8,7 +8,7 @@ jobs:
   build-and-publish-to-ghcr:
     name: Build and Publish Images to Github Container Registry
     runs-on:
-      labels: ubuntu-latest-16-cores
+      labels: oracle-16cpu-64gb-x86-64
 
     strategy:
       fail-fast: false
@@ -69,7 +69,7 @@ jobs:
   build-and-publish-to-dockerhub:
     name: Build and Publish Images to DockerHub
     runs-on:
-      labels: ubuntu-latest-16-cores
+      labels: oracle-16cpu-64gb-x86-64
 
     strategy:
       fail-fast: false

--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -49,23 +49,24 @@ runs:
         docker system df
         df -hT
 
-    - name: Move docker data directory
-      shell: bash
-      run: |
-        echo "Stopping docker service ..."
-        sudo systemctl stop docker
-        DOCKER_DEFAULT_ROOT_DIR=/var/lib/docker
-        DOCKER_ROOT_DIR=/mnt/docker
-        echo "Moving ${DOCKER_DEFAULT_ROOT_DIR} -> ${DOCKER_ROOT_DIR}"
-        sudo mv ${DOCKER_DEFAULT_ROOT_DIR} ${DOCKER_ROOT_DIR}
-        echo "Creating symlink ${DOCKER_DEFAULT_ROOT_DIR} -> ${DOCKER_ROOT_DIR}"
-        sudo ln -s ${DOCKER_ROOT_DIR} ${DOCKER_DEFAULT_ROOT_DIR}
-        echo "$(sudo ls -l ${DOCKER_DEFAULT_ROOT_DIR})"
-        echo "Starting docker service ..."
-        sudo systemctl daemon-reload
-        sudo systemctl start docker
-        echo "Docker service status:"
-        sudo systemctl --no-pager -l -o short status docker
+# Tombstoning this step as it isn't needed on CNCF Runners
+#    - name: Move docker data directory
+#      shell: bash
+#      run: |
+#        echo "Stopping docker service ..."
+#        sudo systemctl stop docker
+#        DOCKER_DEFAULT_ROOT_DIR=/var/lib/docker
+#        DOCKER_ROOT_DIR=/mnt/docker
+#        echo "Moving ${DOCKER_DEFAULT_ROOT_DIR} -> ${DOCKER_ROOT_DIR}"
+#        sudo mv ${DOCKER_DEFAULT_ROOT_DIR} ${DOCKER_ROOT_DIR}
+#        echo "Creating symlink ${DOCKER_DEFAULT_ROOT_DIR} -> ${DOCKER_ROOT_DIR}"
+#        sudo ln -s ${DOCKER_ROOT_DIR} ${DOCKER_DEFAULT_ROOT_DIR}
+#        echo "$(sudo ls -l ${DOCKER_DEFAULT_ROOT_DIR})"
+#        echo "Starting docker service ..."
+#        sudo systemctl daemon-reload
+#        sudo systemctl start docker
+#        echo "Docker service status:"
+#        sudo systemctl --no-pager -l -o short status docker
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -7,7 +7,7 @@ jobs:
   e2e-test:
     name: E2E Test
     runs-on:
-      labels: ubuntu-latest-16-cores
+      labels: oracle-16cpu-64gb-x86-64
     env:
       GOPATH: ${{ github.workspace }}/go
     defaults:


### PR DESCRIPTION
## Description
CNCF has hosted ephemeral GitHub runners in Oracle that we're wanting projects to use rather than the GitHub hosted ones, which are now incur a cost to use. ~This PR is currently a WIP to work through any tests that break or dependencies that may be missing.~ <3

Please direct any questions to myself, @krook and @RobertKielty