### PR TITLE
docs: update CONTRIBUTING.md for Kubeflow Trainer V2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ make test-e2e-notebook
 When coding:
 
 Follow the [effective go](https://go.dev/doc/effective_go) guidelines.
-Run [`make check`](https://github.com/kubeflow/katib/blob/) locally to verify if changes follow best practices before submitting PRs.
+Run `make check` locally to verify if changes follow best practices before submitting PRs.
 
 When writing tests:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,112 +16,7 @@ For the Kubeflow Trainer documentation, please check [the official Kubeflow docu
 
 Note for Lima the link is to the Adopters, which supports several different container environments.
 
-## Contributing Workflow
-For contributions to the Kubeflow Trainer project, please follow this workflow:
-
-1. Fork the repository on GitHub
-2. Clone your fork locally
-3. Add the upstream remote to keep your fork in sync:
-   ```sh
-   git remote add upstream https://github.com/kubeflow/trainer.git
-   ```
-4. Create a new branch for your changes:
-   ```sh
-   git checkout -b feature/your-feature-name
-   ```
-5. Fetch the latest changes from the upstream repository and rebase your branch:
-   ```sh
-   git fetch upstream
-   git rebase upstream/main
-   ```
-6. Make your changes and commit them:
-   - Install pre-commit hooks before creating commits:
-     ```sh
-     pip install pre-commit
-     pre-commit install
-     ```
-     ```sh
-     git commit -m -s "your commit message"
-     ```
-   - The pre-commit hooks will automatically check your code for style issues
-   - If the hooks fail, fix the issues (if they weren't fixed automatically) and stage your changes again
-   - For more details, see the [Code Style](#code-style) section
-7. Push your changes to your fork and create a pull request (PR)
-
-
-# Building the Operator
-Install dependencies:
-
-```sh
-go mod tidy
-```
-
-Build the library:
-
-```sh
-go install github.com/kubeflow/trainer/cmd/trainer-controller-manager
-```
-
-## Running the Operator Locally
-
-Running the operator locally in a docker container (as opposed to deploying it on a K8s cluster) is convenient for debugging/development.
-
-### Run a Kubernetes cluster
-
-First, you need to run a Kubernetes cluster locally. We recommend [KinD](https://kind.sigs.k8s.io).
-
-You can create a `kind` cluster by running
-
-```sh
-kind create cluster
-```
-
-This will load your kubernetes config file with the new cluster.
-
-After creating the cluster, you can check the nodes with the code below which should show you the kind-control-plane.
-
-```sh
-kubectl get nodes
-```
-
-The output should look something like below:
-
-```
-$ kubectl get nodes
-NAME                 STATUS   ROLES           AGE   VERSION
-kind-control-plane   Ready    control-plane   32s   v1.32.2
-```
-
-### Install Kubeflow Trainer Components
-
-From here we need to install two components:
-
-1. First, deploy the Kubeflow Trainer controller manager:
-   ```sh
-   kubectl apply --server-side -k "https://github.com/kubeflow/trainer.git/manifests/overlays/manager?ref=master"
-   ```
-
-Ensure that the JobSet and Trainer controller manager pods are running:
-
-```sh
-kubectl get pods -n kubeflow-system
-```
-
-You should see something like:
-
-```
-NAME                                                   READY   STATUS    RESTARTS   AGE
-jobset-controller-manager-694f54749-6tgft              1/1     Running   0          96s
-kubeflow-trainer-controller-manager-678d4bfc86-hqgbv   1/1     Running   0          96s
-```
-
-2. Next, deploy the Kubeflow Training Runtimes:
-   ```sh
-   kubectl apply --server-side -k "https://github.com/kubeflow/trainer.git/manifests/overlays/runtimes?ref=master"
-   ```
-
-
-### Development Workflow
+### Development
 
 The Kubeflow Trainer project includes a Makefile with several helpful commands to streamline your development workflow:
 
@@ -198,8 +93,8 @@ make test-e2e-notebook
 ### Go Development
 When coding:
 
-Follow [effective go](https://go.dev/doc/effective_go) guidelines.
-Run locally [make check](https://github.com/kubeflow/katib/blob/46173463027e4fd2e604e25d7075b2b31a702049/Makefile#L31) to verify if changes follow best practices before submitting PRs.
+Follow the [effective go](https://go.dev/doc/effective_go) guidelines.
+Run [`make check`](https://github.com/kubeflow/katib/blob/46173463027e4fd2e604e25d7075b2b31a702049/Makefile#L31) locally to verify if changes follow best practices before submitting PRs.
 
 When writing tests:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,6 @@ The Kubeflow Trainer project includes a Makefile with several helpful commands t
 ```sh
 # Generate manifests, APIs and SDK
 make generate
-
-# Download required tools for development
-make ginkgo envtest controller-gen kind
-
-# Format and verify code
-make fmt vet golangci-lint
 ```
 
 You can see all available commands by running:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ make test-e2e-notebook
 When coding:
 
 Follow the [effective go](https://go.dev/doc/effective_go) guidelines.
-Run `make check` locally to verify if changes follow best practices before submitting PRs.
+Run [`make generate`](https://github.com/kubeflow/trainer/blob/4e6199c9486d861655a712d7017b8f23f9f2e48e/Makefile#L87) locally to verify if changes follow best practices before submitting PRs.
 
 When writing tests:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ make test-e2e-notebook
 When coding:
 
 Follow the [effective go](https://go.dev/doc/effective_go) guidelines.
-Run [`make check`](https://github.com/kubeflow/katib/blob/46173463027e4fd2e604e25d7075b2b31a702049/Makefile#L31) locally to verify if changes follow best practices before submitting PRs.
+Run [`make check`](https://github.com/kubeflow/katib/blob/) locally to verify if changes follow best practices before submitting PRs.
 
 When writing tests:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ For the Kubeflow Trainer documentation, please check [the official Kubeflow docu
 
 Note for Lima the link is to the Adopters, which supports several different container environments.
 
-### Development
+## Development
 
 The Kubeflow Trainer project includes a Makefile with several helpful commands to streamline your development workflow:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,110 @@ For the Kubeflow Trainer documentation, please check [the official Kubeflow docu
 
 Note for Lima the link is to the Adopters, which supports several different container environments.
 
-## Development
+## Contributing Workflow
+For contributions to the Kubeflow Trainer project, please follow this workflow:
+
+1. Fork the repository on GitHub
+2. Clone your fork locally
+3. Add the upstream remote to keep your fork in sync:
+   ```sh
+   git remote add upstream https://github.com/kubeflow/trainer.git
+   ```
+4. Create a new branch for your changes:
+   ```sh
+   git checkout -b feature/your-feature-name
+   ```
+5. Fetch the latest changes from the upstream repository and rebase your branch:
+   ```sh
+   git fetch upstream
+   git rebase upstream/main
+   ```
+6. Make your changes and commit them:
+   - Install pre-commit hooks before creating commits:
+     ```sh
+     pip install pre-commit
+     pre-commit install
+     ```
+     ```sh
+     git commit -m -s "your commit message"
+     ```
+   - The pre-commit hooks will automatically check your code for style issues
+   - If the hooks fail, fix the issues (if they weren't fixed automatically) and stage your changes again
+   - For more details, see the [Code Style](#code-style) section
+7. Push your changes to your fork and create a pull request (PR)
+
+
+# Building the Operator
+Install dependencies:
+
+```sh
+go mod tidy
+```
+
+Build the library:
+
+```sh
+go install github.com/kubeflow/trainer/cmd/trainer-controller-manager
+```
+
+## Running the Operator Locally
+
+Running the operator locally in a docker container (as opposed to deploying it on a K8s cluster) is convenient for debugging/development.
+
+### Run a Kubernetes cluster
+
+First, you need to run a Kubernetes cluster locally. We recommend [KinD](https://kind.sigs.k8s.io).
+
+You can create a `kind` cluster by running
+
+```sh
+kind create cluster
+```
+
+This will load your kubernetes config file with the new cluster.
+
+After creating the cluster, you can check the nodes with the code below which should show you the kind-control-plane.
+
+```sh
+kubectl get nodes
+```
+
+The output should look something like below:
+
+```
+$ kubectl get nodes
+NAME                 STATUS   ROLES           AGE   VERSION
+kind-control-plane   Ready    control-plane   32s   v1.32.2
+```
+
+### Install Kubeflow Trainer Components
+
+From here we need to install two components:
+
+1. First, deploy the Kubeflow Trainer controller manager:
+   ```sh
+   kubectl apply --server-side -k "https://github.com/kubeflow/trainer.git/manifests/overlays/manager?ref=master"
+   ```
+
+Ensure that the JobSet and Trainer controller manager pods are running:
+
+```sh
+kubectl get pods -n kubeflow-system
+```
+
+You should see something like:
+
+```
+NAME                                                   READY   STATUS    RESTARTS   AGE
+jobset-controller-manager-694f54749-6tgft              1/1     Running   0          96s
+kubeflow-trainer-controller-manager-678d4bfc86-hqgbv   1/1     Running   0          96s
+```
+
+2. Next, deploy the Kubeflow Training Runtimes:
+   ```sh
+   kubectl apply --server-side -k "https://github.com/kubeflow/trainer.git/manifests/overlays/runtimes?ref=master"
+   ```
+
 
 ### Development Workflow
 
@@ -119,8 +222,6 @@ Specific programmatically generated files listed in the `exclude` field in [.pre
 
 
 ## Legacy Setup Instructions
-
-> TODO: The following setup instructions need to be updated for Kubeflow Trainer V2.
 
 #### Manual Setup
 

--- a/Makefile
+++ b/Makefile
@@ -111,10 +111,6 @@ ifeq ($(GOLANGCI_LINT),)
 endif
 	golangci-lint run --timeout 5m --go 1.23 ./...
 
-.PHONY: check
-check: go-mod-download fmt vet golangci-lint ## Run checks for code quality and best practices
-	@echo "All code quality checks passed!"
-
 # Instructions to run tests.
 .PHONY: test
 test: ## Run Go unit test.

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,10 @@ ifeq ($(GOLANGCI_LINT),)
 endif
 	golangci-lint run --timeout 5m --go 1.23 ./...
 
+.PHONY: check
+check: go-mod-download fmt vet golangci-lint ## Run checks for code quality and best practices
+	@echo "All code quality checks passed!"
+
 # Instructions to run tests.
 .PHONY: test
 test: ## Run Go unit test.


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the CONTRIBUTING.md documentation to reflect Kubeflow Trainer V2. This PR updates the contributing [guide](https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md) with accurate and updated installation instructions, contributor workflows. These changes ensure new contributors have proper guidance when developing with Kubeflow Trainer V2. 
NOTE : The update is still incomplete in the commented out parts.

Key changes include:
- Update title and remove TODO note
- Add a more detailed and digestable contributor workflow section
- Update installation paths and commands for the new architecture
- Replace old namespace references (kubeflow → kubeflow-system)
- Update Kubernetes deployment instructions for controller manager and runtimes
- Add notes about JobSet components
- Marked outdated instructions for running sample and local testing with a TODO tag (@andreyvelich I request you to look into this)

**Checklist:**
- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing