### PR TITLE
Update Manifest Images to GHCR

### DIFF
--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -75,7 +75,7 @@ jobs:
         with:
           image: |
             docker.io/kubeflow/${{ inputs.component-name }}
-            ghcr.io/kubeflow/training/${{ inputs.component-name }}
+            ghcr.io/kubeflow/training-v1/${{ inputs.component-name }}
           dockerfile: ${{ inputs.dockerfile }}
           platforms: ${{ inputs.platforms }}
           context: ${{ inputs.context }}
@@ -88,7 +88,7 @@ jobs:
         with:
           image: |
             docker.io/kubeflow/${{ inputs.component-name }}
-            ghcr.io/kubeflow/training/${{ inputs.component-name }}
+            ghcr.io/kubeflow/training-v1/${{ inputs.component-name }}
           dockerfile: ${{ inputs.dockerfile }}
           platforms: ${{ inputs.platforms }}
           context: ${{ inputs.context }}

--- a/.github/workflows/build-and-publish-images.yaml
+++ b/.github/workflows/build-and-publish-images.yaml
@@ -75,7 +75,7 @@ jobs:
         with:
           image: |
             docker.io/kubeflow/${{ inputs.component-name }}
-            ghcr.io/kubeflow/trainer/${{ inputs.component-name }}
+            ghcr.io/kubeflow/training/${{ inputs.component-name }}
           dockerfile: ${{ inputs.dockerfile }}
           platforms: ${{ inputs.platforms }}
           context: ${{ inputs.context }}
@@ -88,7 +88,7 @@ jobs:
         with:
           image: |
             docker.io/kubeflow/${{ inputs.component-name }}
