### PR TITLE
ci: refactor build-push-images workflow

### DIFF
--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -1,14 +1,23 @@
 name: Build and Publish Images
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+      - 'release-*'
+    tags:
+      - 'v*'
+  pull_request:
 
 jobs:
   build-and-publish:
     name: Build and Publish Images
+    if: github.repository == 'kubeflow/trainer'
     runs-on:
       labels: ubuntu-latest-16-cores
+
+    env:
+      SHOULD_PUBLISH: ${{ github.event_name == 'push' }}
 
     strategy:
       fail-fast: false
@@ -36,21 +45,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set publish condition
-        id: publish-condition
-        shell: bash
-        run: |
-          if [[ "${{ github.repository }}" == 'kubeflow/trainer' && \
-                ( "${{ github.ref }}" == 'refs/heads/master' || \
-                  "${{ github.ref }}" =~ ^refs/heads/release- || \
-                  "${{ github.ref }}" =~ ^refs/tags/v ) ]]; then
-            echo "should_publish=true" >> $GITHUB_OUTPUT
-          else
-            echo "should_publish=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: GHCR Login
-        if: steps.publish-condition.outputs.should_publish == 'true'
+        if: env.SHOULD_PUBLISH == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -58,7 +54,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Hub Login
-        if: steps.publish-condition.outputs.should_publish == 'true'
+        if: env.SHOULD_PUBLISH == 'true'
         uses: docker/login-action@v3
         with:
           registry: docker.io
@@ -66,7 +62,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Publish Component ${{ matrix.component-name }}
-        if: steps.publish-condition.outputs.should_publish == 'true'
+        if: env.SHOULD_PUBLISH == 'true'
         id: publish
         uses: ./.github/workflows/template-publish-image
         with:
@@ -79,7 +75,7 @@ jobs:
           push: true
 
       - name: Test Build For Component ${{ matrix.component-name }}
-        if: steps.publish-condition.outputs.should_publish != 'true'
+        if: env.SHOULD_PUBLISH != 'true'
         uses: ./.github/workflows/template-publish-image
         with:
           image: |


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
~Splits GHA Workflows for Build and Publish.~
~This refactors actions by splitting the image handling into two separate workflows:~

~1. **Build Images** - Runs on PRs to validate Docker builds without publishing~
~2. **Publish Images** - Runs on master/release branches and version tags to build and publish images~

* Adds a condition at the job to make it run only on `kubeflow/trainer` repo 
  * Earlier this action was failing in forked repo due to unavailability of `ubuntu-latest-16-cores` runners which results in failure
* Publishing logic only when event is `push` 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2601

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
