### PR TITLE
Remove TrainJobCreated condition

### DIFF
--- a/docs/proposals/2170-kubeflow-trainer-v2/README.md
+++ b/docs/proposals/2170-kubeflow-trainer-v2/README.md
@@ -286,9 +286,6 @@ const (
 
 	// TrainJobFailed means that the actual jobs have failed its execution.
 	TrainJobFailed string = "Failed"
-
-	// TrainJobCreated means that the actual jobs creation has succeeded.
-	TrainJobCreated string = "Created"
 )
 
 const (
@@ -299,19 +296,6 @@ const (
 	// TrainJobResumedReason is the "Suspended" condition reason.
 	// When the TrainJob suspension is changed from True to False, this is added.
 	TrainJobResumedReason string = "Resumed"
-
-	// TrainJobJobsCreationSucceededReason is the "Created" condition reason.
-	// When the creating objects succeeded after building succeeded, this is added.
-	TrainJobJobsCreationSucceededReason string = "JobsCreationSucceeded"
-
-	// TrainJobJobsBuildFailedReason is the "Created" condition reason.
-	// When the building objects based on the TrainJob and the specified runtime failed,
-	// this is added.
-	TrainJobJobsBuildFailedReason string = "JobsBuildFailed"
-
-	// TrainJobJobsCreationFailedReason is "Created" condition reason.
-	// When the creating objects failed even though building succeeded, this is added.
-	TrainJobJobsCreationFailedReason string = "JobsCreationFailed"
 )
 
 

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -61,13 +61,17 @@ const (
 )
 
 const (
-	// TrainJobSuspendedReason is the "Suspended" condition reason.
-	// When the TrainJob is suspended, this is added.
+	// TrainJobSuspendedReason is the "Suspended" condition reason
+	// when the TrainJob is suspended.
 	TrainJobSuspendedReason string = "Suspended"
 
-	// TrainJobResumedReason is the "Suspended" condition reason.
-	// When the TrainJob suspension is changed from True to False, this is added.
+	// TrainJobResumedReason is the "Suspended" condition reason
+	// when the TrainJob suspension is changed from True to False.
 	TrainJobResumedReason string = "Resumed"
+
+	// TrainJobRuntimeCreationFailedReason is the "Failed" condition reason
+	// when the creation of the runtime resources failed.
+	TrainJobRuntimeCreationFailedReason string = "RuntimeCreationFailed"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -58,9 +58,6 @@ const (
 
 	// TrainJobFailed means that the actual jobs have failed its execution.
 	TrainJobFailed string = "Failed"
-
-	// TrainJobCreated means that the actual jobs creation has succeeded.
-	TrainJobCreated string = "Created"
 )
 
 const (
@@ -71,19 +68,6 @@ const (
 	// TrainJobResumedReason is the "Suspended" condition reason.
 	// When the TrainJob suspension is changed from True to False, this is added.
 	TrainJobResumedReason string = "Resumed"
-
-	// TrainJobJobsCreationSucceededReason is the "Created" condition reason.
-	// When the creating objects succeeded after building succeeded, this is added.
-	TrainJobJobsCreationSucceededReason string = "JobsCreationSucceeded"
-
-	// TrainJobJobsBuildFailedReason is the "Created" condition reason.
-	// When the building objects based on the TrainJob and the specified runtime failed,
-	// this is added.
-	TrainJobJobsBuildFailedReason string = "JobsBuildFailed"
-
-	// TrainJobJobsCreationFailedReason is the "Created" condition reason.
-	// When the creating objects failed even though building succeeded, this is added.
-	TrainJobJobsCreationFailedReason string = "JobsCreationFailed"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -69,9 +69,9 @@ const (
 	// when the TrainJob suspension is changed from True to False.
 	TrainJobResumedReason string = "Resumed"
 
-	// TrainJobRuntimeCreationFailedReason is the "Failed" condition reason
-	// when the creation of the runtime resources failed.
-	TrainJobRuntimeCreationFailedReason string = "RuntimeCreationFailed"
+	// TrainJobRuntimeNotSupportedReason is the "Failed" condition reason
+	// when the referenced TrainingRuntime is not supported.
+	TrainJobRuntimeNotSupportedReason string = "TrainingRuntimeNotSupported"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -49,18 +49,6 @@ const (
 	// PodGroupKind is the Kind name for the PodGroup.
 	PodGroupKind string = "PodGroup"
 
-	// TrainJobJobsCreationSucceededMessage is status condition message for the
-	// {"type": "Created", "status": "True", "reason": "JobsCreationSucceeded"} condition.
-	TrainJobJobsCreationSucceededMessage = "Succeeded to create Jobs"
-
-	// TrainJobJobsBuildFailedMessage is status condition message for the
-	// {"type": "Created", "status": "True", "reason": "JobsBuildFailed"} condition.
-	TrainJobJobsBuildFailedMessage = "Failed to build Jobs"
-
-	// TrainJobJobsCreationFailedMessage is status condition message for the
-	// {"type": "Created", "status": "True", "reason": "JobsCreationFailed"} condition.
-	TrainJobJobsCreationFailedMessage = "Failed to create Jobs"
-
 	// TrainJobSuspendedMessage is status condition message for the
 	// {"type": "Suspended", "status": "True", "reason": "Suspended"} condition.
 	TrainJobSuspendedMessage = "TrainJob is suspended"

--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -128,8 +128,11 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			//  the creation of the runtime resources failed and the TrainJob is backed off until
 			//  the next retry attempt.
 			// The event message is truncated to stay within the maximum length limit (1024 chars).
-			r.recorder.Eventf(&trainJob, corev1.EventTypeWarning, "TrainJobResourcesCreationFailed",
-				"TrainJob resources reconciliation failed: %.950v", err.Error())
+			message := fmt.Sprintf("TrainJob resources reconciliation failed: %.950v", err.Error())
+			if len(err.Error()) > 950 {
+				message = fmt.Sprintf("%s ...", message)
+			}
+			r.recorder.Event(&trainJob, corev1.EventTypeWarning, "TrainJobResourcesCreationFailed", message)
 		}
 	}
 

--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -127,8 +127,8 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			// TODO (astefanutti): the error should be surfaced in the TrainJob status to indicate
 			//  the creation of the runtime resources failed and the TrainJob is backed off until
 			//  the next retry attempt.
-			r.recorder.Eventf(&trainJob, corev1.EventTypeWarning, "TrainJobReconcileFailed",
-				"Runtime resources reconciliation failed: %v", err.Error())
+			r.recorder.Eventf(&trainJob, corev1.EventTypeWarning, "TrainJobResourcesCreationFailed",
+				"TrainJob resources reconciliation failed: %v", err.Error())
 		}
 	}
 

--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -127,8 +127,9 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			// TODO (astefanutti): the error should be surfaced in the TrainJob status to indicate
 			//  the creation of the runtime resources failed and the TrainJob is backed off until
 			//  the next retry attempt.
+			// The event message is truncated to stay within the maximum length limit (1024 chars).
 			r.recorder.Eventf(&trainJob, corev1.EventTypeWarning, "TrainJobResourcesCreationFailed",
-				"TrainJob resources reconciliation failed: %v", err.Error())
+				"TrainJob resources reconciliation failed: %.950v", err.Error())
 		}
 	}
 

