### PR TITLE
Release Training Operator Image for v1.9.1

### DIFF
--- a/manifests/overlays/kubeflow/kustomization.yaml
+++ b/manifests/overlays/kubeflow/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - kubeflow-training-roles.yaml
 images:
   - name: ghcr.io/kubeflow/training-v1/training-operator
-    newTag: v1-f654b1e
+    newTag: v1-5c0e763
 # TODO (tenzen-y): Once we support cert-manager, we need to remove this secret generation.
 # REF: https://github.com/kubeflow/training-operator/issues/2049
 secretGenerator:

--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - namespace.yaml
 images:
   - name: ghcr.io/kubeflow/training-v1/training-operator
-    newTag: v1-f654b1e
+    newTag: v1-5c0e763
 secretGenerator:
   - name: training-operator-webhook-cert
     options:


### PR DESCRIPTION
Part of: https://github.com/kubeflow/training-operator/issues/2169
I updated image tag for v1.9.1 release.

/assign @kubeflow/wg-training-leads @Electronic-Waste @saileshd1402 @astefanutti 



