### PR TITLE
Construct Trainer based on trainer.kubeflow.org/trainjob-ancestor-step label

### DIFF
--- a/hack/e2e-setup-cluster.sh
+++ b/hack/e2e-setup-cluster.sh
@@ -30,7 +30,7 @@ TIMEOUT="5m"
 
 # Kubeflow Trainer images.
 # TODO (andreyvelich): Support initializers images.
-CONTROLLER_MANAGER_CI_IMAGE_NAME="kubeflow/trainer-controller-manager"
+CONTROLLER_MANAGER_CI_IMAGE_NAME="ghcr.io/kubeflow/trainer/trainer-controller-manager"
 CONTROLLER_MANAGER_CI_IMAGE_TAG="test"
 CONTROLLER_MANAGER_CI_IMAGE="${CONTROLLER_MANAGER_CI_IMAGE_NAME}:${CONTROLLER_MANAGER_CI_IMAGE_TAG}"
 echo "Build Kubeflow Trainer images"

--- a/manifests/base/runtimes/pretraining/mpi_distributed.yaml
+++ b/manifests/base/runtimes/pretraining/mpi_distributed.yaml
@@ -12,10 +12,11 @@ spec:
       numProcPerNode: 1
       mpiImplementation: OpenMPI
       sshAuthMountPath: /home/mpiuser/.ssh
+      runLauncherAsNode: true
   template:
     spec:
       network:
-        publishNotReadyAddresses: false
+        publishNotReadyAddresses: true
       successPolicy:
         operator: All
         targetReplicatedJobs:
@@ -23,25 +24,28 @@ spec:
       replicatedJobs:
         - name: launcher
           template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: trainer
             spec:
               template:
                 spec:
                   containers:
-                    - name: launcher
-                      image: mpioperator/mpi-pi:openmpi
-                      securityContext:
-                        runAsUser: 1000
-                      command:
-                        - mpirun
-                      args:
-                        - /home/mpiuser/pi
-        - name: trainer-node
+                  - name: node
+                    image: mpioperator/mpi-pi:openmpi
+                    securityContext:
+                      runAsUser: 1000
+                    command:
+                      - mpirun
+                    args:
+                      - /home/mpiuser/pi
+        - name: node
           template:
             spec:
               template:
                 spec:
                   containers:
-                    - name: trainer-node
+                    - name: node
                       image: mpioperator/mpi-pi:openmpi
                       securityContext:
                         runAsUser: 1000

--- a/manifests/base/runtimes/pretraining/torch_distributed.yaml
+++ b/manifests/base/runtimes/pretraining/torch_distributed.yaml
@@ -12,13 +12,16 @@ spec:
   template:
     spec:
       replicatedJobs:
-        - name: trainer-node
+        - name: node
           template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: trainer
             spec:
               template:
                 spec:
                   containers:
