### PR TITLE
Fix close-pr message in Stale GitHub Action

### DIFF
--- a/.github/workflows/github-stale.yaml
+++ b/.github/workflows/github-stale.yaml
@@ -36,8 +36,7 @@ jobs:
             recent activity. It will be closed if no further activity occurs. Thank you
             for your contributions.
           close-pr-message: >
-            This pull request has been automatically marked as stale because it has not had
-            recent activity. It will be closed if no further activity occurs. Thank you
-            for your contributions.
+            This pull request has been automatically closed because it has not had recent
+            activity. Please comment "/reopen" to reopen it.
           stale-pr-label: lifecycle/stale
           exempt-pr-labels: lifecycle/frozen


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Update the message shown when a PR is closed due to inactivity via Stale GitHub action

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
