### PR TITLE
fix(sdk): add missing import type Initializer.

### DIFF
--- a/sdk/kubeflow/trainer/__init__.py
+++ b/sdk/kubeflow/trainer/__init__.py
@@ -28,4 +28,5 @@ from kubeflow.trainer.types.types import (
     CustomTrainer,
     HuggingFaceDatasetInitializer,
     HuggingFaceModelInitializer,
+    Initializer,
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

We need to expose `types.Initializer` to users. It seems that we forgot to import it in:

https://github.com/kubeflow/trainer/blob/b47d385928fb7d82fb07cd1e0229861bf8856900/sdk/kubeflow/trainer/__init__.py#L26-L31

I create a small fix PR to add it to the import list so that it would not be blocked by: #2522

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