-                    - name: trainer
+                    - name: node
                       image: pytorch/pytorch:2.5.0-cuda12.4-cudnn9-runtime
                       command:
                         - /bin/bash

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -34,11 +34,12 @@ const (
 	// ModelMountPath is the volumeMount path for model.
 	ModelMountPath string = "/workspace/model"
 
-	// JobTrainerNode is the Job name for the trainer node.
-	JobTrainerNode string = "trainer-node"
+	// AncestorTrainer is the ancestor name for Trainer, which is mostly used for the value of
+	// 'trainer.kubeflow.org/trainjob-ancestor-step'.
+	AncestorTrainer string = "trainer"
 
-	// ContainerTrainer is the container name for the trainer.
-	ContainerTrainer string = "trainer"
+	// Node is the name of the Job and container for the trainer node
+	Node string = "node"
 
 	// ContainerTrainerPort is the default port for the trainer nodes communication.
 	ContainerTrainerPort int32 = 29500

--- a/pkg/runtime/core/clustertrainingruntime_test.go
+++ b/pkg/runtime/core/clustertrainingruntime_test.go
@@ -51,7 +51,7 @@ func TestClusterTrainingRuntimeNewObjects(t *testing.T) {
 				testingutil.MakeTrainingRuntimeSpecWrapper(testingutil.MakeClusterTrainingRuntimeWrapper("test-runtime").Spec).
 					JobSetSpec(
 						testingutil.MakeJobSetWrapper("", "").
-							DependsOn(constants.JobTrainerNode,
+							DependsOn(constants.Node,
 								[]jobsetv1alpha2.DependsOn{
 									{
 										Name:   constants.DatasetInitializer,
@@ -73,7 +73,7 @@ func TestClusterTrainingRuntimeNewObjects(t *testing.T) {
 							WithNumNodes(100).
 							Obj(),
 					).
-					Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 					PodGroupPolicyCoschedulingSchedulingTimeout(120).
 					Obj(),
 			).Obj(),
@@ -92,14 +92,14 @@ func TestClusterTrainingRuntimeNewObjects(t *testing.T) {
 					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
 					Suspend(true).
 					PodLabel(schedulerpluginsv1alpha1.PodGroupLabel, "test-job").
-					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.JobTrainerNode, constants.JobLauncher).
+					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Node, constants.JobLauncher).
 					Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 					Completions(1, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 					NumNodes(100).
 					Container(constants.DatasetInitializer, constants.DatasetInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 					Container(constants.ModelInitializer, constants.ModelInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
-					Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
-					DependsOn(constants.JobTrainerNode,
+					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
+					DependsOn(constants.Node,
 						[]jobsetv1alpha2.DependsOn{
 							{
 								Name:   constants.DatasetInitializer,

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -67,7 +67,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 						PodGroupPolicyCoschedulingSchedulingTimeout(120).
 						Container(constants.DatasetInitializer, constants.DatasetInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 						Container(constants.ModelInitializer, constants.ModelInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
-						Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+						Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 						Obj(),
 				).Obj(),
 			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
@@ -89,13 +89,13 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					Label("conflictLabel", "override").
 					Annotation("conflictAnnotation", "override").
 					PodLabel(schedulerpluginsv1alpha1.PodGroupLabel, "test-job").
-					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.JobTrainerNode, constants.JobLauncher).
+					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Node, constants.JobLauncher).
 					Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 					Completions(1, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 					NumNodes(30).
 					Container(constants.DatasetInitializer, constants.DatasetInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 					Container(constants.ModelInitializer, constants.ModelInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
-					Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 					Obj(),
 				testingutil.MakeSchedulerPluginsPodGroup(metav1.NamespaceDefault, "test-job").
 					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
@@ -116,8 +116,8 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							WithNumNodes(100).
 							Obj(),
 					).
-					Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
-					Env(constants.JobTrainerNode, constants.ContainerTrainer,
+					Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					Env(constants.Node, constants.Node,
 						[]corev1.EnvVar{
 							{
 								Name:  "TRAIN_JOB",
@@ -155,12 +155,12 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 			wantObjs: []runtime.Object{
 				testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
 					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
-					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.JobTrainerNode).
+					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Node).
 					Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer).
 					Completions(1, constants.DatasetInitializer, constants.ModelInitializer).
 					NumNodes(100).
-					Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
-					Env(constants.JobTrainerNode, constants.ContainerTrainer,
+					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
+					Env(constants.Node, constants.Node,
 						[]corev1.EnvVar{
 							{
 								Name:  "TRAIN_JOB",
@@ -189,7 +189,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					).
 					Container(constants.DatasetInitializer, constants.DatasetInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 					Container(constants.ModelInitializer, constants.DatasetInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
-					Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 					Obj(),
 			).Obj(),
 			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
@@ -235,13 +235,13 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 			wantObjs: []runtime.Object{
 				testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
 					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
-					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.JobTrainerNode).
+					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Node).
 					Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer).
 					Completions(1, constants.DatasetInitializer, constants.ModelInitializer).
 					NumNodes(100).
 					Container(constants.DatasetInitializer, constants.DatasetInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 					Container(constants.ModelInitializer, constants.DatasetInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
-					Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 					Env(constants.DatasetInitializer, constants.DatasetInitializer,
 						[]corev1.EnvVar{
 							{
@@ -306,7 +306,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					).
 					JobSetSpec(
 						testingutil.MakeJobSetWrapper("", "").
-							DependsOn(constants.JobTrainerNode,
+							DependsOn(constants.Node,
 								[]jobsetv1alpha2.DependsOn{
 									{
 										Name:   constants.DatasetInitializer,
@@ -321,7 +321,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							Obj().
 							Spec,
 					).
-					Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 					Obj(),
 			).Obj(),
 			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
@@ -337,13 +337,13 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 			wantObjs: []runtime.Object{
 				testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
 					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
-					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.JobTrainerNode, constants.JobLauncher).
+					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Node, constants.JobLauncher).
 					Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer).
 					Completions(1, constants.DatasetInitializer, constants.ModelInitializer).
 					NumNodes(30).
-					Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 					ContainerTrainerPorts([]corev1.ContainerPort{{ContainerPort: constants.ContainerTrainerPort}}).
-					Env(constants.JobTrainerNode, constants.ContainerTrainer,
+					Env(constants.Node, constants.Node,
 						[]corev1.EnvVar{
 							{
 								Name:  constants.TorchEnvNumNodes,
@@ -363,7 +363,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							},
 							{
 								Name:  constants.TorchEnvMasterAddr,
-								Value: fmt.Sprintf("test-job-%s-0-0.test-job", constants.JobTrainerNode),
+								Value: fmt.Sprintf("test-job-%s-0-0.test-job", constants.Node),
 							},
 							{
 								Name:  constants.TorchEnvMasterPort,
@@ -371,7 +371,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							},
 						}...,
 					).
-					DependsOn(constants.JobTrainerNode,
+					DependsOn(constants.Node,
 						[]jobsetv1alpha2.DependsOn{
 							{
 								Name:   constants.DatasetInitializer,
@@ -398,8 +398,8 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							).
 							Obj(),
 					).
-					Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
-					Env(constants.JobTrainerNode, constants.ContainerTrainer,
+					Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					Env(constants.Node, constants.Node,
 						[]corev1.EnvVar{
 							{
 								Name:  "TRAIN_JOB",
@@ -437,13 +437,13 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 			wantObjs: []runtime.Object{
 				testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
 					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
-					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.JobTrainerNode, constants.JobLauncher).
+					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Node, constants.JobLauncher).
 					Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer).
 					Completions(1, constants.DatasetInitializer, constants.ModelInitializer).
 					NumNodes(100).
-					Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
+					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
 					ContainerTrainerPorts([]corev1.ContainerPort{{ContainerPort: constants.ContainerTrainerPort}}).
-					Env(constants.JobTrainerNode, constants.ContainerTrainer,
+					Env(constants.Node, constants.Node,
 						[]corev1.EnvVar{
 							{
 								Name:  "TRAIN_JOB",
@@ -471,7 +471,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							},
 							{
 								Name:  constants.TorchEnvMasterAddr,
-								Value: fmt.Sprintf("test-job-%s-0-0.test-job", constants.JobTrainerNode),
+								Value: fmt.Sprintf("test-job-%s-0-0.test-job", constants.Node),
 							},
 							{
 								Name:  constants.TorchEnvMasterPort,
@@ -490,21 +490,22 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 			ObjCmpOpts: cmp.Options{
 				cmp.Comparer(testingutil.MPISecretDataComparer),
 			},
-			trainingRuntime: testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "test-runtime").RuntimeSpec(
-				testingutil.MakeTrainingRuntimeSpecWrapper(testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "test-runtime").Spec).
-					WithMLPolicy(
-						testingutil.MakeMLPolicyWrapper().
-							WithNumNodes(1).
-							WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
-								MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(false)).
+			trainingRuntime: testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "test-runtime").
+				RuntimeSpec(
+					testingutil.MakeTrainingRuntimeSpecWrapper(testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "test-runtime").Spec).
+						WithMLPolicy(
+							testingutil.MakeMLPolicyWrapper().
+								WithNumNodes(1).
+								WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+									MPIPolicy(ptr.To[int32](1), ptr.To(trainer.MPIImplementationOpenMPI), ptr.To("/root/.ssh"), ptr.To(false)).
+									Obj(),
+								).
 								Obj(),
-							).
-							Obj(),
-					).
-					LauncherReplica().
-					Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
-					Obj(),
-			).
+						).
+						LauncherReplica().
+						Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+						Obj(),
+				).
 				Obj(),
 			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
 				UID("uid").
@@ -520,8 +521,8 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 				testingutil.MakeConfigMapWrapper(fmt.Sprintf("test-job%s", constants.MPIHostfileConfigMapSuffix), metav1.NamespaceDefault).
 					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
 					WithData(map[string]string{
-						constants.MPIHostfileName: `test-job-trainer-node-0-0.test-job slots=8
-test-job-trainer-node-0-1.test-job slots=8
+						constants.MPIHostfileName: `test-job-node-0-0.test-job slots=8
+test-job-node-0-1.test-job slots=8
 `,
 					}).
 					Obj(),
@@ -537,7 +538,7 @@ test-job-trainer-node-0-1.test-job slots=8
 				testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
 					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
 					LauncherReplica().
-					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.JobTrainerNode, constants.JobLauncher).
+					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Node, constants.JobLauncher).
 					Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 					Completions(1, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 					NumNodes(2).
@@ -580,7 +581,7 @@ test-job-trainer-node-0-1.test-job slots=8
 							},
 						},
 					).
-					Volumes(constants.JobTrainerNode,
+					Volumes(constants.Node,
 						corev1.Volume{
 							Name: constants.MPISSHAuthVolumeName,
 							VolumeSource: corev1.VolumeSource{
@@ -608,6 +609,9 @@ test-job-trainer-node-0-1.test-job slots=8
 						corev1.VolumeMount{Name: constants.MPISSHAuthVolumeName, MountPath: "/root/.ssh"},
 						corev1.VolumeMount{Name: constants.MPIHostfileVolumeName, MountPath: constants.MPIHostfileDir},
 					).
+					VolumeMounts(constants.Node, constants.Node,
+						corev1.VolumeMount{Name: constants.MPISSHAuthVolumeName, MountPath: "/root/.ssh"},
+					).
 					Env(constants.JobLauncher, constants.ContainerLauncher,
 						corev1.EnvVar{
 							Name:  constants.OpenMPIEnvHostFileLocation,
@@ -626,7 +630,7 @@ test-job-trainer-node-0-1.test-job slots=8
 							Value: constants.OpenMPIEnvDefaultValueRSHArgs,
 						},
 					).
-					Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 					Obj(),
 			},
 		},

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -174,18 +174,18 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 			registry: fwkplugins.NewRegistry(),
 			runtimeInfo: runtime.NewInfo(
 				runtime.WithMLPolicySource(testingutil.MakeMLPolicyWrapper().Obj()),
-				runtime.WithPodSet(constants.DatasetInitializer, 1, corev1.PodSpec{}, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.DatasetInitializer, ptr.To(constants.DatasetInitializer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(
 						corev1ac.Container().WithName(constants.DatasetInitializer),
 					),
 				),
-				runtime.WithPodSet(constants.ModelInitializer, 1, corev1.PodSpec{}, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.ModelInitializer, ptr.To(constants.ModelInitializer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(
 						corev1ac.Container().WithName(constants.ModelInitializer),
 					),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 10, corev1.PodSpec{}, corev1ac.PodSpec().
-					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 10, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
 			),
 			trainJob: &trainer.TrainJob{
@@ -198,8 +198,9 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{
 						{
-							Name:  constants.DatasetInitializer,
-							Count: ptr.To[int32](1),
+							Name:     constants.DatasetInitializer,
+							Ancestor: ptr.To(constants.DatasetInitializer),
+							Count:    ptr.To[int32](1),
 							Containers: []runtime.Container{
 								{
 									Name: constants.DatasetInitializer,
@@ -207,8 +208,9 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 							},
 						},
 						{
-							Name:  constants.ModelInitializer,
-							Count: ptr.To[int32](1),
+							Name:     constants.ModelInitializer,
+							Ancestor: ptr.To(constants.ModelInitializer),
+							Count:    ptr.To[int32](1),
 							Containers: []runtime.Container{
 								{
 									Name: constants.ModelInitializer,
@@ -216,10 +218,11 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 							},
 						},
 						{
-							Name:  constants.JobTrainerNode,
-							Count: ptr.To[int32](10),
+							Name:     constants.Node,
+							Ancestor: ptr.To(constants.AncestorTrainer),
+							Count:    ptr.To[int32](10),
 							Containers: []runtime.Container{{
-								Name: constants.ContainerTrainer,
+								Name: constants.Node,
 							}},
 						},
 					},
@@ -233,18 +236,18 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 				runtime.WithMLPolicySource(
 					testingutil.MakeMLPolicyWrapper().Obj(),
 				),
-				runtime.WithPodSet(constants.DatasetInitializer, 1, corev1.PodSpec{}, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.DatasetInitializer, ptr.To(constants.DatasetInitializer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(
 						corev1ac.Container().WithName(constants.DatasetInitializer),
 					),
 				),
-				runtime.WithPodSet(constants.ModelInitializer, 1, corev1.PodSpec{}, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.ModelInitializer, ptr.To(constants.ModelInitializer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(
 						corev1ac.Container().WithName(constants.ModelInitializer),
 					),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 10, corev1.PodSpec{}, corev1ac.PodSpec().
-					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 10, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
 			),
 			trainJob: &trainer.TrainJob{
@@ -261,8 +264,9 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{
 						{
-							Name:  constants.DatasetInitializer,
-							Count: ptr.To[int32](1),
+							Name:     constants.DatasetInitializer,
+							Ancestor: ptr.To(constants.DatasetInitializer),
+							Count:    ptr.To[int32](1),
 							Containers: []runtime.Container{
 								{
 									Name: constants.DatasetInitializer,
@@ -270,8 +274,9 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 							},
 						},
 						{
-							Name:  constants.ModelInitializer,
-							Count: ptr.To[int32](1),
+							Name:     constants.ModelInitializer,
+							Ancestor: ptr.To(constants.ModelInitializer),
+							Count:    ptr.To[int32](1),
 							Containers: []runtime.Container{
 								{
 									Name: constants.ModelInitializer,
@@ -279,10 +284,11 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 							},
 						},
 						{
-							Name:  constants.JobTrainerNode,
-							Count: ptr.To[int32](30),
+							Name:     constants.Node,
+							Ancestor: ptr.To(constants.AncestorTrainer),
+							Count:    ptr.To[int32](30),
 							Containers: []runtime.Container{{
-								Name: constants.ContainerTrainer,
+								Name: constants.Node,
 							}},
 						},
 					},
@@ -440,8 +446,9 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 		wantError       error
 	}{
 		"succeeded to build PodGroup and JobSet with NumNodes from TrainJob": {
-			registry:        fwkplugins.NewRegistry(),
-			trainingRuntime: testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "test-runtime").DeepCopy(),
+			registry: fwkplugins.NewRegistry(),
+			trainingRuntime: testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "test-runtime").
+				Obj(),
 			runtimeInfo: &runtime.Info{
 				RuntimePolicy: runtime.RuntimePolicy{
 					PodGroupPolicy: &trainer.PodGroupPolicy{
@@ -455,8 +462,9 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{
 						{
-							Name:  constants.DatasetInitializer,
-							Count: ptr.To[int32](1),
+							Name:     constants.DatasetInitializer,
+							Ancestor: ptr.To(constants.DatasetInitializer),
+							Count:    ptr.To[int32](1),
 							SinglePodRequests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("1"),
 								corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -479,8 +487,9 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 							},
 						},
 						{
-							Name:  constants.ModelInitializer,
-							Count: ptr.To[int32](1),
+							Name:     constants.ModelInitializer,
+							Ancestor: ptr.To(constants.ModelInitializer),
+							Count:    ptr.To[int32](1),
 							SinglePodRequests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("1"),
 								corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -503,7 +512,9 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 							},
 						},
 						{
-							Name: constants.JobTrainerNode,
+							Name:     constants.Node,
+							Ancestor: ptr.To(constants.AncestorTrainer),
+							Count:    ptr.To[int32](1),
 							SinglePodRequests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("1"),
 								corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -525,9 +536,11 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 							jobsetv1alpha2ac.ReplicatedJob().
 								WithName(constants.DatasetInitializer).
 								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithLabels(map[string]string{
+										constants.LabelTrainJobAncestor: constants.DatasetInitializer,
+									}).
 									WithSpec(batchv1ac.JobSpec().
 										WithTemplate(corev1ac.PodTemplateSpec().
-											WithLabels(map[string]string{constants.LabelTrainJobAncestor: constants.DatasetInitializer}).
 											WithSpec(corev1ac.PodSpec().
 												WithContainers(
 													corev1ac.Container().
@@ -551,9 +564,11 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 							jobsetv1alpha2ac.ReplicatedJob().
 								WithName(constants.ModelInitializer).
 								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithLabels(map[string]string{
+										constants.LabelTrainJobAncestor: constants.ModelInitializer,
+									}).
 									WithSpec(batchv1ac.JobSpec().
 										WithTemplate(corev1ac.PodTemplateSpec().
-											WithLabels(map[string]string{constants.LabelTrainJobAncestor: constants.ModelInitializer}).
 											WithSpec(corev1ac.PodSpec().
 												WithContainers(
 													corev1ac.Container().
@@ -575,14 +590,17 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 									),
 								),
 							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.JobTrainerNode).
+								WithName(constants.Node).
 								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithLabels(map[string]string{
+										constants.LabelTrainJobAncestor: constants.AncestorTrainer,
+									}).
 									WithSpec(batchv1ac.JobSpec().
 										WithTemplate(corev1ac.PodTemplateSpec().
 											WithSpec(corev1ac.PodSpec().
 												WithContainers(
 													corev1ac.Container().
-														WithName(constants.ContainerTrainer).
+														WithName(constants.Node).
 														WithVolumeMounts(
 															corev1ac.VolumeMount().
 																WithName(jobsetplgconsts.VolumeNameInitializer).
@@ -636,10 +654,12 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 								WithReplicas(1).
 								WithName(constants.DatasetInitializer).
 								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithLabels(map[string]string{
+										constants.LabelTrainJobAncestor: constants.DatasetInitializer,
+									}).
 									WithSpec(batchv1ac.JobSpec().
 										WithTemplate(corev1ac.PodTemplateSpec().
 											WithLabels(map[string]string{
-												constants.LabelTrainJobAncestor:        constants.DatasetInitializer,
 												schedulerpluginsv1alpha1.PodGroupLabel: "test-job",
 											}).
 											WithSpec(corev1ac.PodSpec().
@@ -666,10 +686,12 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 								WithReplicas(1).
 								WithName(constants.ModelInitializer).
 								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithLabels(map[string]string{
+										constants.LabelTrainJobAncestor: constants.ModelInitializer,
+									}).
 									WithSpec(batchv1ac.JobSpec().
 										WithTemplate(corev1ac.PodTemplateSpec().
 											WithLabels(map[string]string{
-												constants.LabelTrainJobAncestor:        constants.ModelInitializer,
 												schedulerpluginsv1alpha1.PodGroupLabel: "test-job",
 											}).
 											WithSpec(corev1ac.PodSpec().
@@ -693,9 +715,12 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 									),
 								),
 							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.JobTrainerNode).
+								WithName(constants.Node).
 								WithReplicas(1).
 								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithLabels(map[string]string{
+										constants.LabelTrainJobAncestor: constants.AncestorTrainer,
+									}).
 									WithSpec(batchv1ac.JobSpec().
 										WithParallelism(100).
 										WithCompletions(100).
@@ -706,7 +731,7 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 											WithSpec(corev1ac.PodSpec().
 												WithContainers(
 													corev1ac.Container().
-														WithName(constants.ContainerTrainer).
+														WithName(constants.Node).
 														WithImage("test:trainjob").
 														WithCommand("trainjob").
 														WithArgs("trainjob").
@@ -737,8 +762,9 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 						),
 					PodSets: []runtime.PodSet{
 						{
-							Name:  constants.DatasetInitializer,
-							Count: ptr.To[int32](1),
+							Name:     constants.DatasetInitializer,
+							Ancestor: ptr.To(constants.DatasetInitializer),
+							Count:    ptr.To[int32](1),
 							SinglePodRequests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("1"),
 								corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -761,8 +787,9 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 							},
 						},
 						{
-							Name:  constants.ModelInitializer,
-							Count: ptr.To[int32](1),
+							Name:     constants.ModelInitializer,
+							Ancestor: ptr.To(constants.ModelInitializer),
+							Count:    ptr.To[int32](1),
 							SinglePodRequests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("1"),
 								corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -785,8 +812,9 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 							},
 						},
 						{
-							Name:  constants.JobTrainerNode,
-							Count: ptr.To[int32](100),
+							Name:     constants.Node,
+							Ancestor: ptr.To(constants.AncestorTrainer),
+							Count:    ptr.To[int32](100),
 							SinglePodRequests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("1"),
 								corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -821,9 +849,9 @@ func TestRunComponentBuilderPlugins(t *testing.T) {
 				testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
 					ControllerReference(trainer.SchemeGroupVersion.WithKind("TrainJob"), "test-job", "uid").
 					PodLabel(schedulerpluginsv1alpha1.PodGroupLabel, "test-job").
-					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.JobTrainerNode).
+					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Node).
 					NumNodes(100).
-					Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, corev1.ResourceList{
+					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("1"),
 						corev1.ResourceMemory: resource.MustParse("4Gi"),
 					}).
@@ -1046,7 +1074,7 @@ func TestPodNetworkPlugins(t *testing.T) {
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{
 						{
-							Name:       constants.JobTrainerNode,
+							Name:       constants.Node,
 							Count:      ptr.To[int32](2),
 							Containers: make([]runtime.Container, 1),
 						},
@@ -1054,7 +1082,7 @@ func TestPodNetworkPlugins(t *testing.T) {
 					ObjApply: jobsetv1alpha2ac.JobSetSpec().
 						WithReplicatedJobs(
 							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.JobTrainerNode).
+								WithName(constants.Node).
 								WithTemplate(batchv1ac.JobTemplateSpec().
 									WithSpec(batchv1ac.JobSpec().
 										WithParallelism(1).
@@ -1063,7 +1091,7 @@ func TestPodNetworkPlugins(t *testing.T) {
 											WithSpec(corev1ac.PodSpec().
 												WithContainers(
 													corev1ac.Container().
-														WithName(constants.ContainerTrainer),
+														WithName(constants.Node),
 												),
 											),
 										),
@@ -1079,19 +1107,19 @@ func TestPodNetworkPlugins(t *testing.T) {
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{
 						{
-							Name:       constants.JobTrainerNode,
+							Name:       constants.Node,
 							Containers: make([]runtime.Container, 1),
 							Count:      ptr.To[int32](2),
 							Endpoints: func(yield func(string) bool) {
-								yield("test-job-trainer-node-0-0.test-job")
-								yield("test-job-trainer-node-0-1.test-job")
+								yield("test-job-node-0-0.test-job")
+								yield("test-job-node-0-1.test-job")
 							},
 						},
 					},
 					ObjApply: jobsetv1alpha2ac.JobSetSpec().
 						WithReplicatedJobs(
 							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.JobTrainerNode).
+								WithName(constants.Node).
 								WithTemplate(batchv1ac.JobTemplateSpec().
 									WithSpec(batchv1ac.JobSpec().
 										WithParallelism(1).
@@ -1100,7 +1128,7 @@ func TestPodNetworkPlugins(t *testing.T) {
 											WithSpec(corev1ac.PodSpec().
 												WithContainers(
 													corev1ac.Container().
-														WithName(constants.ContainerTrainer),
+														WithName(constants.Node),
 												),
 											),
 										),

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -146,7 +146,7 @@ func (j *JobSet) IdentifyPodNetwork(info *runtime.Info, trainJob *trainer.TrainJ
 		// TODO: Support multiple replicas for replicated Jobs.
 		// REF: https://github.com/kubeflow/trainer/issues/2318
 		podCount := info.TemplateSpec.PodSets[rJobIdx].Count
-		rJobReplicas := 1
+		rJobReplicas := constants.DefaultJobReplicas
 		info.TemplateSpec.PodSets[rJobIdx].Endpoints = func(yield func(string) bool) {
 			for podIdx := range ptr.Deref(podCount, 1) {
 				endpoint := fmt.Sprintf("%s-%s-%d-%d.%s", trainJob.Name, *rJob.Name, rJobReplicas-1, podIdx, subDomain)
@@ -194,7 +194,7 @@ func (j *JobSet) Build(ctx context.Context, info *runtime.Info, trainJob *traine
 	// TODO: Once we remove deprecated runtime.Info.Trainer, we should remove JobSet Builder with DeprecatedTrainer().
 	jobSet := jobSetBuilder.
 		Initializer(trainJob).
-		Launcher().
+		Launcher(info, trainJob).
 		Trainer(info, trainJob).
 		PodLabels(info.Scheduler.PodLabels).
 		Suspend(trainJob.Spec.Suspend).

--- a/pkg/runtime/framework/plugins/jobset/jobset_test.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset_test.go
@@ -74,7 +74,7 @@ func TestJobSet(t *testing.T) {
 				},
 			},
 		},
-		"trainer numNodes is respected rather than parallelism when replicatedJob name is trainer-node": {
+		"trainer numNodes is respected rather than parallelism when replicatedJob name is node": {
 			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "trainJob").
 				Obj(),
 			info: &runtime.Info{
@@ -90,7 +90,7 @@ func TestJobSet(t *testing.T) {
 							Containers: make([]runtime.Container, 1),
 						},
 						{
-							Name:       constants.JobTrainerNode,
+							Name:       constants.Node,
 							Count:      ptr.To[int32](2),
 							Containers: make([]runtime.Container, 1),
 						},
@@ -113,14 +113,14 @@ func TestJobSet(t *testing.T) {
 									),
 								),
 							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.JobTrainerNode).
+								WithName(constants.Node).
 								WithTemplate(batchv1ac.JobTemplateSpec().
 									WithSpec(batchv1ac.JobSpec().
 										WithParallelism(2).
 										WithTemplate(corev1ac.PodTemplateSpec().
 											WithSpec(corev1ac.PodSpec().
 												WithContainers(
-													corev1ac.Container().WithName(constants.ContainerTrainer),
+													corev1ac.Container().WithName(constants.Node),
 												),
 											),
 										),
@@ -145,12 +145,12 @@ func TestJobSet(t *testing.T) {
 							},
 						},
 						{
-							Name:       constants.JobTrainerNode,
+							Name:       constants.Node,
 							Count:      ptr.To[int32](2),
 							Containers: make([]runtime.Container, 1),
 							Endpoints: func(yield func(string) bool) {
-								yield("trainJob-trainer-node-0-0.trainJob")
-								yield("trainJob-trainer-node-0-1.trainJob")
+								yield("trainJob-node-0-0.trainJob")
+								yield("trainJob-node-0-1.trainJob")
 							},
 						},
 					},
@@ -172,14 +172,14 @@ func TestJobSet(t *testing.T) {
 									),
 								),
 							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.JobTrainerNode).
+								WithName(constants.Node).
 								WithTemplate(batchv1ac.JobTemplateSpec().
 									WithSpec(batchv1ac.JobSpec().
 										WithParallelism(2).
 										WithTemplate(corev1ac.PodTemplateSpec().
 											WithSpec(corev1ac.PodSpec().
 												WithContainers(
-													corev1ac.Container().WithName(constants.ContainerTrainer),
+													corev1ac.Container().WithName(constants.Node),
 												),
 											),
 										),
@@ -203,7 +203,7 @@ func TestJobSet(t *testing.T) {
 							Containers: make([]runtime.Container, 1),
 						},
 						{
-							Name:       constants.JobTrainerNode,
+							Name:       constants.Node,
 							Containers: make([]runtime.Container, 1),
 						},
 					},
@@ -226,14 +226,14 @@ func TestJobSet(t *testing.T) {
 									),
 								),
 							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.JobTrainerNode).
+								WithName(constants.Node).
 								WithTemplate(batchv1ac.JobTemplateSpec().
 									WithSpec(batchv1ac.JobSpec().
 										WithParallelism(1).
 										WithTemplate(corev1ac.PodTemplateSpec().
 											WithSpec(corev1ac.PodSpec().
 												WithContainers(
-													corev1ac.Container().WithName(constants.ContainerTrainer),
+													corev1ac.Container().WithName(constants.Node),
 												),
 											),
 										),
@@ -256,10 +256,10 @@ func TestJobSet(t *testing.T) {
 							},
 						},
 						{
-							Name:       constants.JobTrainerNode,
+							Name:       constants.Node,
 							Containers: make([]runtime.Container, 1),
 							Endpoints: func(yield func(string) bool) {
-								yield("trainJob-trainer-node-0-0.kubeflow.org")
+								yield("trainJob-node-0-0.kubeflow.org")
 							},
 						},
 					},
@@ -282,14 +282,14 @@ func TestJobSet(t *testing.T) {
 									),
 								),
 							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.JobTrainerNode).
+								WithName(constants.Node).
 								WithTemplate(batchv1ac.JobTemplateSpec().
 									WithSpec(batchv1ac.JobSpec().
 										WithParallelism(1).
 										WithTemplate(corev1ac.PodTemplateSpec().
 											WithSpec(corev1ac.PodSpec().
 												WithContainers(
-													corev1ac.Container().WithName(constants.ContainerTrainer),
+													corev1ac.Container().WithName(constants.Node),
 												),
 											),
 										),

--- a/pkg/runtime/framework/plugins/plainml/plainml.go
+++ b/pkg/runtime/framework/plugins/plainml/plainml.go
@@ -50,13 +50,15 @@ func (p *PlainML) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob
 
 	// TrainJob contains the actual information for the number of nodes.
 	if trainJob.Spec.Trainer != nil && trainJob.Spec.Trainer.NumNodes != nil {
-		info.FindPodSetByName(constants.JobTrainerNode).Count = trainJob.Spec.Trainer.NumNodes
+		if trainerPS := info.FindPodSetByAncestor(constants.AncestorTrainer); trainerPS != nil && trainerPS.Count != nil {
+			*trainerPS.Count = *trainJob.Spec.Trainer.NumNodes
+		}
 	}
 
 	// Add envs from the TrainJob.
 	var trainerContainer *runtime.Container
 	if trainJob.Spec.Trainer != nil {
-		if trainerContainer = info.FindContainerByPodSetContainerName(constants.JobTrainerNode, constants.ContainerTrainer); trainerContainer != nil {
+		if trainerContainer = info.FindContainerByPodSetAncestorContainerName(constants.AncestorTrainer, constants.Node); trainerContainer != nil {
 			apply.UpsertEnvVars(&trainerContainer.Env, apply.EnvVars(trainJob.Spec.Trainer.Env...)...)
 		}
 	}

--- a/pkg/runtime/framework/plugins/plainml/plainml_test.go
+++ b/pkg/runtime/framework/plugins/plainml/plainml_test.go
@@ -89,8 +89,8 @@ func TestPlainML(t *testing.T) {
 				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().Obj(),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 100, corev1.PodSpec{}, corev1ac.PodSpec().
-					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 100, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
 			),
 			wantInfo: &runtime.Info{
@@ -101,11 +101,12 @@ func TestPlainML(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name:              constants.JobTrainerNode,
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
 						Count:             ptr.To[int32](200),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
-							Name: constants.ContainerTrainer,
+							Name: constants.Node,
 						}},
 					}},
 				},
@@ -129,9 +130,9 @@ func TestPlainML(t *testing.T) {
 				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().Obj(),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 100, corev1.PodSpec{}, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 100, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().
-						WithName(constants.ContainerTrainer).
+						WithName(constants.Node).
 						WithEnv(corev1ac.EnvVar().
 							WithName("CONFLICT").
 							WithValue("FROM_TRAINER"),
@@ -147,11 +148,12 @@ func TestPlainML(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name:              constants.JobTrainerNode,
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
 						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
-							Name: constants.ContainerTrainer,
+							Name: constants.Node,
 							Env: []corev1ac.EnvVarApplyConfiguration{
 								*corev1ac.EnvVar().WithName("CONFLICT").WithValue("FROM_TRAINER"),
 							},

--- a/pkg/runtime/framework/plugins/torch/torch_test.go
+++ b/pkg/runtime/framework/plugins/torch/torch_test.go
@@ -76,9 +76,9 @@ func TestTorch(t *testing.T) {
 						).
 						Obj(),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(
-						corev1ac.Container().WithName(constants.ContainerTrainer),
+						corev1ac.Container().WithName(constants.Node),
 					),
 				),
 			),
@@ -98,11 +98,12 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name:              constants.JobTrainerNode,
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
 						Count:             ptr.To[int32](2),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
-							Name: constants.ContainerTrainer,
+							Name: constants.Node,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
 								ContainerPort: ptr.To[int32](constants.ContainerTrainerPort),
 							}},
@@ -125,7 +126,7 @@ func TestTorch(t *testing.T) {
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterAddr),
-									Value: ptr.To("trainJob-trainer-node-0-0.trainJob"),
+									Value: ptr.To("trainJob-node-0-0.trainJob"),
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
@@ -158,8 +159,8 @@ func TestTorch(t *testing.T) {
 						).
 						Obj(),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
-					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
 			),
 			wantInfo: &runtime.Info{
@@ -172,11 +173,12 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name:              constants.JobTrainerNode,
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
 						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
-							Name: constants.ContainerTrainer,
+							Name: constants.Node,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
 								ContainerPort: ptr.To[int32](constants.ContainerTrainerPort),
 							}},
@@ -199,7 +201,7 @@ func TestTorch(t *testing.T) {
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterAddr),
-									Value: ptr.To("test-job-trainer-node-0-0.test-job"),
+									Value: ptr.To("test-job-node-0-0.test-job"),
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
@@ -230,8 +232,8 @@ func TestTorch(t *testing.T) {
 						).
 						Obj(),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
-					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
 			),
 			wantInfo: &runtime.Info{
@@ -244,11 +246,12 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name:              constants.JobTrainerNode,
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
 						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
-							Name: constants.ContainerTrainer,
+							Name: constants.Node,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
 								ContainerPort: ptr.To[int32](constants.ContainerTrainerPort),
 							}},
@@ -271,7 +274,7 @@ func TestTorch(t *testing.T) {
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterAddr),
-									Value: ptr.To("test-job-trainer-node-0-0.test-job"),
+									Value: ptr.To("test-job-node-0-0.test-job"),
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
@@ -304,8 +307,8 @@ func TestTorch(t *testing.T) {
 						).
 						Obj(),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
-					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
 			),
 			wantInfo: &runtime.Info{
@@ -318,11 +321,12 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name:              constants.JobTrainerNode,
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
 						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
-							Name: constants.ContainerTrainer,
+							Name: constants.Node,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
 								ContainerPort: ptr.To[int32](constants.ContainerTrainerPort),
 							}},
@@ -345,7 +349,7 @@ func TestTorch(t *testing.T) {
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterAddr),
-									Value: ptr.To("test-job-trainer-node-0-0.test-job"),
+									Value: ptr.To("test-job-node-0-0.test-job"),
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
@@ -378,8 +382,8 @@ func TestTorch(t *testing.T) {
 						).
 						Obj(),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
-					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
 			),
 			wantInfo: &runtime.Info{
@@ -392,11 +396,12 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name:              constants.JobTrainerNode,
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
 						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
-							Name: constants.ContainerTrainer,
+							Name: constants.Node,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
 								ContainerPort: ptr.To[int32](constants.ContainerTrainerPort),
 							}},
@@ -419,7 +424,7 @@ func TestTorch(t *testing.T) {
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterAddr),
-									Value: ptr.To("test-job-trainer-node-0-0.test-job"),
+									Value: ptr.To("test-job-node-0-0.test-job"),
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
@@ -452,8 +457,8 @@ func TestTorch(t *testing.T) {
 						).
 						Obj(),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
-					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
 			),
 			wantInfo: &runtime.Info{
@@ -466,11 +471,12 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name:              constants.JobTrainerNode,
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
 						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
-							Name: constants.ContainerTrainer,
+							Name: constants.Node,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
 								ContainerPort: ptr.To[int32](constants.ContainerTrainerPort),
 							}},
@@ -493,7 +499,7 @@ func TestTorch(t *testing.T) {
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterAddr),
-									Value: ptr.To("test-job-trainer-node-0-0.test-job"),
+									Value: ptr.To("test-job-node-0-0.test-job"),
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
@@ -526,8 +532,8 @@ func TestTorch(t *testing.T) {
 						).
 						Obj(),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
-					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
 			),
 			wantInfo: &runtime.Info{
@@ -540,11 +546,12 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name:              constants.JobTrainerNode,
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
 						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
-							Name: constants.ContainerTrainer,
+							Name: constants.Node,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
 								ContainerPort: ptr.To[int32](constants.ContainerTrainerPort),
 							}},
@@ -567,7 +574,7 @@ func TestTorch(t *testing.T) {
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterAddr),
-									Value: ptr.To("test-job-trainer-node-0-0.test-job"),
+									Value: ptr.To("test-job-node-0-0.test-job"),
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
@@ -600,8 +607,8 @@ func TestTorch(t *testing.T) {
 						).
 						Obj(),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
-					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
 			),
 			wantInfo: &runtime.Info{
@@ -614,11 +621,12 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name:              constants.JobTrainerNode,
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
 						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
-							Name: constants.ContainerTrainer,
+							Name: constants.Node,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
 								ContainerPort: ptr.To[int32](constants.ContainerTrainerPort),
 							}},
@@ -641,7 +649,7 @@ func TestTorch(t *testing.T) {
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterAddr),
-									Value: ptr.To("test-job-trainer-node-0-0.test-job"),
+									Value: ptr.To("test-job-node-0-0.test-job"),
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
@@ -674,8 +682,8 @@ func TestTorch(t *testing.T) {
 						).
 						Obj(),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
-					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
 			),
 			wantInfo: &runtime.Info{
@@ -688,11 +696,12 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name:              constants.JobTrainerNode,
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
 						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
-							Name: constants.ContainerTrainer,
+							Name: constants.Node,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
 								ContainerPort: ptr.To[int32](constants.ContainerTrainerPort),
 							}},
@@ -715,7 +724,7 @@ func TestTorch(t *testing.T) {
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterAddr),
-									Value: ptr.To("test-job-trainer-node-0-0.test-job"),
+									Value: ptr.To("test-job-node-0-0.test-job"),
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
@@ -748,8 +757,8 @@ func TestTorch(t *testing.T) {
 						).
 						Obj(),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
-					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
 			),
 			wantInfo: &runtime.Info{
@@ -762,11 +771,12 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name:              constants.JobTrainerNode,
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
 						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
-							Name: constants.ContainerTrainer,
+							Name: constants.Node,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
 								ContainerPort: ptr.To[int32](constants.ContainerTrainerPort),
 							}},
@@ -789,7 +799,7 @@ func TestTorch(t *testing.T) {
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterAddr),
-									Value: ptr.To("test-job-trainer-node-0-0.test-job"),
+									Value: ptr.To("test-job-node-0-0.test-job"),
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
@@ -822,8 +832,8 @@ func TestTorch(t *testing.T) {
 						).
 						Obj(),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
-					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
 			),
 			wantInfo: &runtime.Info{
@@ -836,11 +846,12 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name:              constants.JobTrainerNode,
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
 						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
-							Name: constants.ContainerTrainer,
+							Name: constants.Node,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
 								ContainerPort: ptr.To[int32](constants.ContainerTrainerPort),
 							}},
@@ -863,7 +874,7 @@ func TestTorch(t *testing.T) {
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterAddr),
-									Value: ptr.To("cpu-job-trainer-node-0-0.cpu-job"),
+									Value: ptr.To("cpu-job-node-0-0.cpu-job"),
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
@@ -897,8 +908,8 @@ func TestTorch(t *testing.T) {
 						).
 						Obj(),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
-					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
 			),
 			wantInfo: &runtime.Info{
@@ -911,11 +922,12 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name:              constants.JobTrainerNode,
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
 						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
-							Name: constants.ContainerTrainer,
+							Name: constants.Node,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
 								ContainerPort: ptr.To[int32](constants.ContainerTrainerPort),
 							}},
@@ -938,7 +950,7 @@ func TestTorch(t *testing.T) {
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterAddr),
-									Value: ptr.To("cpu-gpu-job-trainer-node-0-0.cpu-gpu-job"),
+									Value: ptr.To("cpu-gpu-job-node-0-0.cpu-gpu-job"),
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
@@ -971,8 +983,8 @@ func TestTorch(t *testing.T) {
 						).
 						Obj(),
 				),
-				runtime.WithPodSet(constants.JobTrainerNode, 1, corev1.PodSpec{}, corev1ac.PodSpec().
-					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
 			),
 			wantInfo: &runtime.Info{
@@ -985,11 +997,12 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name:              constants.JobTrainerNode,
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
 						Count:             ptr.To[int32](1),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
-							Name: constants.ContainerTrainer,
+							Name: constants.Node,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
 								ContainerPort: ptr.To[int32](constants.ContainerTrainerPort),
 							}},
@@ -1012,7 +1025,7 @@ func TestTorch(t *testing.T) {
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterAddr),
-									Value: ptr.To("cpu-frac-job-trainer-node-0-0.cpu-frac-job"),
+									Value: ptr.To("cpu-frac-job-node-0-0.cpu-frac-job"),
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),
@@ -1052,8 +1065,8 @@ func TestTorch(t *testing.T) {
 					"app": "pytorch-training",
 					"env": "production",
 				}),
-				runtime.WithPodSet(constants.JobTrainerNode, 2, corev1.PodSpec{}, corev1ac.PodSpec().
-					WithContainers(corev1ac.Container().WithName(constants.ContainerTrainer)),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 2, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
 			),
 			wantInfo: &runtime.Info{
@@ -1069,11 +1082,12 @@ func TestTorch(t *testing.T) {
 				},
 				TemplateSpec: runtime.TemplateSpec{
 					PodSets: []runtime.PodSet{{
-						Name:              constants.JobTrainerNode,
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
 						Count:             ptr.To[int32](4),
 						SinglePodRequests: make(corev1.ResourceList),
 						Containers: []runtime.Container{{
-							Name: constants.ContainerTrainer,
+							Name: constants.Node,
 							Ports: []corev1ac.ContainerPortApplyConfiguration{{
 								ContainerPort: ptr.To[int32](constants.ContainerTrainerPort),
 							}},
@@ -1096,7 +1110,7 @@ func TestTorch(t *testing.T) {
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterAddr),
-									Value: ptr.To("gpu-job-trainer-node-0-0.gpu-job"),
+									Value: ptr.To("gpu-job-node-0-0.gpu-job"),
 								},
 								{
 									Name:  ptr.To(constants.TorchEnvMasterPort),

--- a/pkg/util/testing/wrapper.go
+++ b/pkg/util/testing/wrapper.go
@@ -54,13 +54,13 @@ func MakeJobSetWrapper(namespace, name string) *JobSetWrapper {
 					{
 						Name: constants.DatasetInitializer,
 						Template: batchv1.JobTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									constants.LabelTrainJobAncestor: constants.DatasetInitializer,
+								},
+							},
 							Spec: batchv1.JobSpec{
 								Template: corev1.PodTemplateSpec{
-									ObjectMeta: metav1.ObjectMeta{
-										Labels: map[string]string{
-											constants.LabelTrainJobAncestor: constants.DatasetInitializer,
-										},
-									},
 									Spec: corev1.PodSpec{
 										Containers: []corev1.Container{
 											{
@@ -87,13 +87,13 @@ func MakeJobSetWrapper(namespace, name string) *JobSetWrapper {
 					{
 						Name: constants.ModelInitializer,
 						Template: batchv1.JobTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									constants.LabelTrainJobAncestor: constants.ModelInitializer,
+								},
+							},
 							Spec: batchv1.JobSpec{
 								Template: corev1.PodTemplateSpec{
-									ObjectMeta: metav1.ObjectMeta{
-										Labels: map[string]string{
-											constants.LabelTrainJobAncestor: constants.ModelInitializer,
-										},
-									},
 									Spec: corev1.PodSpec{
 										Containers: []corev1.Container{
 											{
@@ -118,14 +118,19 @@ func MakeJobSetWrapper(namespace, name string) *JobSetWrapper {
 						},
 					},
 					{
-						Name: constants.JobTrainerNode,
+						Name: constants.Node,
 						Template: batchv1.JobTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									constants.LabelTrainJobAncestor: constants.AncestorTrainer,
+								},
+							},
 							Spec: batchv1.JobSpec{
 								Template: corev1.PodTemplateSpec{
 									Spec: corev1.PodSpec{
 										Containers: []corev1.Container{
 											{
-												Name: constants.ContainerTrainer,
+												Name: constants.Node,
 												VolumeMounts: []corev1.VolumeMount{
 													{
 														Name:      jobsetplgconsts.VolumeNameInitializer,
@@ -168,7 +173,7 @@ func (j *JobSetWrapper) Replicas(replicas int32, rJobNames ...string) *JobSetWra
 
 func (j *JobSetWrapper) NumNodes(numNodes int32) *JobSetWrapper {
 	for i, rJob := range j.Spec.ReplicatedJobs {
-		if rJob.Name == constants.JobTrainerNode {
+		if rJob.Name == constants.Node {
 			j.Spec.ReplicatedJobs[i].Template.Spec.Parallelism = &numNodes
 			j.Spec.ReplicatedJobs[i].Template.Spec.Completions = &numNodes
 		}
@@ -196,7 +201,7 @@ func (j *JobSetWrapper) Completions(c int32, rJobNames ...string) *JobSetWrapper
 
 func (j *JobSetWrapper) LauncherReplica() *JobSetWrapper {
 	for i, rJob := range j.Spec.ReplicatedJobs {
-		if rJob.Name == constants.JobTrainerNode {
+		if rJob.Name == constants.Node {
 			j.Spec.ReplicatedJobs = append(j.Spec.ReplicatedJobs, jobsetv1alpha2.ReplicatedJob{})
 			copy(j.Spec.ReplicatedJobs[i+1:], j.Spec.ReplicatedJobs[i:])
 			j.Spec.ReplicatedJobs[i] = jobsetv1alpha2.ReplicatedJob{
@@ -238,9 +243,9 @@ func (j *JobSetWrapper) Container(rJobName, containerName, image string, command
 
 func (j *JobSetWrapper) ContainerTrainerPorts(ports []corev1.ContainerPort) *JobSetWrapper {
 	for i, rJob := range j.Spec.ReplicatedJobs {
-		if rJob.Name == constants.JobTrainerNode {
+		if rJob.Name == constants.Node {
 			for k, container := range rJob.Template.Spec.Template.Spec.Containers {
-				if container.Name == constants.ContainerTrainer {
+				if container.Name == constants.Node {
 					j.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.Containers[k].Ports = ports
 				}
 			}
@@ -594,13 +599,13 @@ func MakeTrainingRuntimeWrapper(namespace, name string) *TrainingRuntimeWrapper 
 							{
 								Name: constants.DatasetInitializer,
 								Template: batchv1.JobTemplateSpec{
+									ObjectMeta: metav1.ObjectMeta{
+										Labels: map[string]string{
+											constants.LabelTrainJobAncestor: constants.DatasetInitializer,
+										},
+									},
 									Spec: batchv1.JobSpec{
 										Template: corev1.PodTemplateSpec{
-											ObjectMeta: metav1.ObjectMeta{
-												Labels: map[string]string{
-													constants.LabelTrainJobAncestor: constants.DatasetInitializer,
-												},
-											},
 											Spec: corev1.PodSpec{
 												Containers: []corev1.Container{
 													{
@@ -627,13 +632,13 @@ func MakeTrainingRuntimeWrapper(namespace, name string) *TrainingRuntimeWrapper 
 							{
 								Name: constants.ModelInitializer,
 								Template: batchv1.JobTemplateSpec{
+									ObjectMeta: metav1.ObjectMeta{
+										Labels: map[string]string{
+											constants.LabelTrainJobAncestor: constants.ModelInitializer,
+										},
+									},
 									Spec: batchv1.JobSpec{
 										Template: corev1.PodTemplateSpec{
-											ObjectMeta: metav1.ObjectMeta{
-												Labels: map[string]string{
-													constants.LabelTrainJobAncestor: constants.ModelInitializer,
-												},
-											},
 											Spec: corev1.PodSpec{
 												Containers: []corev1.Container{
 													{
@@ -658,14 +663,19 @@ func MakeTrainingRuntimeWrapper(namespace, name string) *TrainingRuntimeWrapper 
 								},
 							},
 							{
-								Name: constants.JobTrainerNode,
+								Name: constants.Node,
 								Template: batchv1.JobTemplateSpec{
+									ObjectMeta: metav1.ObjectMeta{
+										Labels: map[string]string{
+											constants.LabelTrainJobAncestor: constants.AncestorTrainer,
+										},
+									},
 									Spec: batchv1.JobSpec{
 										Template: corev1.PodTemplateSpec{
 											Spec: corev1.PodSpec{
 												Containers: []corev1.Container{
 													{
-														Name: constants.ContainerTrainer,
+														Name: constants.Node,
 														VolumeMounts: []corev1.VolumeMount{
 															{
 																Name:      jobsetplgconsts.VolumeNameInitializer,
@@ -799,14 +809,14 @@ func MakeClusterTrainingRuntimeWrapper(name string) *ClusterTrainingRuntimeWrapp
 								},
 							},
 							{
-								Name: constants.JobTrainerNode,
+								Name: constants.Node,
 								Template: batchv1.JobTemplateSpec{
 									Spec: batchv1.JobSpec{
 										Template: corev1.PodTemplateSpec{
 											Spec: corev1.PodSpec{
 												Containers: []corev1.Container{
 													{
-														Name: constants.ContainerTrainer,
+														Name: constants.Node,
 														VolumeMounts: []corev1.VolumeMount{
 															{
 																Name:      jobsetplgconsts.VolumeNameInitializer,
@@ -871,7 +881,7 @@ func (s *TrainingRuntimeSpecWrapper) WithMLPolicy(mlPolicy *trainer.MLPolicy) *T
 
 func (s *TrainingRuntimeSpecWrapper) LauncherReplica() *TrainingRuntimeSpecWrapper {
 	for i, rJob := range s.Template.Spec.ReplicatedJobs {
-		if rJob.Name == constants.JobTrainerNode {
+		if rJob.Name == constants.Node {
 			s.Template.Spec.ReplicatedJobs = append(s.Template.Spec.ReplicatedJobs, jobsetv1alpha2.ReplicatedJob{})
 			copy(s.Template.Spec.ReplicatedJobs[i+1:], s.Template.Spec.ReplicatedJobs[i:])
 			s.Template.Spec.ReplicatedJobs[i] = jobsetv1alpha2.ReplicatedJob{

--- a/pkg/webhooks/trainingruntime_webhook_test.go
+++ b/pkg/webhooks/trainingruntime_webhook_test.go
@@ -35,12 +35,12 @@ func TestValidateReplicatedJobs(t *testing.T) {
 	}{
 		"valid replicatedJobs": {
 			rJobs: testingutil.MakeJobSetWrapper("ns", "valid").
-				Replicas(1, constants.JobTrainerNode, constants.DatasetInitializer, constants.ModelInitializer).
+				Replicas(1, constants.Node, constants.DatasetInitializer, constants.ModelInitializer).
 				Obj().Spec.ReplicatedJobs,
 		},
 		"invalid replicas": {
 			rJobs: testingutil.MakeJobSetWrapper("ns", "valid").
-				Replicas(2, constants.JobTrainerNode, constants.DatasetInitializer, constants.ModelInitializer).
+				Replicas(2, constants.Node, constants.DatasetInitializer, constants.ModelInitializer).
 				Obj().Spec.ReplicatedJobs,
 			wantError: field.ErrorList{
 				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(0).Child("replicas"),

--- a/test/integration/controller/trainjob_controller_test.go
+++ b/test/integration/controller/trainjob_controller_test.go
@@ -119,7 +119,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 						PodGroupPolicyCoscheduling(&trainer.CoschedulingPodGroupPolicySource{ScheduleTimeoutSeconds: ptr.To[int32](100)}).
 						Container(constants.ModelInitializer, constants.ModelInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 						Container(constants.DatasetInitializer, constants.DatasetInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
-						Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+						Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 						Obj()).
 				Obj()
 		})
@@ -144,7 +144,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 							Label("testingKey", "testingVal").
 							Annotation("testingKey", "testingVal").
 							PodLabel(schedulerpluginsv1alpha1.PodGroupLabel, trainJobKey.Name).
-							Replicas(1, constants.JobTrainerNode, constants.DatasetInitializer, constants.ModelInitializer).
+							Replicas(1, constants.Node, constants.DatasetInitializer, constants.ModelInitializer).
 							Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer).
 							Completions(1, constants.DatasetInitializer, constants.ModelInitializer).
 							NumNodes(100).
@@ -166,7 +166,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 									},
 								}...,
 							).
-							Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
+							Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
 							Obj(),
 						util.IgnoreObjectMetadata))
 					pg := &schedulerpluginsv1alpha1.PodGroup{}
@@ -219,7 +219,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 							Label("testingKey", "testingVal").
 							Annotation("testingKey", "testingVal").
 							PodLabel(schedulerpluginsv1alpha1.PodGroupLabel, trainJobKey.Name).
-							Replicas(1, constants.JobTrainerNode, constants.DatasetInitializer, constants.ModelInitializer).
+							Replicas(1, constants.Node, constants.DatasetInitializer, constants.ModelInitializer).
 							Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer).
 							Completions(1, constants.DatasetInitializer, constants.ModelInitializer).
 							NumNodes(100).
@@ -241,7 +241,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 									},
 								}...,
 							).
-							Container(constants.JobTrainerNode, constants.ContainerTrainer, updatedImageName, []string{"trainjob"}, []string{"trainjob"}, resRequests).
+							Container(constants.Node, constants.Node, updatedImageName, []string{"trainjob"}, []string{"trainjob"}, resRequests).
 							Obj(),
 						util.IgnoreObjectMetadata))
 					pg := &schedulerpluginsv1alpha1.PodGroup{}
@@ -283,7 +283,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 					jobSet := &jobsetv1alpha2.JobSet{}
 					g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
 					for _, rJob := range jobSet.Spec.ReplicatedJobs {
-						if rJob.Name == constants.JobTrainerNode {
+						if rJob.Name == constants.Node {
 							g.Expect(rJob.Template.Spec.Template.Spec.Containers[0].Image).Should(gomega.Equal(updatedImageName))
 						}
 					}
@@ -304,7 +304,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 					g.Expect(jobSet.Spec.Suspend).ShouldNot(gomega.BeNil())
 					g.Expect(*jobSet.Spec.Suspend).Should(gomega.BeTrue())
 					for _, rJob := range jobSet.Spec.ReplicatedJobs {
-						if rJob.Name == constants.JobTrainerNode {
+						if rJob.Name == constants.Node {
 							g.Expect(rJob.Template.Spec.Template.Spec.Containers[0].Image).Should(gomega.Equal(originImageName))
 						}
 					}
@@ -337,7 +337,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 									).
 									Obj(),
 							).
-							Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+							Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 							Obj()).
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
@@ -354,13 +354,13 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 						testingutil.MakeJobSetWrapper(ns.Name, trainJobKey.Name).
 							ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), trainJobKey.Name, string(trainJob.UID)).
 							Suspend(false).
-							Replicas(1, constants.JobTrainerNode, constants.DatasetInitializer, constants.ModelInitializer).
+							Replicas(1, constants.Node, constants.DatasetInitializer, constants.ModelInitializer).
 							Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer).
 							Completions(1, constants.DatasetInitializer, constants.ModelInitializer).
 							NumNodes(100).
-							Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
+							Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
 							ContainerTrainerPorts([]corev1.ContainerPort{{ContainerPort: constants.ContainerTrainerPort, Protocol: "TCP"}}).
-							Env(constants.JobTrainerNode, constants.ContainerTrainer,
+							Env(constants.Node, constants.Node,
 								[]corev1.EnvVar{
 									{
 										Name:  "TRAIN_JOB",
@@ -384,7 +384,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 									},
 									{
 										Name:  constants.TorchEnvMasterAddr,
-										Value: fmt.Sprintf("alpha-%s-0-0.alpha", constants.JobTrainerNode),
+										Value: fmt.Sprintf("alpha-%s-0-0.alpha", constants.Node),
 									},
 									{
 										Name:  constants.TorchEnvMasterPort,
@@ -616,7 +616,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 									).
 									Obj(),
 							).
-							Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
+							Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
 							Obj()).
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
@@ -634,11 +634,11 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 							ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), trainJobKey.Name, string(trainJob.UID)).
 							Suspend(false).
 							LauncherReplica().
-							Replicas(1, constants.JobTrainerNode, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
+							Replicas(1, constants.Node, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 							Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 							Completions(1, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 							NumNodes(2).
-							Container(constants.JobTrainerNode, constants.ContainerTrainer, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
+							Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
 							Volumes(constants.JobLauncher,
 								corev1.Volume{
 									Name: constants.MPISSHAuthVolumeName,
@@ -678,7 +678,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 									},
 								},
 							).
-							Volumes(constants.JobTrainerNode,
+							Volumes(constants.Node,
 								corev1.Volume{
 									Name: constants.MPISSHAuthVolumeName,
 									VolumeSource: corev1.VolumeSource{
@@ -706,6 +706,9 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 								corev1.VolumeMount{Name: constants.MPISSHAuthVolumeName, MountPath: "/root/.ssh"},
 								corev1.VolumeMount{Name: constants.MPIHostfileVolumeName, MountPath: constants.MPIHostfileDir},
 							).
+							VolumeMounts(constants.Node, constants.Node,
+								corev1.VolumeMount{Name: constants.MPISSHAuthVolumeName, MountPath: "/root/.ssh"},
+							).
 							Env(constants.JobLauncher, constants.ContainerLauncher,
 								corev1.EnvVar{
 									Name:  constants.OpenMPIEnvHostFileLocation,
@@ -724,7 +727,7 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 									Value: constants.OpenMPIEnvDefaultValueRSHArgs,
 								},
 							).
-							Env(constants.JobTrainerNode, constants.ContainerTrainer,
+							Env(constants.Node, constants.Node,
 								corev1.EnvVar{
 									Name:  "TRAIN_JOB",
 									Value: "value",
@@ -741,8 +744,8 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 					g.Expect(cm).Should(gomega.BeComparableTo(
 						testingutil.MakeConfigMapWrapper(cmKey.Name, cmKey.Namespace).
 							WithData(map[string]string{
-								constants.MPIHostfileName: `alpha-trainer-node-0-0.alpha slots=8
-alpha-trainer-node-0-1.alpha slots=8
+								constants.MPIHostfileName: `alpha-node-0-0.alpha slots=8
+alpha-node-0-1.alpha slots=8
 `,
 							}).
 							ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), trainJobKey.Name, string(trainJob.UID)).

--- a/test/integration/webhooks/trainingruntime_webhook_test.go
+++ b/test/integration/webhooks/trainingruntime_webhook_test.go
@@ -189,7 +189,7 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 						},
 					}
 					runtime.Spec.Template.Spec = testingutil.MakeJobSetWrapper(ns.Name, "runtime").
-						Replicas(1, constants.JobTrainerNode, constants.DatasetInitializer, constants.ModelInitializer).
+						Replicas(1, constants.Node, constants.DatasetInitializer, constants.ModelInitializer).
 						Obj().
 						Spec
 					return runtime
@@ -209,7 +209,7 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							).
 							JobSetSpec(
 								testingutil.MakeJobSetWrapper(ns.Name, "jobset").
-									Replicas(1, constants.JobTrainerNode, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
+									Replicas(1, constants.Node, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 									Obj().
 									Spec,
 							).
@@ -231,7 +231,7 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							).
 							JobSetSpec(
 								testingutil.MakeJobSetWrapper(ns.Name, "jobset").
-									Replicas(1, constants.JobTrainerNode, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
+									Replicas(1, constants.Node, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 									Obj().
 									Spec,
 							).
@@ -254,7 +254,7 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							).
 							JobSetSpec(
 								testingutil.MakeJobSetWrapper(ns.Name, "jobset").
-									Replicas(1, constants.JobTrainerNode, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
+									Replicas(1, constants.Node, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 									Obj().
 									Spec,
 							).
@@ -276,7 +276,7 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							).
 							JobSetSpec(
 								testingutil.MakeJobSetWrapper(ns.Name, "jobset").
-									Replicas(1, constants.JobTrainerNode, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
+									Replicas(1, constants.Node, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 									Obj().
 									Spec,
 							).
@@ -299,7 +299,7 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							).
 							JobSetSpec(
 								testingutil.MakeJobSetWrapper(ns.Name, "jobset").
-									Replicas(1, constants.JobTrainerNode, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
+									Replicas(1, constants.Node, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 									Obj().
 									Spec,
 							).
@@ -321,7 +321,7 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							).
 							JobSetSpec(
 								testingutil.MakeJobSetWrapper(ns.Name, "jobset").
-									Replicas(1, constants.JobTrainerNode, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
+									Replicas(1, constants.Node, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 									Obj().
 									Spec,
 							).
@@ -344,7 +344,7 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							).
 							JobSetSpec(
 								testingutil.MakeJobSetWrapper(ns.Name, "jobset").
-									Replicas(1, constants.JobTrainerNode, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
+									Replicas(1, constants.Node, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 									Obj().
 									Spec,
 							).
@@ -366,7 +366,7 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 							).
 							JobSetSpec(
 								testingutil.MakeJobSetWrapper(ns.Name, "jobset").
-									Replicas(1, constants.JobTrainerNode, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
+									Replicas(1, constants.Node, constants.DatasetInitializer, constants.ModelInitializer, constants.JobLauncher).
 									Obj().
 									Spec,
 							).


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

As @andreyvelich described in https://github.com/kubeflow/trainer/pull/2523, we construct actual Trainers based on `trainer.kubeflow.org/trainjob-ancestor-step` label. Additionally, I enabled runLauncherAsNode by default for MPI runtime.
By this change, MLEs can override commands, args, images.... via TrainJob.

```yaml
apiVersion: trainer.kubeflow.org/v1alpha1
kind: TrainJob
metadata:
  name: mpirun
  namespace: default
spec:
  runtimeRef:
    name: mpi-distributed
  trainer:
    numNodes: 10
    command:
    - "mpirun"
    args:
    - "--tag-output"
    - "/home/mpiuser/pi"
```

```shell
$ kubectl get pod
NAME                        READY   STATUS      RESTARTS   AGE
mpirun-launcher-0-0-t5k6p   0/2     Completed   0          2s
mpirun-node-0-0-5nzbd       0/1     Running     0          2s
mpirun-node-0-1-gwxnq       0/1     Running     0          2s
mpirun-node-0-2-4rnbv       0/1     Running     0          2s
mpirun-node-0-3-2xvj2       0/1     Running     0          2s
mpirun-node-0-4-5k7zb       0/1     Running     0          2s
mpirun-node-0-5-llrz9       0/1     Running     0          2s
mpirun-node-0-6-hkndl       0/1     Running     0          2s
mpirun-node-0-7-dht76       0/1     Running     0          2s
mpirun-node-0-8-j88q5       0/1     Running     0          2s. # There are only 9 nodes since we use RunLauncherAsNode
$
$ k get pod mpirun-launcher-0-0-t5k6p -ojsonpath='{.spec.containers[0].args}'
# The `--tag-output` was propagated from TrainJob.
["--tag-output","/home/mpiuser/pi"]
$ 
$ kubectl logs mpirun-launcher-0-0-t5k6p
[1,0]<stdout>:Workers: 10.                                  # World size is 10 (launcher + 9 nodes)
[1,0]<stdout>:Rank 0 on host mpirun-launcher-0-0
[1,5]<stdout>:Rank 5 on host mpirun-node-0-4
[1,8]<stdout>:Rank 8 on host mpirun-node-0-7
[1,3]<stdout>:Rank 3 on host mpirun-node-0-2
[1,9]<stdout>:Rank 9 on host mpirun-node-0-8
[1,7]<stdout>:Rank 7 on host mpirun-node-0-6
[1,1]<stdout>:Rank 1 on host mpirun-node-0-0
[1,2]<stdout>:Rank 2 on host mpirun-node-0-1
[1,4]<stdout>:Rank 4 on host mpirun-node-0-3
[1,6]<stdout>:Rank 6 on host mpirun-node-0-5
[1,0]<stdout>:pi is approximately 3.1414545600000001
```

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