--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -512,15 +512,15 @@ class TrainerClient:
 
         # Add the TrainJob status.
         # TODO (andreyvelich): Discuss how we should show TrainJob status to SDK users.
+        # The TrainJob exists at that stage so its status can safely default to Created
+        trainjob.status = constants.TRAINJOB_CREATED
+        # Then it can be read from the TrainJob conditions if any
         if trainjob_crd.status and trainjob_crd.status.conditions:
-            # The TrainJob exists at that stage so its status can safely default to Created
-            status = constants.TRAINJOB_CREATED
             for c in trainjob_crd.status.conditions:
                 if c.type == "Complete" and c.status == "True":
-                    status = "Succeeded"
+                    trainjob.status = "Succeeded"
                 elif c.type == "Failed" and c.status == "True":
-                    status = "Failed"
-            trainjob.status = status
+                    trainjob.status = "Failed"
 
         # Select Pods created by the appropriate JobSet. It checks the following ReplicatedJob.name:
         # dataset-initializer, model-initializer, launcher, node.

--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -513,10 +513,10 @@ class TrainerClient:
         # Add the TrainJob status.
         # TODO (andreyvelich): Discuss how we should show TrainJob status to SDK users.
         if trainjob_crd.status and trainjob_crd.status.conditions:
+            # The TrainJob exists at that stage so its status can safely default to Created
+            status = constants.TRAINJOB_CREATED
             for c in trainjob_crd.status.conditions:
