### PR TITLE
Remove kubeflow-trainer prefix from jobset resource names

### DIFF
--- a/charts/kubeflow-trainer/values.yaml
+++ b/charts/kubeflow-trainer/values.yaml
@@ -28,6 +28,8 @@ jobset:
   # -- Whether to install jobset as a dependency managed by trainer.
   # This must be set to `false` if jobset controller/webhook has already been installed into the cluster.
   install: true
+  # -- String to fully override jobset release name.
+  fullnameOverride: jobset
 
 # -- Common labels to add to the resources.
 commonLabels: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Remove kubeflow-trainer prefix from jobset resource names.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2595

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing