### PR TITLE
Store the TrainingRuntime numNodes as runtime.Info.PodSet.Count

### DIFF
--- a/pkg/runtime/core/clustertrainingruntime.go
+++ b/pkg/runtime/core/clustertrainingruntime.go
@@ -79,7 +79,7 @@ func (r *ClusterTrainingRuntime) ValidateObjects(ctx context.Context, old, new *
 				fmt.Sprintf("%v: specified clusterTrainingRuntime must be created before the TrainJob is created", err)),
 		}
 	}
-	info, _ := r.runtimeInfo(ctx, new, clusterTrainingRuntime.Spec.Template, clusterTrainingRuntime.Spec.MLPolicy, clusterTrainingRuntime.Spec.PodGroupPolicy)
+	info, _ := r.newRuntimeInfo(new, clusterTrainingRuntime.Spec.Template, clusterTrainingRuntime.Spec.MLPolicy, clusterTrainingRuntime.Spec.PodGroupPolicy)
 	jobSetTemplate := jobsetv1alpha2.JobSet{
 		Spec: clusterTrainingRuntime.Spec.Template.Spec,
 	}

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -298,7 +298,10 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					WithMLPolicy(
 						testingutil.MakeMLPolicyWrapper().
 							WithNumNodes(100).
-							TorchPolicy("auto", nil).
+							WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+								TorchPolicy("auto", nil).
+								Obj(),
+							).
 							Obj(),
 					).
 					JobSetSpec(
@@ -389,7 +392,10 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					WithMLPolicy(
 						testingutil.MakeMLPolicyWrapper().
 							WithNumNodes(100).
-							TorchPolicy("auto", nil).
+							WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+								TorchPolicy("auto", nil).
+								Obj(),
+							).
 							Obj(),
 					).
 					Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