-                if c.type == "Created" and c.status == "True":
-                    status = "Created"
-                elif c.type == "Complete" and c.status == "True":
+                if c.type == "Complete" and c.status == "True":
                     status = "Succeeded"
                 elif c.type == "Failed" and c.status == "True":
                     status = "Failed"

--- a/sdk/kubeflow/trainer/constants/constants.py
+++ b/sdk/kubeflow/trainer/constants/constants.py
@@ -37,6 +37,9 @@ TRAINJOB_KIND = "TrainJob"
 # The plural for the TrainJob.
 TRAINJOB_PLURAL = "trainjobs"
 
+# The default status for the TrainJob.
+TRAINJOB_CREATED = "Created"
+
 # The label key to identify the relationship between TrainJob and Pod template in the runtime.
 # For example, what PodTemplate must be overridden by TrainJob's .spec.trainer APIs.
 TRAINJOB_ANCESTOR_LABEL = "trainer.kubeflow.org/trainjob-ancestor-step"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -9,7 +9,6 @@ import (
 	jobsetconsts "sigs.k8s.io/jobset/pkg/constants"
 
 	trainer "github.com/kubeflow/trainer/pkg/apis/trainer/v1alpha1"
-	"github.com/kubeflow/trainer/pkg/constants"
 	testingutil "github.com/kubeflow/trainer/pkg/util/testing"
 	"github.com/kubeflow/trainer/test/util"
 )
@@ -64,12 +63,6 @@ var _ = ginkgo.Describe("TrainJob e2e", func() {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainJob), gotTrainJob)).Should(gomega.Succeed())
 					g.Expect(gotTrainJob.Status.Conditions).Should(gomega.BeComparableTo([]metav1.Condition{
 						{
-							Type:    trainer.TrainJobCreated,
-							Status:  metav1.ConditionTrue,
-							Reason:  trainer.TrainJobJobsCreationSucceededReason,
-							Message: constants.TrainJobJobsCreationSucceededMessage,
-						},
-						{
 							Type:    trainer.TrainJobComplete,
 							Status:  metav1.ConditionTrue,
 							Reason:  jobsetconsts.AllJobsCompletedReason,
@@ -97,12 +90,6 @@ var _ = ginkgo.Describe("TrainJob e2e", func() {
 					gotTrainJob := &trainer.TrainJob{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainJob), gotTrainJob)).Should(gomega.Succeed())
 					g.Expect(gotTrainJob.Status.Conditions).Should(gomega.BeComparableTo([]metav1.Condition{
-						{
-							Type:    trainer.TrainJobCreated,
-							Status:  metav1.ConditionTrue,
-							Reason:  trainer.TrainJobJobsCreationSucceededReason,
-							Message: constants.TrainJobJobsCreationSucceededMessage,
-						},
 						{
 							Type:    trainer.TrainJobComplete,
 							Status:  metav1.ConditionTrue,

--- a/test/integration/controller/trainjob_controller_test.go
+++ b/test/integration/controller/trainjob_controller_test.go
@@ -423,12 +423,6 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 							Reason:  trainer.TrainJobSuspendedReason,
 							Message: constants.TrainJobSuspendedMessage,
 						},
-						{
-							Type:    trainer.TrainJobCreated,
-							Status:  metav1.ConditionTrue,
-							Reason:  trainer.TrainJobJobsCreationSucceededReason,
-							Message: constants.TrainJobJobsCreationSucceededMessage,
-						},
 					}, util.IgnoreConditions))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -445,12 +439,6 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 							Status:  metav1.ConditionFalse,
 							Reason:  trainer.TrainJobResumedReason,
 							Message: constants.TrainJobResumedMessage,
-						},
-						{
-							Type:    trainer.TrainJobCreated,
-							Status:  metav1.ConditionTrue,
-							Reason:  trainer.TrainJobJobsCreationSucceededReason,
-							Message: constants.TrainJobJobsCreationSucceededMessage,
 						},
 					}, util.IgnoreConditions))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -478,12 +466,6 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 							Status:  metav1.ConditionFalse,
 							Reason:  trainer.TrainJobResumedReason,
 							Message: constants.TrainJobResumedMessage,
