### PR TITLE
fix: remove redundant K8s version matrix from integration tests

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -53,12 +53,6 @@ jobs:
       run:
         working-directory: ${{ env.GOPATH }}/src/github.com/kubeflow/trainer
 
-    strategy:
-      fail-fast: false
-      matrix:
-        # Kubernetes versions for setup-envtest integration tests.
-        kubernetes-version: ["1.29.3", "1.30.0", "1.31.0", "1.32.0"]
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -76,7 +70,7 @@ jobs:
 
       - name: Run Go integration tests
         run: |
-          make test-integration K8S_VERSION=${{ matrix.kubernetes-version }}
+          make test-integration
 
       - name: Coveralls report
         uses: shogo82148/actions-goveralls@v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2616 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
