### PR TITLE
Fix MPI Test runnable errors

### DIFF
--- a/pkg/runtime/framework/plugins/mpi/mpi_test.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi_test.go
@@ -818,7 +818,7 @@ func TestValidate(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to initialize MPI plugin: %v", err)
 			}
-			warnings, errs := p.(framework.CustomValidationPlugin).Validate(nil, tc.info, tc.oldObj, tc.newObj)
+			warnings, errs := p.(framework.CustomValidationPlugin).Validate(tc.info, tc.oldObj, tc.newObj)
 			if diff := gocmp.Diff(tc.wantError, errs); len(diff) != 0 {
 				t.Errorf("Unexpected error from Validate (-want, +got): %s", diff)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

The `Validate()` function is no more acceptable for JobSetTemplate as a dedicated argument. However, when we merge https://github.com/kubeflow/trainer/pull/2555, unfortunately added the no available arguments to our MPI UTs

> ```
> # github.com/kubeflow/trainer/pkg/runtime/framework/plugins/mpi [github.com/kubeflow/trainer/pkg/runtime/framework/plugins/mpi.test]
> Error: pkg/runtime/framework/plugins/mpi/mpi_test.go:821:93: too many arguments in call to p.(framework.CustomValidationPlugin).Validate
> 	have (nil, *"github.com/kubeflow/trainer/pkg/runtime".Info, *"github.com/kubeflow/trainer/pkg/apis/trainer/v1alpha1".TrainJob, *"github.com/kubeflow/trainer/pkg/apis/trainer/v1alpha1".TrainJob)
> 	want (*"github.com/kubeflow/trainer/pkg/runtime".Info, *"github.com/kubeflow/trainer/pkg/apis/trainer/v1alpha1".TrainJob, *"github.com/kubeflow/trainer/pkg/apis/trainer/v1alpha1".TrainJob)
> ```

https://github.com/kubeflow/trainer/actions/runs/14106238715/job/39513354634#step:4:91

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