-						},
-						{
-							Type:    trainer.TrainJobCreated,
-							Status:  metav1.ConditionTrue,
-							Reason:  trainer.TrainJobJobsCreationSucceededReason,
-							Message: constants.TrainJobJobsCreationSucceededMessage,
 						},
 						{
 							Type:    trainer.TrainJobComplete,
@@ -528,12 +510,6 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 							Reason:  trainer.TrainJobResumedReason,
 							Message: constants.TrainJobResumedMessage,
 						},
-						{
-							Type:    trainer.TrainJobCreated,
-							Status:  metav1.ConditionTrue,
-							Reason:  trainer.TrainJobJobsCreationSucceededReason,
-							Message: constants.TrainJobJobsCreationSucceededMessage,
-						},
 					}, util.IgnoreConditions))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -560,12 +536,6 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 							Status:  metav1.ConditionFalse,
 							Reason:  trainer.TrainJobResumedReason,
 							Message: constants.TrainJobResumedMessage,
-						},
-						{
-							Type:    trainer.TrainJobCreated,
-							Status:  metav1.ConditionTrue,
-							Reason:  trainer.TrainJobJobsCreationSucceededReason,
-							Message: constants.TrainJobJobsCreationSucceededMessage,
 						},
 						{
 							Type:    trainer.TrainJobFailed,
@@ -799,12 +769,6 @@ alpha-node-0-1.alpha slots=8
 							Reason:  trainer.TrainJobSuspendedReason,
 							Message: constants.TrainJobSuspendedMessage,
 						},
-						{
-							Type:    trainer.TrainJobCreated,
-							Status:  metav1.ConditionTrue,
-							Reason:  trainer.TrainJobJobsCreationSucceededReason,
-							Message: constants.TrainJobJobsCreationSucceededMessage,
-						},
 					}, util.IgnoreConditions))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -821,12 +785,6 @@ alpha-node-0-1.alpha slots=8
 							Status:  metav1.ConditionFalse,
 							Reason:  trainer.TrainJobResumedReason,
 							Message: constants.TrainJobResumedMessage,
-						},
-						{
-							Type:    trainer.TrainJobCreated,
-							Status:  metav1.ConditionTrue,
-							Reason:  trainer.TrainJobJobsCreationSucceededReason,
-							Message: constants.TrainJobJobsCreationSucceededMessage,
 						},
 					}, util.IgnoreConditions))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -854,12 +812,6 @@ alpha-node-0-1.alpha slots=8
 							Status:  metav1.ConditionFalse,
 							Reason:  trainer.TrainJobResumedReason,
 							Message: constants.TrainJobResumedMessage,
-						},
-						{
-							Type:    trainer.TrainJobCreated,
-							Status:  metav1.ConditionTrue,
-							Reason:  trainer.TrainJobJobsCreationSucceededReason,
-							Message: constants.TrainJobJobsCreationSucceededMessage,
 						},
 						{
 							Type:    trainer.TrainJobComplete,
@@ -905,12 +857,6 @@ alpha-node-0-1.alpha slots=8
 							Reason:  trainer.TrainJobResumedReason,
 							Message: constants.TrainJobResumedMessage,
 						},
-						{
-							Type:    trainer.TrainJobCreated,
-							Status:  metav1.ConditionTrue,
-							Reason:  trainer.TrainJobJobsCreationSucceededReason,
-							Message: constants.TrainJobJobsCreationSucceededMessage,
-						},
 					}, util.IgnoreConditions))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -937,12 +883,6 @@ alpha-node-0-1.alpha slots=8
 							Status:  metav1.ConditionFalse,
 							Reason:  trainer.TrainJobResumedReason,
 							Message: constants.TrainJobResumedMessage,
-						},
-						{
-							Type:    trainer.TrainJobCreated,
-							Status:  metav1.ConditionTrue,
-							Reason:  trainer.TrainJobJobsCreationSucceededReason,
-							Message: constants.TrainJobJobsCreationSucceededMessage,
 						},
 						{
 							Type:    trainer.TrainJobFailed,


### PR DESCRIPTION
This removes the `TrainJobCreated` condition.

**What this PR does / why we need it**:

The `TrainJobCreated` condition will be revisited with #2459.

To avoid any backward incompatible changes once there is an agreement on the new condition(s), we've decided to remove it for now as discussed in https://github.com/kubeflow/trainer/issues/2459#issuecomment-2822457310.

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