@@ -489,7 +495,10 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					WithMLPolicy(
 						testingutil.MakeMLPolicyWrapper().
 							WithNumNodes(1).
-							MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(false)).
+							WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+								MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(false)).
+								Obj(),
+							).
 							Obj(),
 					).
 					LauncherReplica().

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -173,11 +173,7 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 		"plainml MLPolicy is applied to runtime.Info, TrainJob doesn't have numNodes": {
 			registry: fwkplugins.NewRegistry(),
 			runtimeInfo: runtime.NewInfo(
-				runtime.WithMLPolicy(
-					testingutil.MakeMLPolicyWrapper().
-						WithNumNodes(100).
-						Obj(),
-				),
+				runtime.WithMLPolicySource(testingutil.MakeMLPolicyWrapper().Obj()),
 				runtime.WithPodSet(constants.DatasetInitializer, 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(
 						corev1ac.Container().WithName(constants.DatasetInitializer),
@@ -197,15 +193,13 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 			},
 			wantRuntimeInfo: &runtime.Info{
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: &trainer.MLPolicy{
-						NumNodes: ptr.To[int32](100),
-					},
+					MLPolicySource: testingutil.MakeMLPolicySourceWrapper().Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{
 						{
-							Name:               constants.DatasetInitializer,
-							CountForNonTrainer: ptr.To[int32](1),
+							Name:  constants.DatasetInitializer,
+							Count: ptr.To[int32](1),
 							Containers: []runtime.Container{
 								{
 									Name: constants.DatasetInitializer,
@@ -213,8 +207,8 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 							},
 						},
 						{
-							Name:               constants.ModelInitializer,
-							CountForNonTrainer: ptr.To[int32](1),
+							Name:  constants.ModelInitializer,
+							Count: ptr.To[int32](1),
 							Containers: []runtime.Container{
 								{
 									Name: constants.ModelInitializer,
@@ -222,7 +216,8 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 							},
 						},
 						{
-							Name: constants.JobTrainerNode,
+							Name:  constants.JobTrainerNode,
+							Count: ptr.To[int32](10),
 							Containers: []runtime.Container{{
 								Name: constants.ContainerTrainer,
 							}},
@@ -235,10 +230,8 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 		"plainml MLPolicy is applied to runtime.Info, TrainJob has numNodes": {
 			registry: fwkplugins.NewRegistry(),
 			runtimeInfo: runtime.NewInfo(
-				runtime.WithMLPolicy(
-					testingutil.MakeMLPolicyWrapper().
-						WithNumNodes(100).
-						Obj(),
+				runtime.WithMLPolicySource(
+					testingutil.MakeMLPolicyWrapper().Obj(),
 				),
 				runtime.WithPodSet(constants.DatasetInitializer, 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(
@@ -263,15 +256,13 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 			},
 			wantRuntimeInfo: &runtime.Info{
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: &trainer.MLPolicy{
-						NumNodes: ptr.To[int32](30),
-					},
+					MLPolicySource: testingutil.MakeMLPolicySourceWrapper().Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{
 						{
-							Name:               constants.DatasetInitializer,
-							CountForNonTrainer: ptr.To[int32](1),
+							Name:  constants.DatasetInitializer,
+							Count: ptr.To[int32](1),
 							Containers: []runtime.Container{
 								{
 									Name: constants.DatasetInitializer,
@@ -279,8 +270,8 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 							},
 						},
 						{
-							Name:               constants.ModelInitializer,
-							CountForNonTrainer: ptr.To[int32](1),
+							Name:  constants.ModelInitializer,
+							Count: ptr.To[int32](1),
 							Containers: []runtime.Container{
 								{
 									Name: constants.ModelInitializer,
@@ -288,7 +279,8 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 							},
 						},
 						{
-							Name: constants.JobTrainerNode,
+							Name:  constants.JobTrainerNode,
+							Count: ptr.To[int32](30),
 							Containers: []runtime.Container{{
 								Name: constants.ContainerTrainer,
 							}},
@@ -452,9 +444,6 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 			trainingRuntime: testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "test-runtime").DeepCopy(),
 			runtimeInfo: &runtime.Info{
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: &trainer.MLPolicy{
-						NumNodes: ptr.To[int32](10),
-					},
 					PodGroupPolicy: &trainer.PodGroupPolicy{
 						PodGroupPolicySource: trainer.PodGroupPolicySource{
 							Coscheduling: &trainer.CoschedulingPodGroupPolicySource{
@@ -466,8 +455,8 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{
 						{
-							Name:               constants.DatasetInitializer,
-							CountForNonTrainer: ptr.To[int32](1),
+							Name:  constants.DatasetInitializer,
+							Count: ptr.To[int32](1),
 							SinglePodRequests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("1"),
 								corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -490,8 +479,8 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 							},
 						},
 						{
-							Name:               constants.ModelInitializer,
-							CountForNonTrainer: ptr.To[int32](1),
+							Name:  constants.ModelInitializer,
+							Count: ptr.To[int32](1),
 							SinglePodRequests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("1"),
 								corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -632,9 +621,6 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 				Obj(),
 			wantRuntimeInfo: &runtime.Info{
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: &trainer.MLPolicy{
-						NumNodes: ptr.To[int32](100),
-					},
 					PodGroupPolicy: &trainer.PodGroupPolicy{
 						PodGroupPolicySource: trainer.PodGroupPolicySource{
 							Coscheduling: &trainer.CoschedulingPodGroupPolicySource{
@@ -751,8 +737,8 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 						),
 					PodSets: []runtime.PodSet{
 						{
-							Name:               constants.DatasetInitializer,
-							CountForNonTrainer: ptr.To[int32](1),
+							Name:  constants.DatasetInitializer,
+							Count: ptr.To[int32](1),
 							SinglePodRequests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("1"),
 								corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -775,8 +761,8 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 							},
 						},
 						{
-							Name:               constants.ModelInitializer,
-							CountForNonTrainer: ptr.To[int32](1),
+							Name:  constants.ModelInitializer,
+							Count: ptr.To[int32](1),
 							SinglePodRequests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("1"),
 								corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -799,7 +785,8 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 							},
 						},
 						{
-							Name: constants.JobTrainerNode,
+							Name:  constants.JobTrainerNode,
+							Count: ptr.To[int32](100),
 							SinglePodRequests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("1"),
 								corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -1054,14 +1041,13 @@ func TestPodNetworkPlugins(t *testing.T) {
 			registry: fwkplugins.NewRegistry(),
 			runtimeInfo: &runtime.Info{
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: testingutil.MakeMLPolicyWrapper().
-						WithNumNodes(2).
-						Obj(),
+					MLPolicySource: testingutil.MakeMLPolicySourceWrapper().Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{
 						{
 							Name:       constants.JobTrainerNode,
+							Count:      ptr.To[int32](2),
 							Containers: make([]runtime.Container, 1),
 						},
 					},
@@ -1071,6 +1057,8 @@ func TestPodNetworkPlugins(t *testing.T) {
 								WithName(constants.JobTrainerNode).
 								WithTemplate(batchv1ac.JobTemplateSpec().
 									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(1).
+										WithCompletions(1).
 										WithTemplate(corev1ac.PodTemplateSpec().
 											WithSpec(corev1ac.PodSpec().
 												WithContainers(
@@ -1086,15 +1074,14 @@ func TestPodNetworkPlugins(t *testing.T) {
 			},
 			wantRuntimeInfo: &runtime.Info{
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: testingutil.MakeMLPolicyWrapper().
-						WithNumNodes(2).
-						Obj(),
+					MLPolicySource: testingutil.MakeMLPolicySourceWrapper().Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{
 						{
 							Name:       constants.JobTrainerNode,
 							Containers: make([]runtime.Container, 1),
+							Count:      ptr.To[int32](2),
 							Endpoints: func(yield func(string) bool) {
 								yield("test-job-trainer-node-0-0.test-job")
 								yield("test-job-trainer-node-0-1.test-job")
@@ -1107,6 +1094,8 @@ func TestPodNetworkPlugins(t *testing.T) {
 								WithName(constants.JobTrainerNode).
 								WithTemplate(batchv1ac.JobTemplateSpec().
 									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(1).
+										WithCompletions(1).
 										WithTemplate(corev1ac.PodTemplateSpec().
 											WithSpec(corev1ac.PodSpec().
 												WithContainers(

--- a/pkg/runtime/framework/plugins/coscheduling/coscheduling.go
+++ b/pkg/runtime/framework/plugins/coscheduling/coscheduling.go
@@ -45,7 +45,6 @@ import (
 	schedulerpluginsv1alpha1ac "sigs.k8s.io/scheduler-plugins/pkg/generated/applyconfiguration/scheduling/v1alpha1"
 
 	trainer "github.com/kubeflow/trainer/pkg/apis/trainer/v1alpha1"
-	"github.com/kubeflow/trainer/pkg/constants"
 	"github.com/kubeflow/trainer/pkg/runtime"
 	"github.com/kubeflow/trainer/pkg/runtime/framework"
 	runtimeindexer "github.com/kubeflow/trainer/pkg/runtime/indexer"
@@ -123,13 +122,7 @@ func (c *CoScheduling) Build(ctx context.Context, info *runtime.Info, trainJob *
 	var totalMembers int32
 	totalResources := make(corev1.ResourceList)
 	for _, ps := range info.TemplateSpec.PodSets {
-		var count int32
-		switch ps.Name {
-		case constants.JobTrainerNode:
-			count = *info.RuntimePolicy.MLPolicy.NumNodes
-		default:
-			count = *ps.CountForNonTrainer
-		}
+		count := *ps.Count
 		totalMembers += count
 		for resName, quantity := range ps.SinglePodRequests {
 			quantity.Mul(int64(count))

--- a/pkg/runtime/framework/plugins/jobset/builder.go
+++ b/pkg/runtime/framework/plugins/jobset/builder.go
@@ -120,8 +120,8 @@ func (b *Builder) Trainer(info *runtime.Info, trainJob *trainer.TrainJob) *Build
 			// REF: https://github.com/kubeflow/trainer/issues/2318
 			b.Spec.ReplicatedJobs[i].Replicas = ptr.To[int32](1)
 			// Update the Parallelism and Completions values for the Trainer Job.
-			b.Spec.ReplicatedJobs[i].Template.Spec.Parallelism = info.RuntimePolicy.MLPolicy.NumNodes
-			b.Spec.ReplicatedJobs[i].Template.Spec.Completions = info.RuntimePolicy.MLPolicy.NumNodes
+			b.Spec.ReplicatedJobs[i].Template.Spec.Parallelism = info.TemplateSpec.PodSets[i].Count
+			b.Spec.ReplicatedJobs[i].Template.Spec.Completions = info.TemplateSpec.PodSets[i].Count
 
 			// Update values for the Trainer container.
 			for j, container := range rJob.Template.Spec.Template.Spec.Containers {

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -145,10 +145,7 @@ func (j *JobSet) IdentifyPodNetwork(info *runtime.Info, trainJob *trainer.TrainJ
 	for rJobIdx, rJob := range spec.ReplicatedJobs {
 		// TODO: Support multiple replicas for replicated Jobs.
 		// REF: https://github.com/kubeflow/trainer/issues/2318
-		podCount := info.TemplateSpec.PodSets[rJobIdx].CountForNonTrainer
-		if *rJob.Name == constants.JobTrainerNode {
-			podCount = info.RuntimePolicy.MLPolicy.NumNodes
-		}
+		podCount := info.TemplateSpec.PodSets[rJobIdx].Count
 		rJobReplicas := 1
 		info.TemplateSpec.PodSets[rJobIdx].Endpoints = func(yield func(string) bool) {
 			for podIdx := range ptr.Deref(podCount, 1) {

--- a/pkg/runtime/framework/plugins/jobset/jobset_test.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset_test.go
@@ -79,8 +79,7 @@ func TestJobSet(t *testing.T) {
 				Obj(),
 			info: &runtime.Info{
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(2).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						MPIPolicy(nil, ptr.To(trainer.MPIImplementationOpenMPI), nil, nil).
 						Obj(),
 				},
@@ -88,10 +87,11 @@ func TestJobSet(t *testing.T) {
 					PodSets: []runtime.PodSet{
 						{
 							Name:       constants.JobLauncher,
-							Containers: make([]runtime.Container, 2),
+							Containers: make([]runtime.Container, 1),
 						},
 						{
 							Name:       constants.JobTrainerNode,
+							Count:      ptr.To[int32](2),
 							Containers: make([]runtime.Container, 1),
 						},
 					},
@@ -116,7 +116,7 @@ func TestJobSet(t *testing.T) {
 								WithName(constants.JobTrainerNode).
 								WithTemplate(batchv1ac.JobTemplateSpec().
 									WithSpec(batchv1ac.JobSpec().
-										WithParallelism(1).
+										WithParallelism(2).
 										WithTemplate(corev1ac.PodTemplateSpec().
 											WithSpec(corev1ac.PodSpec().
 												WithContainers(
@@ -131,8 +131,7 @@ func TestJobSet(t *testing.T) {
 			},
 			wantInfo: &runtime.Info{
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(2).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						MPIPolicy(nil, ptr.To(trainer.MPIImplementationOpenMPI), nil, nil).
 						Obj(),
 				},
@@ -140,13 +139,14 @@ func TestJobSet(t *testing.T) {
 					PodSets: []runtime.PodSet{
 						{
 							Name:       constants.JobLauncher,
-							Containers: make([]runtime.Container, 2),
+							Containers: make([]runtime.Container, 1),
 							Endpoints: func(yield func(string) bool) {
 								yield("trainJob-launcher-0-0.trainJob")
 							},
 						},
 						{
 							Name:       constants.JobTrainerNode,
+							Count:      ptr.To[int32](2),
 							Containers: make([]runtime.Container, 1),
 							Endpoints: func(yield func(string) bool) {
 								yield("trainJob-trainer-node-0-0.trainJob")
@@ -175,7 +175,7 @@ func TestJobSet(t *testing.T) {
 								WithName(constants.JobTrainerNode).
 								WithTemplate(batchv1ac.JobTemplateSpec().
 									WithSpec(batchv1ac.JobSpec().
-										WithParallelism(1).
+										WithParallelism(2).
 										WithTemplate(corev1ac.PodTemplateSpec().
 											WithSpec(corev1ac.PodSpec().
 												WithContainers(
@@ -194,9 +194,7 @@ func TestJobSet(t *testing.T) {
 				Obj(),
 			info: &runtime.Info{
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
-						Obj(),
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{
@@ -246,9 +244,7 @@ func TestJobSet(t *testing.T) {
 			},
 			wantInfo: &runtime.Info{
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
-						Obj(),
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{

--- a/pkg/runtime/framework/plugins/mpi/mpi.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi.go
@@ -82,7 +82,7 @@ func (m *MPI) Name() string {
 
 func (m *MPI) Validate(runtimeJobTemplate client.Object, runtimeInfo *runtime.Info, oldJobObj, newJobObj *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
 	var allErrs field.ErrorList
-	if runtimeInfo == nil || runtimeInfo.RuntimePolicy.MLPolicy == nil || runtimeInfo.RuntimePolicy.MLPolicy.MPI == nil {
+	if runtimeInfo == nil || runtimeInfo.RuntimePolicy.MLPolicySource == nil || runtimeInfo.RuntimePolicy.MLPolicySource.MPI == nil {
 		return nil, allErrs
 	}
 
@@ -98,17 +98,17 @@ func (m *MPI) Validate(runtimeJobTemplate client.Object, runtimeInfo *runtime.In
 }
 
 func (m *MPI) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) error {
-	if info == nil || info.RuntimePolicy.MLPolicy == nil || info.RuntimePolicy.MLPolicy.MPI == nil {
+	if info == nil || info.RuntimePolicy.MLPolicySource == nil || info.RuntimePolicy.MLPolicySource.MPI == nil {
 		return nil
 	}
 
 	// TrainJob contains the actual information for the Trainer.
 	if trainJob.Spec.Trainer != nil && trainJob.Spec.Trainer.NumNodes != nil {
-		info.RuntimePolicy.MLPolicy.NumNodes = trainJob.Spec.Trainer.NumNodes
+		info.FindPodSetByName(constants.JobTrainerNode).Count = trainJob.Spec.Trainer.NumNodes
 	}
 
 	if trainJob.Spec.Trainer != nil && trainJob.Spec.Trainer.NumProcPerNode != nil {
-		info.RuntimePolicy.MLPolicy.MPI.NumProcPerNode = ptr.To(int32(trainJob.Spec.Trainer.NumProcPerNode.IntValue()))
+		info.RuntimePolicy.MLPolicySource.MPI.NumProcPerNode = ptr.To(int32(trainJob.Spec.Trainer.NumProcPerNode.IntValue()))
 	}
 
 	// Add Secret and ConfigMap volumes to the Info object
@@ -164,7 +164,7 @@ func (m *MPI) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) er
 				[]corev1ac.VolumeMountApplyConfiguration{
 					*corev1ac.VolumeMount().
 						WithName(constants.MPISSHAuthVolumeName).
-						WithMountPath(*info.RuntimePolicy.MLPolicy.MPI.SSHAuthMountPath),
+						WithMountPath(*info.RuntimePolicy.MLPolicySource.MPI.SSHAuthMountPath),
 				}...,
 			)
 			if ps.Name == constants.JobLauncher && container.Name == constants.ContainerLauncher {
@@ -174,7 +174,7 @@ func (m *MPI) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) er
 						WithName(constants.MPIHostfileVolumeName).
 						WithMountPath(constants.MPIHostfileDir),
 				)
-				switch *info.RuntimePolicy.MLPolicy.MPI.MPIImplementation {
+				switch *info.RuntimePolicy.MLPolicySource.MPI.MPIImplementation {
 				case trainer.MPIImplementationOpenMPI:
 					apply.UpsertEnvVars(
 						&info.TemplateSpec.PodSets[psIdx].Containers[cIdx].Env,
@@ -186,13 +186,13 @@ func (m *MPI) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) er
 							WithValue("true"),
 						*corev1ac.EnvVar().
 							WithName(constants.OpenMPIEnvDefaultSlots).
-							WithValue(strconv.Itoa(int(*info.RuntimePolicy.MLPolicy.MPI.NumProcPerNode))),
+							WithValue(strconv.Itoa(int(*info.RuntimePolicy.MLPolicySource.MPI.NumProcPerNode))),
 						*corev1ac.EnvVar().
 							WithName(constants.OpenMPIEnvKeyRSHArgs).
 							WithValue(constants.OpenMPIEnvDefaultValueRSHArgs),
 					)
 				default:
-					return fmt.Errorf("MPI implementation for %v doesn't supported", info.RuntimePolicy.MLPolicy.MPI.MPIImplementation)
+					return fmt.Errorf("MPI implementation for %v doesn't supported", info.RuntimePolicy.MLPolicySource.MPI.MPIImplementation)
 				}
 			}
 		}
@@ -213,7 +213,7 @@ func (m *MPI) ReconcilerBuilders() []runtime.ReconcilerBuilder {
 }
 
 func (m *MPI) Build(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]any, error) {
-	if info == nil || info.RuntimePolicy.MLPolicy == nil || info.RuntimePolicy.MLPolicy.MPI == nil {
+	if info == nil || info.RuntimePolicy.MLPolicySource == nil || info.RuntimePolicy.MLPolicySource.MPI == nil {
 		return nil, nil
 	}
 
@@ -272,13 +272,13 @@ func sshAuthSecretName(trainJobName string) string {
 
 func (m *MPI) buildHostFileConfigMap(info *runtime.Info, trainJob *trainer.TrainJob) *corev1ac.ConfigMapApplyConfiguration {
 	var hostFile bytes.Buffer
-	runLauncherAsNode := ptr.Deref(info.RuntimePolicy.MLPolicy.MPI.RunLauncherAsNode, false)
-	slots := ptr.Deref(info.RuntimePolicy.MLPolicy.MPI.NumProcPerNode, 1)
+	runLauncherAsNode := ptr.Deref(info.RuntimePolicy.MLPolicySource.MPI.RunLauncherAsNode, false)
+	slots := ptr.Deref(info.RuntimePolicy.MLPolicySource.MPI.NumProcPerNode, 1)
 	for _, ps := range info.TemplateSpec.PodSets {
 		if !isTrainerNode(runLauncherAsNode, ps) {
 			continue
 		}
-		switch *info.RuntimePolicy.MLPolicy.MPI.MPIImplementation {
+		switch *info.RuntimePolicy.MLPolicySource.MPI.MPIImplementation {
 		case trainer.MPIImplementationOpenMPI:
 			for e := range ps.Endpoints {
 				hostFile.WriteString(fmt.Sprintf("%s slots=%d\n", e, slots))

--- a/pkg/runtime/framework/plugins/mpi/mpi_test.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi_test.go
@@ -61,7 +61,7 @@ func TestMPI(t *testing.T) {
 		wantBuildError    error
 	}{
 		"no action when info is nil": {},
-		"no action when mlPolicy is nil": {
+		"no action when mlPolicySource is nil": {
 			info: &runtime.Info{
 				Labels: map[string]string{"key": "value"},
 			},
@@ -69,15 +69,15 @@ func TestMPI(t *testing.T) {
 				Labels: map[string]string{"key": "value"},
 			},
 		},
-		"no action when mlPolicy mpi is null": {
+		"no action when mlPolicySource mpi is null": {
 			info: &runtime.Info{
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().Obj(),
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().Obj(),
 				},
 			},
 			wantInfo: &runtime.Info{
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().Obj(),
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().Obj(),
 				},
 			},
 		},
@@ -97,19 +97,13 @@ func TestMPI(t *testing.T) {
 							Name: constants.JobTrainerNode,
 							Endpoints: func(yield func(string) bool) {
 								yield("trainJob-trainer-node-1-0.trainJob")
-							},
-						},
-						{
-							Name: constants.JobTrainerNode,
-							Endpoints: func(yield func(string) bool) {
 								yield("trainJob-trainer-node-1-1.trainJob")
 							},
 						},
 					},
 				},
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), nil).
 						Obj(),
 				},
@@ -165,7 +159,8 @@ func TestMPI(t *testing.T) {
 							},
 						},
 						{
-							Name: constants.JobTrainerNode,
+							Name:  constants.JobTrainerNode,
+							Count: ptr.To[int32](2),
 							Volumes: []corev1ac.VolumeApplyConfiguration{
 								*corev1ac.Volume().
 									WithName(constants.MPISSHAuthVolumeName).
@@ -186,37 +181,13 @@ func TestMPI(t *testing.T) {
 							},
 							Endpoints: func(yield func(string) bool) {
 								yield("trainJob-trainer-node-1-0.trainJob")
-							},
-						},
-						{
-							Name: constants.JobTrainerNode,
-							Volumes: []corev1ac.VolumeApplyConfiguration{
-								*corev1ac.Volume().
-									WithName(constants.MPISSHAuthVolumeName).
-									WithSecret(corev1ac.SecretVolumeSource().
-										WithSecretName(fmt.Sprintf("trainJob%s", constants.MPISSHAuthSecretSuffix)).
-										WithItems(
-											corev1ac.KeyToPath().
-												WithKey(corev1.SSHAuthPrivateKey).
-												WithPath(constants.MPISSHPrivateKeyFile),
-											corev1ac.KeyToPath().
-												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHPublicKeyFile),
-											corev1ac.KeyToPath().
-												WithKey(constants.MPISSHPublicKey).
-												WithPath(constants.MPISSHAuthorizedKeys),
-										),
-									),
-							},
-							Endpoints: func(yield func(string) bool) {
 								yield("trainJob-trainer-node-1-1.trainJob")
 							},
 						},
 					},
 				},
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(2).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), nil).
 						Obj(),
 				},
@@ -263,7 +234,7 @@ trainJob-trainer-node-1-1.trainJob slots=1
 					},
 				},
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), nil).
 						Obj(),
 				},
@@ -320,7 +291,8 @@ trainJob-trainer-node-1-1.trainJob slots=1
 							},
 						},
 						{
-							Name: constants.JobTrainerNode,
+							Name:  constants.JobTrainerNode,
+							Count: ptr.To[int32](1),
 							Volumes: []corev1ac.VolumeApplyConfiguration{
 								*corev1ac.Volume().
 									WithName(constants.MPISSHAuthVolumeName).
@@ -346,8 +318,7 @@ trainJob-trainer-node-1-1.trainJob slots=1
 					},
 				},
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						MPIPolicy(ptr.To[int32](2), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), nil).
 						Obj(),
 				},
@@ -377,8 +348,7 @@ trainJob-trainer-node-1-1.trainJob slots=1
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(true)).
 						Obj(),
 				},
@@ -411,8 +381,7 @@ trainJob-trainer-node-1-1.trainJob slots=1
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(true)).
 						Obj(),
 				},
@@ -454,7 +423,8 @@ trainJob-trainer-node-1-1.trainJob slots=1
 							},
 						},
 						{
-							Name: constants.JobTrainerNode,
+							Name:  constants.JobTrainerNode,
+							Count: ptr.To[int32](1),
 							Volumes: []corev1ac.VolumeApplyConfiguration{
 								*corev1ac.Volume().
 									WithName(constants.MPISSHAuthVolumeName).
@@ -522,8 +492,7 @@ trainJob-trainer-node-1-0.trainJob slots=1
 					},
 				},
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(true)).
 						Obj(),
 				},
@@ -575,8 +544,7 @@ trainJob-trainer-node-1-0.trainJob slots=1
 					},
 				},
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(true)).
 						Obj(),
 				},
@@ -607,8 +575,7 @@ trainJob-trainer-node-1-0.trainJob slots=1
 					},
 				},
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(true)).
 						Obj(),
 				},
@@ -660,8 +627,7 @@ trainJob-trainer-node-1-0.trainJob slots=1
 					},
 				},
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(true)).
 						Obj(),
 				},

--- a/pkg/runtime/framework/plugins/plainml/plainml.go
+++ b/pkg/runtime/framework/plugins/plainml/plainml.go
@@ -43,17 +43,15 @@ func (p *PlainML) Name() string {
 }
 
 func (p *PlainML) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) error {
-	if info == nil || info.RuntimePolicy.MLPolicy == nil || info.RuntimePolicy.MLPolicy.Torch != nil || info.RuntimePolicy.MLPolicy.MPI != nil {
+	if info == nil ||
+		(info.RuntimePolicy.MLPolicySource != nil && (info.RuntimePolicy.MLPolicySource.Torch != nil || info.RuntimePolicy.MLPolicySource.MPI != nil)) {
 		return nil
 	}
 
 	// TrainJob contains the actual information for the number of nodes.
-	numNodes := info.RuntimePolicy.MLPolicy.NumNodes
-
 	if trainJob.Spec.Trainer != nil && trainJob.Spec.Trainer.NumNodes != nil {
-		numNodes = trainJob.Spec.Trainer.NumNodes
+		info.FindPodSetByName(constants.JobTrainerNode).Count = trainJob.Spec.Trainer.NumNodes
 	}
-	info.RuntimePolicy.MLPolicy.NumNodes = numNodes
 
 	// Add envs from the TrainJob.
 	var trainerContainer *runtime.Container

--- a/pkg/runtime/framework/plugins/plainml/plainml_test.go
+++ b/pkg/runtime/framework/plugins/plainml/plainml_test.go
@@ -43,20 +43,11 @@ func TestPlainML(t *testing.T) {
 		wantInfo  *runtime.Info
 	}{
 		"no action when info is null": {},
-		"no action when mlPolicy is null": {
-			info: &runtime.Info{
-				Labels: map[string]string{"key": "value"},
-			},
-			wantInfo: &runtime.Info{
-				Labels: map[string]string{"key": "value"},
-			},
-		},
-		"no action when mlPolicy torch is not null": {
+		"no action when mlPolicySource torch is not null": {
 			info: &runtime.Info{
 				Labels: map[string]string{"key": "value"},
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(100).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						TorchPolicy("auto", nil).
 						Obj(),
 				},
@@ -64,19 +55,17 @@ func TestPlainML(t *testing.T) {
 			wantInfo: &runtime.Info{
 				Labels: map[string]string{"key": "value"},
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(100).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						TorchPolicy("auto", nil).
 						Obj(),
 				},
 			},
 		},
-		"no action when mlPolicy mpi is not null": {
+		"no action when mlPolicySource mpi is not null": {
 			info: &runtime.Info{
 				Labels: map[string]string{"key": "value"},
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(100).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), nil, ptr.To(false)).
 						Obj(),
 				},
@@ -84,8 +73,7 @@ func TestPlainML(t *testing.T) {
 			wantInfo: &runtime.Info{
 				Labels: map[string]string{"key": "value"},
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(100).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), nil, ptr.To(false)).
 						Obj(),
 				},
@@ -98,10 +86,8 @@ func TestPlainML(t *testing.T) {
 				).
 				Obj(),
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(
-					utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(100).
-						Obj(),
+				runtime.WithMLPolicySource(
+					utiltesting.MakeMLPolicyWrapper().Obj(),
 				),
 				runtime.WithPodSet(constants.JobTrainerNode, 100, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
@@ -111,11 +97,12 @@ func TestPlainML(t *testing.T) {
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().WithNumNodes(200).Obj(),
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
 						Name:              constants.JobTrainerNode,
+						Count:             ptr.To[int32](200),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
@@ -139,7 +126,7 @@ func TestPlainML(t *testing.T) {
 				).
 				Obj(),
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(
+				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().Obj(),
 				),
 				runtime.WithPodSet(constants.JobTrainerNode, 100, corev1.PodSpec{}, corev1ac.PodSpec().
@@ -156,13 +143,12 @@ func TestPlainML(t *testing.T) {
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
-						Obj(),
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
 						Name:              constants.JobTrainerNode,
+						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,

--- a/pkg/runtime/framework/plugins/torch/torch_test.go
+++ b/pkg/runtime/framework/plugins/torch/torch_test.go
@@ -46,7 +46,7 @@ func TestTorch(t *testing.T) {
 		wantMLPolicyError error
 	}{
 		"no action when info is nil": {},
-		"no action when mlPolicy is nil": {
+		"no action when mlPolicySource is nil": {
 			info: runtime.NewInfo(
 				runtime.WithLabels(map[string]string{"key": "value"}),
 			),
@@ -54,22 +54,26 @@ func TestTorch(t *testing.T) {
 				runtime.WithLabels(map[string]string{"key": "value"}),
 			),
 		},
-		"no action when mlPolicy torch is null": {
+		"no action when mlPolicySource torch is null": {
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(utiltesting.MakeMLPolicyWrapper().
-					Obj()),
+				runtime.WithMLPolicySource(
+					utiltesting.MakeMLPolicyWrapper().Obj(),
+				),
 			),
 			wantInfo: runtime.NewInfo(
-				runtime.WithMLPolicy(utiltesting.MakeMLPolicyWrapper().
-					Obj()),
+				runtime.WithMLPolicySource(
+					utiltesting.MakeMLPolicyWrapper().Obj(),
+				),
 			),
 		},
 		"trainJob numNodes is respected rather than mlPolicy one": {
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(
+				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
-						TorchPolicy("auto", nil).
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							TorchPolicy("auto", nil).
+							Obj(),
+						).
 						Obj(),
 				),
 				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
@@ -88,14 +92,14 @@ func TestTorch(t *testing.T) {
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(2).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						TorchPolicy("auto", nil).
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
 						Name:              constants.JobTrainerNode,
+						Count:             ptr.To[int32](2),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
@@ -139,17 +143,19 @@ func TestTorch(t *testing.T) {
 				Trainer(
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumProcPerNode(intstr.FromString("auto")).
-						Container("test:image", []string{}, []string{}, corev1.ResourceList{
+						Container("test:image", nil, nil, corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("4"),
 						}).
 						Obj(),
 				).
 				Obj(),
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(
+				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
-						TorchPolicy("auto", nil).
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							TorchPolicy("auto", nil).
+							Obj(),
+						).
 						Obj(),
 				),
 				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
@@ -160,14 +166,14 @@ func TestTorch(t *testing.T) {
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						TorchPolicy("auto", nil).
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
 						Name:              constants.JobTrainerNode,
+						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
@@ -211,15 +217,17 @@ func TestTorch(t *testing.T) {
 				Trainer(
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumProcPerNode(intstr.FromString("auto")).
-						Container("test:image", []string{}, []string{}, nil).
+						Container("test:image", nil, nil, nil).
 						Obj(),
 				).
 				Obj(),
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(
+				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
-						TorchPolicy("auto", nil).
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							TorchPolicy("auto", nil).
+							Obj(),
+						).
 						Obj(),
 				),
 				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
@@ -230,14 +238,14 @@ func TestTorch(t *testing.T) {
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						TorchPolicy("auto", nil).
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
 						Name:              constants.JobTrainerNode,
+						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
@@ -281,17 +289,19 @@ func TestTorch(t *testing.T) {
 				Trainer(
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumProcPerNode(intstr.FromString("auto")).
-						Container("test:image", []string{}, []string{}, corev1.ResourceList{
+						Container("test:image", nil, nil, corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("2"), // Low CPU limit
 						}).
 						Obj(),
 				).
 				Obj(),
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(
+				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
-						TorchPolicy("auto", nil).
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							TorchPolicy("auto", nil).
+							Obj(),
+						).
 						Obj(),
 				),
 				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
@@ -302,14 +312,14 @@ func TestTorch(t *testing.T) {
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						TorchPolicy("auto", nil).
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
 						Name:              constants.JobTrainerNode,
+						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
@@ -353,17 +363,19 @@ func TestTorch(t *testing.T) {
 				Trainer(
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumProcPerNode(intstr.FromString("auto")).
-						Container("test:image", []string{}, []string{}, corev1.ResourceList{
+						Container("test:image", nil, nil, corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("3"),
 						}).
 						Obj(),
 				).
 				Obj(),
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(
+				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
-						TorchPolicy("auto", nil).
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							TorchPolicy("auto", nil).
+							Obj(),
+						).
 						Obj(),
 				),
 				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
@@ -374,14 +386,14 @@ func TestTorch(t *testing.T) {
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						TorchPolicy("auto", nil).
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
 						Name:              constants.JobTrainerNode,
+						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
@@ -425,17 +437,19 @@ func TestTorch(t *testing.T) {
 				Trainer(
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumProcPerNode(intstr.FromString("auto")).
-						Container("test:image", []string{}, []string{}, corev1.ResourceList{
+						Container("test:image", nil, nil, corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("2.5"), // 2.5 CPU cores
 						}).
 						Obj(),
 				).
 				Obj(),
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(
+				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
-						TorchPolicy("auto", nil).
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							TorchPolicy("auto", nil).
+							Obj(),
+						).
 						Obj(),
 				),
 				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
@@ -446,14 +460,14 @@ func TestTorch(t *testing.T) {
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						TorchPolicy("auto", nil).
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
 						Name:              constants.JobTrainerNode,
+						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
@@ -497,17 +511,19 @@ func TestTorch(t *testing.T) {
 				Trainer(
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumProcPerNode(intstr.FromString("auto")).
-						Container("test:image", []string{}, []string{}, corev1.ResourceList{
+						Container("test:image", nil, nil, corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("0.7"), // 0.7 CPU cores
 						}).
 						Obj(),
 				).
 				Obj(),
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(
+				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
-						TorchPolicy("auto", nil).
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							TorchPolicy("auto", nil).
+							Obj(),
+						).
 						Obj(),
 				),
 				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
@@ -518,14 +534,14 @@ func TestTorch(t *testing.T) {
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						TorchPolicy("auto", nil).
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
 						Name:              constants.JobTrainerNode,
+						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
@@ -569,17 +585,19 @@ func TestTorch(t *testing.T) {
 				Trainer(
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumProcPerNode(intstr.FromString("auto")).
-						Container("test:image", []string{}, []string{}, corev1.ResourceList{
+						Container("test:image", nil, nil, corev1.ResourceList{
 							"nvidia.com/gpu": resource.MustParse("2"),
 						}).
 						Obj(),
 				).
 				Obj(),
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(
+				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
-						TorchPolicy("auto", nil).
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							TorchPolicy("auto", nil).
+							Obj(),
+						).
 						Obj(),
 				),
 				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
@@ -590,14 +608,14 @@ func TestTorch(t *testing.T) {
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						TorchPolicy("auto", nil).
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
 						Name:              constants.JobTrainerNode,
+						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
@@ -641,17 +659,19 @@ func TestTorch(t *testing.T) {
 				Trainer(
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumProcPerNode(intstr.FromInt32(3)).
-						Container("test:image", []string{}, []string{}, corev1.ResourceList{
+						Container("test:image", nil, nil, corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("8"),
 						}).
 						Obj(),
 				).
 				Obj(),
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(
+				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
-						TorchPolicy("auto", nil).
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							TorchPolicy("auto", nil).
+							Obj(),
+						).
 						Obj(),
 				),
 				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
@@ -662,14 +682,14 @@ func TestTorch(t *testing.T) {
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						TorchPolicy("auto", nil).
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
 						Name:              constants.JobTrainerNode,
+						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
@@ -713,17 +733,19 @@ func TestTorch(t *testing.T) {
 				Trainer(
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumProcPerNode(intstr.FromString("auto")).
-						Container("test:image", []string{}, []string{}, corev1.ResourceList{
+						Container("test:image", nil, nil, corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("2500m"), // 2.5 CPU cores in millicore format
 						}).
 						Obj(),
 				).
 				Obj(),
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(
+				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
-						TorchPolicy("auto", nil).
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							TorchPolicy("auto", nil).
+							Obj(),
+						).
 						Obj(),
 				),
 				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
@@ -734,14 +756,14 @@ func TestTorch(t *testing.T) {
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						TorchPolicy("auto", nil).
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
 						Name:              constants.JobTrainerNode,
+						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
@@ -785,17 +807,19 @@ func TestTorch(t *testing.T) {
 				Trainer(
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumProcPerNode(intstr.FromString("cpu")).
-						Container("test:image", []string{}, []string{}, corev1.ResourceList{
+						Container("test:image", nil, nil, corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("4"),
 						}).
 						Obj(),
 				).
 				Obj(),
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(
+				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
-						TorchPolicy("auto", nil).
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							TorchPolicy("auto", nil).
+							Obj(),
+						).
 						Obj(),
 				),
 				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
@@ -806,14 +830,14 @@ func TestTorch(t *testing.T) {
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						TorchPolicy("auto", nil).
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
 						Name:              constants.JobTrainerNode,
+						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
@@ -857,7 +881,7 @@ func TestTorch(t *testing.T) {
 				Trainer(
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumProcPerNode(intstr.FromString("cpu")).
-						Container("test:image", []string{}, []string{}, corev1.ResourceList{
+						Container("test:image", nil, nil, corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("6"),
 							"nvidia.com/gpu":   resource.MustParse("2"),
 						}).
@@ -865,10 +889,12 @@ func TestTorch(t *testing.T) {
 				).
 				Obj(),
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(
+				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
-						TorchPolicy("auto", nil).
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							TorchPolicy("auto", nil).
+							Obj(),
+						).
 						Obj(),
 				),
 				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
@@ -879,14 +905,14 @@ func TestTorch(t *testing.T) {
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						TorchPolicy("auto", nil).
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
 						Name:              constants.JobTrainerNode,
+						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
@@ -930,17 +956,19 @@ func TestTorch(t *testing.T) {
 				Trainer(
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumProcPerNode(intstr.FromString("cpu")).
-						Container("test:image", []string{}, []string{}, corev1.ResourceList{
+						Container("test:image", nil, nil, corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("3.7"),
 						}).
 						Obj(),
 				).
 				Obj(),
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(
+				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
-						TorchPolicy("auto", nil).
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							TorchPolicy("auto", nil).
+							Obj(),
+						).
 						Obj(),
 				),
 				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
@@ -951,14 +979,14 @@ func TestTorch(t *testing.T) {
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(1).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						TorchPolicy("auto", nil).
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
 						Name:              constants.JobTrainerNode,
+						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,
@@ -1003,7 +1031,7 @@ func TestTorch(t *testing.T) {
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumNodes(4).
 						NumProcPerNode(intstr.FromString("auto")).
-						Container("pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime", []string{}, []string{}, corev1.ResourceList{
+						Container("pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime", nil, nil, corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("8"),
 							corev1.ResourceMemory: resource.MustParse("16Gi"),
 							"nvidia.com/gpu":      resource.MustParse("4"), // 4 GPUs per node
@@ -1012,10 +1040,12 @@ func TestTorch(t *testing.T) {
 				).
 				Obj(),
 			info: runtime.NewInfo(
-				runtime.WithMLPolicy(
+				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(2). // This value should be overridden by the value in trainJob
-						TorchPolicy("auto", nil).
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							TorchPolicy("auto", nil).
+							Obj(),
+						).
 						Obj(),
 				),
 				runtime.WithLabels(map[string]string{
@@ -1033,14 +1063,14 @@ func TestTorch(t *testing.T) {
 				},
 				Annotations: make(map[string]string),
 				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicy: utiltesting.MakeMLPolicyWrapper().
-						WithNumNodes(4).
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
 						TorchPolicy("auto", nil).
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
 						Name:              constants.JobTrainerNode,
+						Count:             ptr.To[int32](4),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
 							Name: constants.ContainerTrainer,

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -272,8 +272,8 @@ func TestNewInfo(t *testing.T) {
 				TemplateSpec: TemplateSpec{
 					PodSets: []PodSet{
 						{
-							Name:               constants.DatasetInitializer,
-							CountForNonTrainer: ptr.To[int32](1),
+							Name:  constants.DatasetInitializer,
+							Count: ptr.To[int32](1),
 							InitContainers: []Container{{
 								Name: "setup-initializer",
 							}},
@@ -285,8 +285,8 @@ func TestNewInfo(t *testing.T) {
 							},
 						},
 						{
-							Name:               constants.ModelInitializer,
-							CountForNonTrainer: ptr.To[int32](1),
+							Name:  constants.ModelInitializer,
+							Count: ptr.To[int32](1),
 							InitContainers: []Container{{
 								Name: "setup-initializer",
 							}},
@@ -298,7 +298,8 @@ func TestNewInfo(t *testing.T) {
 							},
 						},
 						{
-							Name: constants.JobTrainerNode,
+							Name:  constants.JobTrainerNode,
+							Count: ptr.To[int32](10),
 							Containers: []Container{{
 								Name: constants.ContainerTrainer,
 								Env: []corev1ac.EnvVarApplyConfiguration{{
@@ -505,6 +506,52 @@ func TestFindContainerByPodSetContainerName(t *testing.T) {
 			got := tc.info.FindContainerByPodSetContainerName(tc.psName, tc.containerName)
 			if diff := cmp.Diff(tc.wantContainer, got); len(diff) != 0 {
 				t.Errorf("Unexpected Container (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFindContainerByName(t *testing.T) {
+	cases := map[string]struct {
+		info   *Info
+		psName string
+		want   *PodSet
+	}{
+		"PodSet exists": {
+			info: &Info{
+				TemplateSpec: TemplateSpec{
+					PodSets: []PodSet{
+						{
+							Name: "alpha",
+						},
+						{
+							Name: "beta",
+						},
+					},
+				},
+			},
+			psName: "alpha",
+			want: &PodSet{
+				Name: "alpha",
+			},
+		},
+		"PodSet does not exist": {
+			info: &Info{
+				TemplateSpec: TemplateSpec{
+					PodSets: []PodSet{{
+						Name: "alpha",
+					}},
+				},
+			},
+			psName: "beta",
+			want:   nil,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.info.FindPodSetByName(tc.psName)
+			if diff := cmp.Diff(tc.want, got); len(diff) != 0 {
+				t.Errorf("Unexpected PodSet (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/util/testing/wrapper.go
+++ b/pkg/util/testing/wrapper.go
@@ -964,30 +964,47 @@ func (m *MLPolicyWrapper) WithNumNodes(numNodes int32) *MLPolicyWrapper {
 	return m
 }
 
-func (m *MLPolicyWrapper) TorchPolicy(numProcPerNode string, elasticPolicy *trainer.TorchElasticPolicy) *MLPolicyWrapper {
-	if m.MLPolicySource.Torch == nil {
-		m.MLPolicySource.Torch = &trainer.TorchMLPolicySource{}
+func (m *MLPolicyWrapper) WithMLPolicySource(source trainer.MLPolicySource) *MLPolicyWrapper {
+	m.MLPolicySource = source
+	return m
+}
+
+func (m *MLPolicyWrapper) Obj() *trainer.MLPolicy {
+	return &m.MLPolicy
+}
+
+type MLPolicySourceWrapper struct {
+	trainer.MLPolicySource
+}
+
+func MakeMLPolicySourceWrapper() *MLPolicySourceWrapper {
+	return &MLPolicySourceWrapper{}
+}
+
+func (m *MLPolicySourceWrapper) TorchPolicy(numProcPerNode string, elasticPolicy *trainer.TorchElasticPolicy) *MLPolicySourceWrapper {
+	if m.Torch == nil {
+		m.Torch = &trainer.TorchMLPolicySource{}
 	}
-	m.MLPolicySource.Torch = &trainer.TorchMLPolicySource{
+	m.Torch = &trainer.TorchMLPolicySource{
 		NumProcPerNode: ptr.To(intstr.FromString(numProcPerNode)),
 		ElasticPolicy:  elasticPolicy,
 	}
 	return m
 }
 
-func (m *MLPolicyWrapper) MPIPolicy(numProcPerNode *int32, MPImplementation *trainer.MPIImplementation, sshAuthMountPath *string, runLauncherAsNode *bool) *MLPolicyWrapper {
-	if m.MLPolicySource.MPI == nil {
-		m.MLPolicySource.MPI = &trainer.MPIMLPolicySource{}
+func (m *MLPolicySourceWrapper) MPIPolicy(numProcPerNode *int32, MPImplementation *trainer.MPIImplementation, sshAuthMountPath *string, runLauncherAsNode *bool) *MLPolicySourceWrapper {
+	if m.MPI == nil {
+		m.MPI = &trainer.MPIMLPolicySource{}
 	}
-	m.MLPolicySource.MPI.NumProcPerNode = numProcPerNode
-	m.MLPolicySource.MPI.MPIImplementation = MPImplementation
-	m.MLPolicySource.MPI.SSHAuthMountPath = sshAuthMountPath
-	m.MLPolicySource.MPI.RunLauncherAsNode = runLauncherAsNode
+	m.MPI.NumProcPerNode = numProcPerNode
+	m.MPI.MPIImplementation = MPImplementation
+	m.MPI.SSHAuthMountPath = sshAuthMountPath
+	m.MPI.RunLauncherAsNode = runLauncherAsNode
 	return m
 }
 
-func (m *MLPolicyWrapper) Obj() *trainer.MLPolicy {
-	return &m.MLPolicy
+func (m *MLPolicySourceWrapper) Obj() *trainer.MLPolicySource {
+	return &m.MLPolicySource
 }
 
 type SchedulerPluginsPodGroupWrapper struct {

--- a/test/integration/controller/trainjob_controller_test.go
+++ b/test/integration/controller/trainjob_controller_test.go
@@ -331,7 +331,10 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
 									WithNumNodes(100).
-									TorchPolicy("auto", nil).
+									WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+										TorchPolicy("auto", nil).
+										Obj(),
+									).
 									Obj(),
 							).
 							Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
@@ -607,7 +610,10 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
 									WithNumNodes(1).
-									MPIPolicy(ptr.To[int32](8), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(false)).
+									WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+										MPIPolicy(ptr.To[int32](8), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(false)).
+										Obj(),
+									).
 									Obj(),
 							).
 							Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).

--- a/test/integration/webhooks/trainingruntime_webhook_test.go
+++ b/test/integration/webhooks/trainingruntime_webhook_test.go
@@ -135,7 +135,7 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 				func() *trainer.TrainingRuntime {
 					runtime := testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj()
 					runtime.Spec.MLPolicy = &trainer.MLPolicy{
-						NumNodes: ptr.To(int32(2)),
+						NumNodes: ptr.To[int32](2),
 						MLPolicySource: trainer.MLPolicySource{
 							Torch: &trainer.TorchMLPolicySource{
 								ElasticPolicy: &trainer.TorchElasticPolicy{},
@@ -152,7 +152,10 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
-									MPIPolicy(nil, ptr.To[trainer.MPIImplementation]("invalid"), nil, nil).
+									WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+										MPIPolicy(nil, ptr.To[trainer.MPIImplementation]("invalid"), nil, nil).
+										Obj(),
+									).
 									Obj(),
 							).
 							Obj()).
@@ -198,7 +201,10 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
-									MPIPolicy(ptr.To[int32](1), nil, ptr.To("/usr/dir"), ptr.To(false)).
+									WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+										MPIPolicy(ptr.To[int32](1), nil, ptr.To("/usr/dir"), ptr.To(false)).
+										Obj(),
+									).
 									Obj(),
 							).
 							JobSetSpec(
@@ -217,7 +223,10 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
-									MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), ptr.To(false)).
+									WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+										MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), ptr.To(false)).
+										Obj(),
+									).
 									Obj(),
 							).
 							JobSetSpec(
@@ -237,7 +246,10 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
-									MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), nil, ptr.To(false)).
+									WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+										MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), nil, ptr.To(false)).
+										Obj(),
+									).
 									Obj(),
 							).
 							JobSetSpec(
@@ -256,7 +268,10 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
-									MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(false)).
+									WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+										MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(false)).
+										Obj(),
+									).
 									Obj(),
 							).
 							JobSetSpec(
@@ -276,7 +291,10 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
-									MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), nil).
+									WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+										MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), nil).
+										Obj(),
+									).
 									Obj(),
 							).
 							JobSetSpec(
@@ -295,7 +313,10 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
-									MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), ptr.To(false)).
+									WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+										MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), ptr.To(false)).
+										Obj(),
+									).
 									Obj(),
 							).
 							JobSetSpec(
@@ -315,7 +336,10 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
-									MPIPolicy(nil, ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), ptr.To(false)).
+									WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+										MPIPolicy(nil, ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), ptr.To(false)).
+										Obj(),
+									).
 									Obj(),
 							).
 							JobSetSpec(
@@ -334,7 +358,10 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
 							WithMLPolicy(
 								testingutil.MakeMLPolicyWrapper().
-									MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), ptr.To(false)).
+									WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+										MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/usr/dir"), ptr.To(false)).
+										Obj(),
+									).
 									Obj(),
 							).
 							JobSetSpec(


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I replaced the `runtime.Info.RuntimePolicy.MLPolicy` with `runtime.Info.RuntimePolicy.MLPolicySource` so that we can store all rJob numNodes to `runtime.Info.TemplateSpec.PodSet.Count`.

Previously, we stored the non-Trainer numNodes to `runtime.Info.TemplateSpec.PodSet.Count` and stored the Trainer numNodes to `runtime.Info.RuntimePolicy.MLPolicy.NumNodes`, which introduce internal data structure fragmentation.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Part-of: https://github.com/kubeflow/trainer/issues/2495

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