-            ghcr.io/kubeflow/trainer/${{ inputs.component-name }}
+            ghcr.io/kubeflow/training/${{ inputs.component-name }}
           dockerfile: ${{ inputs.dockerfile }}
           platforms: ${{ inputs.platforms }}
           context: ${{ inputs.context }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= kubeflow/training-operator:latest
+IMG ?= ghcr.io/kubeflow/training/training-operator:latest
 # CRD generation options
 CRD_OPTIONS ?= "crd:generateEmbeddedObjectMeta=true,maxDescLen=400"
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/kubeflow/training/training-operator:latest
+IMG ?= ghcr.io/kubeflow/training-v1/training-operator:latest
 # CRD generation options
 CRD_OPTIONS ?= "crd:generateEmbeddedObjectMeta=true,maxDescLen=400"
 

--- a/examples/jax/cpu-demo/demo.yaml
+++ b/examples/jax/cpu-demo/demo.yaml
@@ -12,7 +12,7 @@ spec:
         spec:
           containers:
             - name: jax
-              image: ghcr.io/kubeflow/training/jaxjob-simple:latest
+              image: ghcr.io/kubeflow/training-v1/jaxjob-simple:latest
               command:
                 - "python3"
                 - "train.py"

--- a/examples/jax/cpu-demo/demo.yaml
+++ b/examples/jax/cpu-demo/demo.yaml
@@ -12,7 +12,7 @@ spec:
         spec:
           containers:
             - name: jax
-              image: docker.io/kubeflow/jaxjob-simple:latest
+              image: ghcr.io/kubeflow/training/jaxjob-simple:latest
               command:
                 - "python3"
                 - "train.py"

--- a/examples/jax/jax-dist-spmd-mnist/jaxjob_dist_spmd_mnist_gloo.yaml
+++ b/examples/jax/jax-dist-spmd-mnist/jaxjob_dist_spmd_mnist_gloo.yaml
@@ -12,5 +12,5 @@ spec:
         spec:
           containers:
             - name: jax
-              image: ghcr.io/kubeflow/training/jaxjob-dist-spmd-mnist:latest
+              image: ghcr.io/kubeflow/training-v1/jaxjob-dist-spmd-mnist:latest
               imagePullPolicy: Always

--- a/examples/jax/jax-dist-spmd-mnist/jaxjob_dist_spmd_mnist_gloo.yaml
+++ b/examples/jax/jax-dist-spmd-mnist/jaxjob_dist_spmd_mnist_gloo.yaml
@@ -12,5 +12,5 @@ spec:
         spec:
           containers:
             - name: jax
-              image: docker.io/kubeflow/jaxjob-dist-spmd-mnist:latest
+              image: ghcr.io/kubeflow/training/jaxjob-dist-spmd-mnist:latest
               imagePullPolicy: Always

--- a/examples/pytorch/deepspeed-demo/pytorch_deepspeed_demo.yaml
+++ b/examples/pytorch/deepspeed-demo/pytorch_deepspeed_demo.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: kubeflow/pytorch-deepspeed-demo:latest
+              image: ghcr.io/kubeflow/training/pytorch-deepspeed-demo:latest
               command:
                 - torchrun
                 - /train_bert_ds.py
@@ -27,7 +27,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: kubeflow/pytorch-deepspeed-demo:latest
+              image: ghcr.io/kubeflow/training/pytorch-deepspeed-demo:latest
               command:
                 - torchrun
                 - /train_bert_ds.py

--- a/examples/pytorch/deepspeed-demo/pytorch_deepspeed_demo.yaml
+++ b/examples/pytorch/deepspeed-demo/pytorch_deepspeed_demo.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: ghcr.io/kubeflow/training/pytorch-deepspeed-demo:latest
+              image: ghcr.io/kubeflow/training-v1/pytorch-deepspeed-demo:latest
               command:
                 - torchrun
                 - /train_bert_ds.py
@@ -27,7 +27,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: ghcr.io/kubeflow/training/pytorch-deepspeed-demo:latest
+              image: ghcr.io/kubeflow/training-v1/pytorch-deepspeed-demo:latest
               command:
                 - torchrun
                 - /train_bert_ds.py

--- a/examples/pytorch/elastic/echo/echo.yaml
+++ b/examples/pytorch/elastic/echo/echo.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: ghcr.io/kubeflow/training/pytorch-elastic-example-echo:latest
+              image: ghcr.io/kubeflow/training-v1/pytorch-elastic-example-echo:latest
               imagePullPolicy: IfNotPresent
               env:
               - name: LOGLEVEL

--- a/examples/pytorch/elastic/echo/echo.yaml
+++ b/examples/pytorch/elastic/echo/echo.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: kubeflow/pytorch-elastic-example-echo:latest
+              image: ghcr.io/kubeflow/training/pytorch-elastic-example-echo:latest
               imagePullPolicy: IfNotPresent
               env:
               - name: LOGLEVEL

--- a/examples/pytorch/elastic/imagenet/imagenet.yaml
+++ b/examples/pytorch/elastic/imagenet/imagenet.yaml
@@ -23,7 +23,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: ghcr.io/kubeflow/training/pytorch-elastic-example-imagenet:latest
+              image: ghcr.io/kubeflow/training-v1/pytorch-elastic-example-imagenet:latest
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/examples/pytorch/elastic/imagenet/imagenet.yaml
+++ b/examples/pytorch/elastic/imagenet/imagenet.yaml
@@ -23,7 +23,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: kubeflow/pytorch-elastic-example-imagenet:latest
+              image: ghcr.io/kubeflow/training/pytorch-elastic-example-imagenet:latest
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/examples/pytorch/image-classification/create-pytorchjob.ipynb
+++ b/examples/pytorch/image-classification/create-pytorchjob.ipynb
@@ -121,7 +121,7 @@
     "\n",
     "container = V1Container(\n",
     "    name=container_name,\n",
-    "    image=\"ghcr.io/kubeflow/training/pytorch-dist-mnist:latest\",\n",
+    "    image=\"ghcr.io/kubeflow/training-v1/pytorch-dist-mnist:latest\",\n",
     "    args=[\"--backend\", \"gloo\"],\n",
     ")\n",
     "\n",

--- a/examples/pytorch/image-classification/create-pytorchjob.ipynb
+++ b/examples/pytorch/image-classification/create-pytorchjob.ipynb
@@ -121,7 +121,7 @@
     "\n",
     "container = V1Container(\n",
     "    name=container_name,\n",
-    "    image=\"kubeflow/pytorch-dist-mnist:latest\",\n",
+    "    image=\"ghcr.io/kubeflow/training/pytorch-dist-mnist:latest\",\n",
     "    args=[\"--backend\", \"gloo\"],\n",
     ")\n",
     "\n",

--- a/examples/pytorch/mnist/v1/pytorch_job_mnist_gloo.yaml
+++ b/examples/pytorch/mnist/v1/pytorch_job_mnist_gloo.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: kubeflow/pytorch-dist-mnist:latest
+              image: ghcr.io/kubeflow/training/pytorch-dist-mnist:latest
               args: ["--backend", "gloo"]
               # Comment out the below resources to use the CPU.
               resources:
@@ -24,7 +24,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: kubeflow/pytorch-dist-mnist:latest
+              image: ghcr.io/kubeflow/training/pytorch-dist-mnist:latest
               args: ["--backend", "gloo"]
               # Comment out the below resources to use the CPU.
               resources:

--- a/examples/pytorch/mnist/v1/pytorch_job_mnist_gloo.yaml
+++ b/examples/pytorch/mnist/v1/pytorch_job_mnist_gloo.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: ghcr.io/kubeflow/training/pytorch-dist-mnist:latest
+              image: ghcr.io/kubeflow/training-v1/pytorch-dist-mnist:latest
               args: ["--backend", "gloo"]
               # Comment out the below resources to use the CPU.
               resources:
@@ -24,7 +24,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: ghcr.io/kubeflow/training/pytorch-dist-mnist:latest
+              image: ghcr.io/kubeflow/training-v1/pytorch-dist-mnist:latest
               args: ["--backend", "gloo"]
               # Comment out the below resources to use the CPU.
               resources:

--- a/examples/pytorch/mnist/v1/pytorch_job_mnist_mpi.yaml
+++ b/examples/pytorch/mnist/v1/pytorch_job_mnist_mpi.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: kubeflow/pytorch-dist-mnist:latest
+              image: ghcr.io/kubeflow/training/pytorch-dist-mnist:latest
               args: ["--backend", "mpi"]
               # Comment out the below resources to use the CPU.
               resources:
@@ -24,7 +24,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: kubeflow/pytorch-dist-mnist:latest
+              image: ghcr.io/kubeflow/training/pytorch-dist-mnist:latest
               args: ["--backend", "mpi"]
               # Comment out the below resources to use the CPU.
               resources:

--- a/examples/pytorch/mnist/v1/pytorch_job_mnist_mpi.yaml
+++ b/examples/pytorch/mnist/v1/pytorch_job_mnist_mpi.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: ghcr.io/kubeflow/training/pytorch-dist-mnist:latest
+              image: ghcr.io/kubeflow/training-v1/pytorch-dist-mnist:latest
               args: ["--backend", "mpi"]
               # Comment out the below resources to use the CPU.
               resources:
@@ -24,7 +24,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: ghcr.io/kubeflow/training/pytorch-dist-mnist:latest
+              image: ghcr.io/kubeflow/training-v1/pytorch-dist-mnist:latest
               args: ["--backend", "mpi"]
               # Comment out the below resources to use the CPU.
               resources:

--- a/examples/pytorch/mnist/v1/pytorch_job_mnist_nccl.yaml
+++ b/examples/pytorch/mnist/v1/pytorch_job_mnist_nccl.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: kubeflow/pytorch-dist-mnist:latest
+              image: ghcr.io/kubeflow/training/pytorch-dist-mnist:latest
               args: ["--backend", "nccl"]
               resources:
                 limits:
@@ -23,7 +23,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: kubeflow/pytorch-dist-mnist:latest
+              image: ghcr.io/kubeflow/training/pytorch-dist-mnist:latest
               args: ["--backend", "nccl"]
               resources:
                 limits:

--- a/examples/pytorch/mnist/v1/pytorch_job_mnist_nccl.yaml
+++ b/examples/pytorch/mnist/v1/pytorch_job_mnist_nccl.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: ghcr.io/kubeflow/training/pytorch-dist-mnist:latest
+              image: ghcr.io/kubeflow/training-v1/pytorch-dist-mnist:latest
               args: ["--backend", "nccl"]
               resources:
                 limits:
@@ -23,7 +23,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: ghcr.io/kubeflow/training/pytorch-dist-mnist:latest
+              image: ghcr.io/kubeflow/training-v1/pytorch-dist-mnist:latest
               args: ["--backend", "nccl"]
               resources:
                 limits:

--- a/examples/pytorch/smoke-dist/pytorch_job_sendrecv.yaml
+++ b/examples/pytorch/smoke-dist/pytorch_job_sendrecv.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: ghcr.io/kubeflow/training/pytorch-dist-sendrecv-test:latest
+              image: ghcr.io/kubeflow/training-v1/pytorch-dist-sendrecv-test:latest
     Worker:
       replicas: 3
       restartPolicy: OnFailure
@@ -19,4 +19,4 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: ghcr.io/kubeflow/training/pytorch-dist-sendrecv-test:latest
+              image: ghcr.io/kubeflow/training-v1/pytorch-dist-sendrecv-test:latest

--- a/examples/pytorch/smoke-dist/pytorch_job_sendrecv.yaml
+++ b/examples/pytorch/smoke-dist/pytorch_job_sendrecv.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: kubeflow/pytorch-dist-sendrecv-test:latest
+              image: ghcr.io/kubeflow/training/pytorch-dist-sendrecv-test:latest
     Worker:
       replicas: 3
       restartPolicy: OnFailure
@@ -19,4 +19,4 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: kubeflow/pytorch-dist-sendrecv-test:latest
+              image: ghcr.io/kubeflow/training/pytorch-dist-sendrecv-test:latest

--- a/examples/tensorflow/dist-mnist/tf_job_mnist.yaml
+++ b/examples/tensorflow/dist-mnist/tf_job_mnist.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: tensorflow
-              image: ghcr.io/kubeflow/training/tf-dist-mnist-test:latest
+              image: ghcr.io/kubeflow/training-v1/tf-dist-mnist-test:latest
 
     PS:
       replicas: 1
@@ -20,7 +20,7 @@ spec:
         spec:
           containers:
             - name: tensorflow
-              image: ghcr.io/kubeflow/training/tf-dist-mnist-test:latest
+              image: ghcr.io/kubeflow/training-v1/tf-dist-mnist-test:latest
 
     Worker:
       replicas: 2
@@ -29,4 +29,4 @@ spec:
         spec:
           containers:
             - name: tensorflow
-              image: ghcr.io/kubeflow/training/tf-dist-mnist-test:latest
+              image: ghcr.io/kubeflow/training-v1/tf-dist-mnist-test:latest

--- a/examples/tensorflow/dist-mnist/tf_job_mnist.yaml
+++ b/examples/tensorflow/dist-mnist/tf_job_mnist.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: tensorflow
-              image: kubeflow/tf-dist-mnist-test:latest
+              image: ghcr.io/kubeflow/training/tf-dist-mnist-test:latest
 
     PS:
       replicas: 1
@@ -20,7 +20,7 @@ spec:
         spec:
           containers:
             - name: tensorflow
-              image: kubeflow/tf-dist-mnist-test:latest
+              image: ghcr.io/kubeflow/training/tf-dist-mnist-test:latest
 
     Worker:
       replicas: 2
@@ -29,4 +29,4 @@ spec:
         spec:
           containers:
             - name: tensorflow
-              image: kubeflow/tf-dist-mnist-test:latest
+              image: ghcr.io/kubeflow/training/tf-dist-mnist-test:latest

--- a/examples/tensorflow/distribution_strategy/multi_worker_tfjob.yaml
+++ b/examples/tensorflow/distribution_strategy/multi_worker_tfjob.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
             - name: tensorflow
-              image: kubeflow/tf-multi-worker-strategy:latest
+              image: ghcr.io/kubeflow/training/tf-multi-worker-strategy:latest
               volumeMounts:
                 - mountPath: /train
                   name: training

--- a/examples/tensorflow/distribution_strategy/multi_worker_tfjob.yaml
+++ b/examples/tensorflow/distribution_strategy/multi_worker_tfjob.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
             - name: tensorflow
-              image: ghcr.io/kubeflow/training/tf-multi-worker-strategy:latest
+              image: ghcr.io/kubeflow/training-v1/tf-multi-worker-strategy:latest
               volumeMounts:
                 - mountPath: /train
                   name: training

--- a/examples/tensorflow/mnist_with_summaries/tf_job_mnist.yaml
+++ b/examples/tensorflow/mnist_with_summaries/tf_job_mnist.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
             - name: tensorflow
-              image: ghcr.io/kubeflow/training/tf-mnist-with-summaries:latest
+              image: ghcr.io/kubeflow/training-v1/tf-mnist-with-summaries:latest
               command:
                 - "python"
                 - "/var/tf_mnist/mnist_with_summaries.py"

--- a/examples/tensorflow/mnist_with_summaries/tf_job_mnist.yaml
+++ b/examples/tensorflow/mnist_with_summaries/tf_job_mnist.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
             - name: tensorflow
-              image: kubeflow/tf-mnist-with-summaries:latest
+              image: ghcr.io/kubeflow/training/tf-mnist-with-summaries:latest
               command:
                 - "python"
                 - "/var/tf_mnist/mnist_with_summaries.py"

--- a/examples/tensorflow/simple.yaml
+++ b/examples/tensorflow/simple.yaml
@@ -12,7 +12,7 @@ spec:
         spec:
           containers:
             - name: tensorflow
-              image: ghcr.io/kubeflow/training/tf-mnist-with-summaries:latest
+              image: ghcr.io/kubeflow/training-v1/tf-mnist-with-summaries:latest
               command:
                 - "python"
                 - "/var/tf_mnist/mnist_with_summaries.py"

--- a/examples/tensorflow/simple.yaml
+++ b/examples/tensorflow/simple.yaml
@@ -12,7 +12,7 @@ spec:
         spec:
           containers:
             - name: tensorflow
-              image: kubeflow/tf-mnist-with-summaries:latest
+              image: ghcr.io/kubeflow/training/tf-mnist-with-summaries:latest
               command:
                 - "python"
                 - "/var/tf_mnist/mnist_with_summaries.py"

--- a/examples/xgboost/lightgbm-dist/xgboostjob_v1_lightgbm_dist_training.yaml
+++ b/examples/xgboost/lightgbm-dist/xgboostjob_v1_lightgbm_dist_training.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: ghcr.io/kubeflow/training/lightgbm-dist-py-test:latest
+            image: ghcr.io/kubeflow/training-v1/lightgbm-dist-py-test:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port
@@ -45,7 +45,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: ghcr.io/kubeflow/training/lightgbm-dist-py-test:latest
+            image: ghcr.io/kubeflow/training-v1/lightgbm-dist-py-test:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port

--- a/examples/xgboost/lightgbm-dist/xgboostjob_v1_lightgbm_dist_training.yaml
+++ b/examples/xgboost/lightgbm-dist/xgboostjob_v1_lightgbm_dist_training.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: kubeflow/lightgbm-dist-py-test:1.0
+            image: ghcr.io/kubeflow/training/lightgbm-dist-py-test:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port
@@ -45,7 +45,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: kubeflow/lightgbm-dist-py-test:1.0
+            image: ghcr.io/kubeflow/training/lightgbm-dist-py-test:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port

--- a/examples/xgboost/smoke-dist/xgboostjob_v1_rabit_test.yaml
+++ b/examples/xgboost/smoke-dist/xgboostjob_v1_rabit_test.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: ghcr.io/kubeflow/training/xgboost-dist-rabit-test:latest
+            image: ghcr.io/kubeflow/training-v1/xgboost-dist-rabit-test:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port
@@ -23,7 +23,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: ghcr.io/kubeflow/training/xgboost-dist-rabit-test:latest
+            image: ghcr.io/kubeflow/training-v1/xgboost-dist-rabit-test:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port

--- a/examples/xgboost/smoke-dist/xgboostjob_v1_rabit_test.yaml
+++ b/examples/xgboost/smoke-dist/xgboostjob_v1_rabit_test.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: docker.io/kubeflow/xgboost-dist-rabit-test:latest
+            image: ghcr.io/kubeflow/training/xgboost-dist-rabit-test:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port
@@ -23,7 +23,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: docker.io/kubeflow/xgboost-dist-rabit-test:latest
+            image: ghcr.io/kubeflow/training/xgboost-dist-rabit-test:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port

--- a/examples/xgboost/smoke-dist/xgboostjob_v1alpha1_rabit_test.yaml
+++ b/examples/xgboost/smoke-dist/xgboostjob_v1alpha1_rabit_test.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: docker.io/kubeflow/xgboost-dist-rabit-test:latest
+            image: ghcr.io/kubeflow/training/xgboost-dist-rabit-test:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port
@@ -27,7 +27,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: docker.io/kubeflow/xgboost-dist-rabit-test:latest
+            image: ghcr.io/kubeflow/training/xgboost-dist-rabit-test:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port

--- a/examples/xgboost/smoke-dist/xgboostjob_v1alpha1_rabit_test.yaml
+++ b/examples/xgboost/smoke-dist/xgboostjob_v1alpha1_rabit_test.yaml
@@ -13,7 +13,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: ghcr.io/kubeflow/training/xgboost-dist-rabit-test:latest
+            image: ghcr.io/kubeflow/training-v1/xgboost-dist-rabit-test:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port
@@ -27,7 +27,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: ghcr.io/kubeflow/training/xgboost-dist-rabit-test:latest
+            image: ghcr.io/kubeflow/training-v1/xgboost-dist-rabit-test:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port

--- a/examples/xgboost/xgboost-dist/xgboostjob_v1_iris_predict.yaml
+++ b/examples/xgboost/xgboost-dist/xgboostjob_v1_iris_predict.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: docker.io/kubeflow/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: docker.io/kubeflow/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port

--- a/examples/xgboost/xgboost-dist/xgboostjob_v1_iris_predict.yaml
+++ b/examples/xgboost/xgboost-dist/xgboostjob_v1_iris_predict.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training-v1/xgboost-dist-iris:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training-v1/xgboost-dist-iris:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port

--- a/examples/xgboost/xgboost-dist/xgboostjob_v1_iris_predict_local.yaml
+++ b/examples/xgboost/xgboost-dist/xgboostjob_v1_iris_predict_local.yaml
@@ -15,7 +15,7 @@ spec:
               claimName: xgboostlocal
           containers:
           - name: xgboost
-            image: docker.io/kubeflow/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
             volumeMounts:
               - name: task-pv-storage
                 mountPath: /tmp/xgboost_model
@@ -38,7 +38,7 @@ spec:
               claimName: xgboostlocal
           containers:
           - name: xgboost
-            image: docker.io/kubeflow/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
             volumeMounts:
               - name: task-pv-storage
                 mountPath: /tmp/xgboost_model

--- a/examples/xgboost/xgboost-dist/xgboostjob_v1_iris_predict_local.yaml
+++ b/examples/xgboost/xgboost-dist/xgboostjob_v1_iris_predict_local.yaml
@@ -15,7 +15,7 @@ spec:
               claimName: xgboostlocal
           containers:
           - name: xgboost
-            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training-v1/xgboost-dist-iris:latest
             volumeMounts:
               - name: task-pv-storage
                 mountPath: /tmp/xgboost_model
@@ -38,7 +38,7 @@ spec:
               claimName: xgboostlocal
           containers:
           - name: xgboost
-            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training-v1/xgboost-dist-iris:latest
             volumeMounts:
               - name: task-pv-storage
                 mountPath: /tmp/xgboost_model

--- a/examples/xgboost/xgboost-dist/xgboostjob_v1_iris_train.yaml
+++ b/examples/xgboost/xgboost-dist/xgboostjob_v1_iris_train.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training-v1/xgboost-dist-iris:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port
@@ -30,7 +30,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training-v1/xgboost-dist-iris:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port

--- a/examples/xgboost/xgboost-dist/xgboostjob_v1_iris_train.yaml
+++ b/examples/xgboost/xgboost-dist/xgboostjob_v1_iris_train.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: docker.io/kubeflow/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port
@@ -30,7 +30,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: docker.io/kubeflow/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port

--- a/examples/xgboost/xgboost-dist/xgboostjob_v1_iris_train_local.yaml
+++ b/examples/xgboost/xgboost-dist/xgboostjob_v1_iris_train_local.yaml
@@ -15,7 +15,7 @@ spec:
               claimName: xgboostlocal
           containers:
           - name: xgboost
-            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training-v1/xgboost-dist-iris:latest
             volumeMounts:
               - name: task-pv-storage
                 mountPath: /tmp/xgboost_model
@@ -41,7 +41,7 @@ spec:
               claimName: xgboostlocal
           containers:
           - name: xgboost
-            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training-v1/xgboost-dist-iris:latest
             volumeMounts:
               - name: task-pv-storage
                 mountPath: /tmp/xgboost_model

--- a/examples/xgboost/xgboost-dist/xgboostjob_v1_iris_train_local.yaml
+++ b/examples/xgboost/xgboost-dist/xgboostjob_v1_iris_train_local.yaml
@@ -15,7 +15,7 @@ spec:
               claimName: xgboostlocal
           containers:
           - name: xgboost
-            image: docker.io/kubeflow/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
             volumeMounts:
               - name: task-pv-storage
                 mountPath: /tmp/xgboost_model
@@ -41,7 +41,7 @@ spec:
               claimName: xgboostlocal
           containers:
           - name: xgboost
-            image: docker.io/kubeflow/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
             volumeMounts:
               - name: task-pv-storage
                 mountPath: /tmp/xgboost_model

--- a/examples/xgboost/xgboostjob.yaml
+++ b/examples/xgboost/xgboostjob.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training-v1/xgboost-dist-iris:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port
@@ -30,7 +30,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training-v1/xgboost-dist-iris:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port

--- a/examples/xgboost/xgboostjob.yaml
+++ b/examples/xgboost/xgboostjob.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: docker.io/kubeflow/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port
@@ -30,7 +30,7 @@ spec:
         spec:
           containers:
           - name: xgboost
-            image: docker.io/kubeflow/xgboost-dist-iris:latest
+            image: ghcr.io/kubeflow/training/xgboost-dist-iris:latest
             ports:
             - containerPort: 9991
               name: xgboostjob-port

--- a/manifests/overlays/kubeflow/kustomization.yaml
+++ b/manifests/overlays/kubeflow/kustomization.yaml
@@ -5,8 +5,8 @@ resources:
   - ../../base
   - kubeflow-training-roles.yaml
 images:
-  - name: kubeflow/training-operator
-    newTag: v1-5170a36
+  - name: ghcr.io/kubeflow/training/training-operator
+    newTag: v1-f654b1e
 # TODO (tenzen-y): Once we support cert-manager, we need to remove this secret generation.
 # REF: https://github.com/kubeflow/training-operator/issues/2049
 secretGenerator:

--- a/manifests/overlays/kubeflow/kustomization.yaml
+++ b/manifests/overlays/kubeflow/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
   - ../../base
   - kubeflow-training-roles.yaml
 images:
-  - name: ghcr.io/kubeflow/training/training-operator
+  - name: ghcr.io/kubeflow/training-v1/training-operator
     newTag: v1-f654b1e
 # TODO (tenzen-y): Once we support cert-manager, we need to remove this secret generation.
 # REF: https://github.com/kubeflow/training-operator/issues/2049

--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
   - ../../base
   - namespace.yaml
 images:
-  - name: ghcr.io/kubeflow/training/training-operator
+  - name: ghcr.io/kubeflow/training-v1/training-operator
     newTag: v1-f654b1e
 secretGenerator:
   - name: training-operator-webhook-cert

--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -5,8 +5,8 @@ resources:
   - ../../base
   - namespace.yaml
 images:
-  - name: kubeflow/training-operator
-    newTag: v1-5170a36
+  - name: ghcr.io/kubeflow/training/training-operator
+    newTag: v1-f654b1e
 secretGenerator:
   - name: training-operator-webhook-cert
     options:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,5 +32,5 @@ const (
 	// PyTorchInitContainerMaxTriesDefault is the default number of tries for the pytorch init container.
 	PyTorchInitContainerMaxTriesDefault = 100
 	// MPIKubectlDeliveryImageDefault is the default image for launcher pod in MPIJob init container.
-	MPIKubectlDeliveryImageDefault = "ghcr.io/kubeflow/training/kubectl-delivery:latest"
+	MPIKubectlDeliveryImageDefault = "ghcr.io/kubeflow/training-v1/kubectl-delivery:latest"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,5 +32,5 @@ const (
 	// PyTorchInitContainerMaxTriesDefault is the default number of tries for the pytorch init container.
 	PyTorchInitContainerMaxTriesDefault = 100
 	// MPIKubectlDeliveryImageDefault is the default image for launcher pod in MPIJob init container.
-	MPIKubectlDeliveryImageDefault = "kubeflow/kubectl-delivery:latest"
+	MPIKubectlDeliveryImageDefault = "ghcr.io/kubeflow/training/kubectl-delivery:latest"
 )

--- a/scripts/setup-training-operator.sh
+++ b/scripts/setup-training-operator.sh
@@ -34,7 +34,7 @@ aws eks update-kubeconfig --region=${REGION} --name=${CLUSTER_NAME}
 echo "Update training operator manifest with new name $REGISTRY and tag $VERSION"
 cd manifests/overlays/standalone
 #kustomize edit set image public.ecr.aws/j1r0q0g6/training/training-operator=${REGISTRY}:${VERSION}
-kustomize edit set image kubeflow/training-operator=${REGISTRY}:${VERSION}
+kustomize edit set image ghcr.io/kubeflow/training-v1/training-operator=${REGISTRY}:${VERSION}
 
 echo "Installing training operator manifests"
 kustomize build . | kubectl apply --server-side -f -

--- a/sdk/python/kubeflow/training/constants/constants.py
+++ b/sdk/python/kubeflow/training/constants/constants.py
@@ -84,7 +84,7 @@ PVC_DEFAULT_ACCESS_MODES = ["ReadWriteOnce", "ReadOnlyMany"]
 
 # TODO (andreyvelich): We should add image tag for Storage Initializer and Trainer.
 STORAGE_INITIALIZER_IMAGE = os.getenv(
-    "STORAGE_INITIALIZER_IMAGE", "docker.io/kubeflow/storage-initializer"
+    "STORAGE_INITIALIZER_IMAGE", "ghcr.io/kubeflow/training/storage-initializer"
 )
 
 STORAGE_INITIALIZER_VOLUME_MOUNT = models.V1VolumeMount(
@@ -93,7 +93,7 @@ STORAGE_INITIALIZER_VOLUME_MOUNT = models.V1VolumeMount(
 )
 
 TRAINER_TRANSFORMER_IMAGE = os.getenv(
-    "TRAINER_TRANSFORMER_IMAGE", "docker.io/kubeflow/trainer-huggingface"
+    "TRAINER_TRANSFORMER_IMAGE", "ghcr.io/kubeflow/training/trainer-huggingface"
 )
 
 # TFJob constants.
@@ -153,7 +153,7 @@ JAXJOB_MODEL = "KubeflowOrgV1JAXJob"
 JAXJOB_PLURAL = "jaxjobs"
 JAXJOB_CONTAINER = "jax"
 JAXJOB_REPLICA_TYPES = REPLICA_TYPE_WORKER.lower()
-JAXJOB_BASE_IMAGE = "docker.io/kubeflow/jaxjob-dist-spmd-mnist:latest"
+JAXJOB_BASE_IMAGE = "ghcr.io/kubeflow/training/jaxjob-dist-spmd-mnist:latest"
 
 # Dictionary to get plural, model, and container for each Job kind.
 JOB_PARAMETERS = {

--- a/sdk/python/kubeflow/training/constants/constants.py
+++ b/sdk/python/kubeflow/training/constants/constants.py
@@ -84,7 +84,7 @@ PVC_DEFAULT_ACCESS_MODES = ["ReadWriteOnce", "ReadOnlyMany"]
 
 # TODO (andreyvelich): We should add image tag for Storage Initializer and Trainer.
 STORAGE_INITIALIZER_IMAGE = os.getenv(
-    "STORAGE_INITIALIZER_IMAGE", "ghcr.io/kubeflow/training/storage-initializer"
+    "STORAGE_INITIALIZER_IMAGE", "ghcr.io/kubeflow/training-v1/storage-initializer"
 )
 
 STORAGE_INITIALIZER_VOLUME_MOUNT = models.V1VolumeMount(
@@ -93,7 +93,7 @@ STORAGE_INITIALIZER_VOLUME_MOUNT = models.V1VolumeMount(
 )
 
 TRAINER_TRANSFORMER_IMAGE = os.getenv(
-    "TRAINER_TRANSFORMER_IMAGE", "ghcr.io/kubeflow/training/trainer-huggingface"
+    "TRAINER_TRANSFORMER_IMAGE", "ghcr.io/kubeflow/training-v1/trainer-huggingface"
 )
 
 # TFJob constants.
@@ -153,7 +153,7 @@ JAXJOB_MODEL = "KubeflowOrgV1JAXJob"
 JAXJOB_PLURAL = "jaxjobs"
 JAXJOB_CONTAINER = "jax"
 JAXJOB_REPLICA_TYPES = REPLICA_TYPE_WORKER.lower()
-JAXJOB_BASE_IMAGE = "ghcr.io/kubeflow/training/jaxjob-dist-spmd-mnist:latest"
+JAXJOB_BASE_IMAGE = "ghcr.io/kubeflow/training-v1/jaxjob-dist-spmd-mnist:latest"
 
 # Dictionary to get plural, model, and container for each Job kind.
 JOB_PARAMETERS = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Update Manifest images to GHCR instead of Dockerhub. Required to decrease rate limiting issues

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Address this comment to update manifest images: https://github.com/kubeflow/trainer/pull/2491#discussion_r1989054861

cc: @andreyvelich @Electronic-Waste @mahdikhashan @tenzen-y 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
