### PR TITLE
chore(docs): Update Slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ to install and get started with Kubeflow Trainer.
 
 The following links provide information on how to get involved in the community:
 
-- Join our [`#kubeflow-training` Slack channel](https://www.kubeflow.org/docs/about/community/#kubeflow-slack).
+- Join our [`#kubeflow-trainer` Slack channel](https://www.kubeflow.org/docs/about/community/#kubeflow-slack).
 - Attend [the bi-weekly AutoML and Training Working Group](https://bit.ly/2PWVCkV) community meeting.
 - Check out [who is using Kubeflow Trainer](ADOPTERS.md).
 


### PR DESCRIPTION
We've updated our Slack channel name.

/assign @kubeflow/wg-training-leads @Electronic-Waste @astefanutti @terrytangyuan 