### PR TITLE
Update Go to v1.24 (#2615)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ For the Kubeflow Trainer documentation, please check [the official Kubeflow docu
 
 ## Requirements
 
-- [Go](https://golang.org/) (1.23 or later)
+- [Go](https://golang.org/) (1.24 or later)
 - [Docker](https://docs.docker.com/) (23 or later)
 - [Lima](https://github.com/lima-vm/lima?tab=readme-ov-file#adopters) (an alternative to DockerDesktop) (0.21.0 or later)
   - [Colima](https://github.com/abiosoft/colima) (Lima specifically for MacOS) (0.6.8 or later)
@@ -26,6 +26,7 @@ make generate
 ```
 
 You can see all available commands by running:
+
 ```sh
 make help
 ```
@@ -76,15 +77,16 @@ Run the end-to-end tests with:
 make test-e2e
 ```
 
-
 You can also run Jupyter notebook tests with Papermill:
 
 ```sh
 make test-e2e-notebook
 ```
+
 ## Best Practices
 
 ### Go Development
+
 When coding:
 
 Follow the [effective go](https://go.dev/doc/effective_go) guidelines.
@@ -99,7 +101,6 @@ On ubuntu the default go package appears to be gccgo-go which has problems. It's
 
 ## Code Style
 
-
 ### pre-commit
 
 Make sure to install [pre-commit](https://pre-commit.com/) (`pip install pre-commit`) and run `pre-commit install` from the root of the repository at least once before creating git commits.
@@ -108,11 +109,9 @@ The pre-commit hooks ensure code quality and consistency. They are executed in C
 
 Specific programmatically generated files listed in the `exclude` field in [.pre-commit-config.yaml](../../.pre-commit-config.yaml) are deliberately excluded from the hooks.
 
-
-
 ## Legacy Setup Instructions
 
-#### Manual Setup
+### Manual Setup
 
 Create a symbolic link inside your GOPATH to the location you checked out the code:
 
@@ -190,11 +189,13 @@ spec:
 ```
 
 Apply the job:
+
 ```sh
 kubectl apply -f pytorch-job.yaml
 ```
 
 Check the job status:
+
 ```sh
 kubectl get trainjobs
 kubectl describe trainjob pytorch-mnist-example

--- a/Makefile
+++ b/Makefile
@@ -140,10 +140,10 @@ GOLANGCI_LINT=$(shell which golangci-lint)
 .PHONY: golangci-lint
 golangci-lint: ## Run golangci-lint to verify Go files.
 ifeq ($(GOLANGCI_LINT),)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.61.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.64.8
 	$(info golangci-lint has been installed)
 endif
-	golangci-lint run --timeout 5m --go 1.23 ./...
+	golangci-lint run --timeout 5m --go 1.24 ./...
 
 # Instructions to run tests.
 .PHONY: test

--- a/cmd/trainer-controller-manager/Dockerfile
+++ b/cmd/trainer-controller-manager/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/trainer
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

- Update Go from v1.23 to v1.24
- Update golangci-lint from v1.61.0 to v1.64.8
- Fix formatting in CONTRIBUTING.md

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #2615 

**Checklist:**

- [x] Upgrade Go module version to `1.24.0` in `go.mod`
- [x] Upgrade Go version to `1.24` in `Dockerfile`
- [x] Upgrade golangci-lint version to v1.64.8 in `Makefile`
- [x] Upgrade Go version to `1.24` in `Makefile`
- [x] Upgrade Go version to `1.24` in `CONTRIBUTING.md`
- [x] Fix formatting in `CONTRIBUTING.md`
