### PR TITLE
fix(sdk): Using correct entrypoint for mpirun

### DIFF
--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -182,14 +182,16 @@ class TrainerClient:
 
         # Add command and args to the Trainer if training function is set.
         if trainer and trainer.func:
-            trainer_crd.command = constants.DEFAULT_COMMAND
+
             # TODO: Support train function parameters.
-            trainer_crd.args = utils.get_args_using_train_func(
-                runtime,
-                trainer.func,
-                trainer.func_args,
-                trainer.pip_index_url,
-                trainer.packages_to_install,
+            trainer_crd.command, trainer_crd.args = (
+                utils.get_entrypoint_using_train_func(
+                    runtime,
+                    trainer.func,
+                    trainer.func_args,
+                    trainer.pip_index_url,
+                    trainer.packages_to_install,
+                )
             )
 
         train_job = models.TrainerV1alpha1TrainJob(

--- a/sdk/kubeflow/trainer/constants/constants.py
+++ b/sdk/kubeflow/trainer/constants/constants.py
@@ -98,7 +98,7 @@ POD_PENDING = "Pending"
 # The default PIP index URL to download Python packages.
 DEFAULT_PIP_INDEX_URL = os.getenv("DEFAULT_PIP_INDEX_URL", "https://pypi.org/simple")
 
-# The default command for the Trainer.
+# The default command for the Trainer container.
 DEFAULT_COMMAND = ["bash", "-c"]
 
 # The Torch env name for the number of procs per node (e.g. number of GPUs per Pod).

--- a/sdk/kubeflow/trainer/constants/constants.py
+++ b/sdk/kubeflow/trainer/constants/constants.py
@@ -104,5 +104,8 @@ DEFAULT_COMMAND = ["bash", "-c"]
 # The Torch env name for the number of procs per node (e.g. number of GPUs per Pod).
 TORCH_ENV_NUM_PROC_PER_NODE = "PET_NPROC_PER_NODE"
 
+# The default home directory for the MPI user.
+DEFAULT_MPI_USER_HOME = os.getenv("DEFAULT_MPI_USER_HOME", "/home/mpiuser")
+
 # The OpenMPI env name for the number of slots per nude (e.g. number of GPUs per Pod).
 MPI_ENV_NUM_SLOTS_PER_NODE = "OMPI_MCA_orte_set_default_slots"

--- a/sdk/kubeflow/trainer/types/types.py
+++ b/sdk/kubeflow/trainer/types/types.py
@@ -68,7 +68,7 @@ class Framework(Enum):
 class Trainer:
     trainer_type: TrainerType
     framework: Framework
-    entrypoint: str
+    entrypoint: Optional[List[str]] = None
     accelerator: str = constants.UNKNOWN
     accelerator_count: Union[str, float, int] = constants.UNKNOWN
 
@@ -140,23 +140,31 @@ ALL_TRAINERS: Dict[str, Trainer] = {
     "pytorch/pytorch": Trainer(
         trainer_type=TrainerType.CUSTOM_TRAINER,
         framework=Framework.TORCH,
-        entrypoint="torchrun",
+        entrypoint=["torchrun"],
     ),
     "ghcr.io/kubeflow/trainer/mlx-runtime": Trainer(
         trainer_type=TrainerType.CUSTOM_TRAINER,
         framework=Framework.MLX,
-        entrypoint="mpirun --hostfile /etc/mpi/hostfile -x LD_LIBRARY_PATH=/usr/local/lib/ python3",
+        entrypoint=[
+            "mpirun",
+            "--hostfile",
+            "/etc/mpi/hostfile",
+            "-x",
+            "LD_LIBRARY_PATH=/usr/local/lib/",
+            "bash",
+            "-c",
+        ],
     ),
     "ghcr.io/kubeflow/trainer/deepspeed-runtime": Trainer(
         trainer_type=TrainerType.CUSTOM_TRAINER,
         framework=Framework.DEEPSPEED,
-        entrypoint="mpirun --hostfile /etc/mpi/hostfile python3",
+        # TODO (andreyvelich): Change it once we support DeepSpeed runtime.
+        entrypoint=["mpirun"],
     ),
     # Builtin Trainers.
     "ghcr.io/kubeflow/trainer/torchtune-trainer": Trainer(
         trainer_type=TrainerType.BUILTIN_TRAINER,
         framework=Framework.TORCHTUNE,
-        entrypoint="tune run",
     ),
 }
 
@@ -164,7 +172,7 @@ ALL_TRAINERS: Dict[str, Trainer] = {
 DEFAULT_TRAINER = Trainer(
     trainer_type=TrainerType.CUSTOM_TRAINER,
     framework=Framework.TORCH,
-    entrypoint="torchrun",
+    entrypoint=["torchrun"],
 )
 
 # The default runtime configuration for the train() API

--- a/sdk/kubeflow/trainer/utils/utils.py
+++ b/sdk/kubeflow/trainer/utils/utils.py
@@ -277,8 +277,8 @@ def get_entrypoint_using_train_func(
     if runtime.trainer.entrypoint[0] == "mpirun":
         container_command = runtime.trainer.entrypoint
         python_entrypoint = "python"
-        # mpirun uses file from this location: /home/mpiuser/<FILE_NAME>.py
-        func_file = os.path.join("/home", "mpiuser", func_file)
+        # The default file location is: /home/mpiuser/<FILE_NAME>.py
+        func_file = os.path.join(constants.DEFAULT_MPI_USER_HOME, func_file)
     else:
         container_command = constants.DEFAULT_COMMAND
         python_entrypoint = " ".join(runtime.trainer.entrypoint)

--- a/sdk/kubeflow/trainer/utils/utils.py
+++ b/sdk/kubeflow/trainer/utils/utils.py
@@ -281,7 +281,7 @@ def get_entrypoint_using_train_func(
         func_file = os.path.join("/home", "mpiuser", func_file)
     else:
         container_command = constants.DEFAULT_COMMAND
-        python_entrypoint = runtime.trainer.entrypoint
+        python_entrypoint = " ".join(runtime.trainer.entrypoint)
 
     exec_script = textwrap.dedent(
         """

--- a/sdk/kubeflow/trainer/utils/utils.py
+++ b/sdk/kubeflow/trainer/utils/utils.py
@@ -231,15 +231,15 @@ def get_resources_per_node(
     return resources
 
 
-def get_args_using_train_func(
+def get_entrypoint_using_train_func(
     runtime: types.Runtime,
     train_func: Callable,
     train_func_parameters: Optional[Dict[str, Any]],
     pip_index_url: str,
     packages_to_install: Optional[List[str]] = None,
-) -> List[str]:
+) -> Tuple[List[str], List[str]]:
     """
-    Get the Trainer args from the given training function and parameters.
+    Get the Trainer command and args from the given training function and parameters.
     """
     # Check if training function is callable.
     if not callable(train_func):
@@ -270,21 +270,33 @@ def get_args_using_train_func(
     # Prepare the template to execute script.
     # Currently, we override the file where the training function is defined.
     # That allows to execute the training script with the entrypoint.
+    if runtime.trainer.entrypoint is None:
+        raise Exception(f"Runtime trainer must have an entrypoint: {runtime.trainer}")
+
+    # We don't allow to override python entrypoint for `mpirun`
+    if runtime.trainer.entrypoint[0] == "mpirun":
+        container_command = runtime.trainer.entrypoint
+        python_entrypoint = "python"
+        # mpirun uses file from this location: /home/mpiuser/<FILE_NAME>.py
+        func_file = os.path.join("/home", "mpiuser", func_file)
+    else:
+        container_command = constants.DEFAULT_COMMAND
+        python_entrypoint = runtime.trainer.entrypoint
+
     exec_script = textwrap.dedent(
         """
-                program_path=$(mktemp -d)
                 read -r -d '' SCRIPT << EOM\n
                 {func_code}
                 EOM
                 printf "%s" \"$SCRIPT\" > \"{func_file}\"
-                {entrypoint} \"{func_file}\""""
+                {python_entrypoint} \"{func_file}\""""
     )
 
     # Add function code to the execute script.
     exec_script = exec_script.format(
         func_code=func_code,
         func_file=func_file,
-        entrypoint=runtime.trainer.entrypoint,
+        python_entrypoint=python_entrypoint,
     )
 
     # Install Python packages if that is required.
@@ -295,7 +307,7 @@ def get_args_using_train_func(
         )
 
     # Return container command and args to execute training function.
-    return [exec_script]
+    return container_command, [exec_script]
 
 
 def get_script_for_python_packages(


### PR DESCRIPTION
For the MPI use-cases the Python file must be available on all Pods: Launcher + Node.
Thus, we should modify the command and args compare to `torchrun`.

After this change, the container command and args looks as follows for `mpirun`:
```yaml

args:
- |2-

  read -r -d '' SCRIPT << EOM

  def train_func():
    print("script here")

  train_func()

  EOM
  printf "%s" "$SCRIPT" > "/home/mpiuser/4070280887.py"
  python3 "/home/mpiuser/4070280887.py"
command:
- mpirun
- --hostfile
- /etc/mpi/hostfile
- -x
- LD_LIBRARY_PATH=/usr/local/lib/
- bash
- -c
```

/assign @tenzen-y @kubeflow/wg-training-leads @Electronic-Waste @astefanutti @saileshd1402 
