### PR TITLE
Implement trainer.kubeflow.org/resource-in-use finalizer mechanism to ClusterTrainingRuntime

### DIFF
--- a/manifests/base/rbac/role.yaml
+++ b/manifests/base/rbac/role.yaml
@@ -59,6 +59,7 @@ rules:
 - apiGroups:
   - trainer.kubeflow.org
   resources:
+  - clustertrainingruntimes/finalizers
   - trainingruntimes/finalizers
   - trainjobs/finalizers
   - trainjobs/status

--- a/pkg/controller/clustertrainingruntime_controller.go
+++ b/pkg/controller/clustertrainingruntime_controller.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2025 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"iter"
+	"slices"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	trainer "github.com/kubeflow/trainer/pkg/apis/trainer/v1alpha1"
+	"github.com/kubeflow/trainer/pkg/constants"
+	idxer "github.com/kubeflow/trainer/pkg/runtime/indexer"
+	"github.com/kubeflow/trainer/pkg/util/trainjob"
+)
+
+type ClusterTrainingRuntimeReconciler struct {
+	log                        logr.Logger
+	client                     client.Client
+	recorder                   record.EventRecorder
+	nonClRuntimeObjectUpdateCh chan event.TypedGenericEvent[iter.Seq[types.NamespacedName]]
+}
+
+var _ reconcile.Reconciler = (*ClusterTrainingRuntimeReconciler)(nil)
+var _ TrainJobWatcher = (*ClusterTrainingRuntimeReconciler)(nil)
+
+func NewClusterTrainingRuntimeReconciler(cli client.Client, recorder record.EventRecorder) *ClusterTrainingRuntimeReconciler {
+	return &ClusterTrainingRuntimeReconciler{
+		log:                        ctrl.Log.WithName("clustertrainingruntime-controller"),
+		client:                     cli,
+		recorder:                   recorder,
+		nonClRuntimeObjectUpdateCh: make(chan event.TypedGenericEvent[iter.Seq[types.NamespacedName]], updateChBuffer),
+	}
+}
+
+// +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=clustertrainingruntimes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=clustertrainingruntimes/finalizers,verbs=get;update;patch
+
+func (r *ClusterTrainingRuntimeReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	var clRuntime trainer.ClusterTrainingRuntime
+	if err := r.client.Get(ctx, request.NamespacedName, &clRuntime); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	log := r.log.WithValues("clusterTrainingRuntime", klog.KObj(&clRuntime))
+	ctrl.LoggerInto(ctx, log)
+	log.V(2).Info("Reconciling ClusterTrainingRuntime")
+
+	trainJobs := &trainer.TrainJobList{}
+	if err := r.client.List(ctx, trainJobs, client.MatchingFields{
+		idxer.TrainJobClusterRuntimeRefKey: clRuntime.Name,
+	}); err != nil {
+		return ctrl.Result{}, err
+	}
+	if !ctrlutil.ContainsFinalizer(&clRuntime, constants.ResourceInUseFinalizer) && len(trainJobs.Items) != 0 {
+		ctrlutil.AddFinalizer(&clRuntime, constants.ResourceInUseFinalizer)
+		return ctrl.Result{}, r.client.Update(ctx, &clRuntime)
+	} else if !clRuntime.DeletionTimestamp.IsZero() && len(trainJobs.Items) == 0 {
+		ctrlutil.RemoveFinalizer(&clRuntime, constants.ResourceInUseFinalizer)
+		return ctrl.Result{}, r.client.Update(ctx, &clRuntime)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ClusterTrainingRuntimeReconciler) NotifyTrainJobUpdate(oldJob, newJob *trainer.TrainJob) {
+	var clRuntimeNSName *types.NamespacedName
+	switch {
+	case oldJob != nil && newJob != nil:
+		// UPDATE Event.
+		if trainjob.RuntimeRefIsClusterTrainingRuntime(newJob.Spec.RuntimeRef) {
+			clRuntimeNSName = &types.NamespacedName{Name: newJob.Spec.RuntimeRef.Name}
+		}
+	case oldJob == nil:
+		// CREATE Event.
+		if trainjob.RuntimeRefIsClusterTrainingRuntime(newJob.Spec.RuntimeRef) {
+			clRuntimeNSName = &types.NamespacedName{Name: newJob.Spec.RuntimeRef.Name}
+		}
+	default:
+		// DELETE Event.
+		if trainjob.RuntimeRefIsClusterTrainingRuntime(oldJob.Spec.RuntimeRef) {
+			clRuntimeNSName = &types.NamespacedName{Name: oldJob.Spec.RuntimeRef.Name}
+		}
+	}
+	if clRuntimeNSName != nil {
+		r.nonClRuntimeObjectUpdateCh <- event.TypedGenericEvent[iter.Seq[types.NamespacedName]]{
+			Object: slices.Values([]types.NamespacedName{*clRuntimeNSName}),
+		}
+	}
+}
+
+type nonClRuntimeObjectHandler struct{}
+
+var _ handler.TypedEventHandler[iter.Seq[types.NamespacedName], reconcile.Request] = (*nonClRuntimeObjectHandler)(nil)
+
+func (h *nonClRuntimeObjectHandler) Create(context.Context, event.TypedCreateEvent[iter.Seq[types.NamespacedName]], workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+func (h *nonClRuntimeObjectHandler) Update(context.Context, event.TypedUpdateEvent[iter.Seq[types.NamespacedName]], workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+func (h *nonClRuntimeObjectHandler) Delete(context.Context, event.TypedDeleteEvent[iter.Seq[types.NamespacedName]], workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+func (h *nonClRuntimeObjectHandler) Generic(_ context.Context, e event.TypedGenericEvent[iter.Seq[types.NamespacedName]], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	for nsName := range e.Object {
+		q.AddAfter(reconcile.Request{NamespacedName: nsName}, time.Second)
+	}
+}
+
+func (r *ClusterTrainingRuntimeReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
+	return builder.TypedControllerManagedBy[reconcile.Request](mgr).
+		Named("clustertrainingruntime_controller").
+		WithOptions(options).
+		WatchesRawSource(source.TypedKind(
+			mgr.GetCache(),
+			&trainer.ClusterTrainingRuntime{},
+			&handler.TypedEnqueueRequestForObject[*trainer.ClusterTrainingRuntime]{},
+		)).
+		WatchesRawSource(source.Channel(r.nonClRuntimeObjectUpdateCh, &nonClRuntimeObjectHandler{})).
+		Complete(r)
+}

--- a/pkg/controller/clustertrainingruntime_controller_test.go
+++ b/pkg/controller/clustertrainingruntime_controller_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2025 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2/ktesting"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	trainer "github.com/kubeflow/trainer/pkg/apis/trainer/v1alpha1"
+	"github.com/kubeflow/trainer/pkg/constants"
+	idxer "github.com/kubeflow/trainer/pkg/runtime/indexer"
+	utiltesting "github.com/kubeflow/trainer/pkg/util/testing"
+)
+
+func TestReconcile_ClusterTrainingRuntimeReconciler(t *testing.T) {
+	errorFailedGetClusterTrainingRuntime := errors.New("TEST: failed to get ClusterTrainingRuntime")
+	cases := map[string]struct {
+		trainJobs             trainer.TrainJobList
+		clTrainingRuntime     *trainer.ClusterTrainingRuntime
+		wantClTrainingRuntime *trainer.ClusterTrainingRuntime
+		wantError             error
+	}{
+		"no action when clusterTrainingRuntime with finalizer does not being deleted": {
+			clTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
+				Finalizers(constants.ResourceInUseFinalizer).
+				Obj(),
+			wantClTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
+				Finalizers(constants.ResourceInUseFinalizer).
+				Obj(),
+		},
+		"remove clusterTrainingRuntime due to removed finalizers when runtime without finalizer is deleting": {
+			clTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
+				Finalizers(constants.ResourceInUseFinalizer).
+				DeletionTimestamp(metav1.Now()).
+				Obj(),
+			wantError:             errorFailedGetClusterTrainingRuntime,
+			wantClTrainingRuntime: &trainer.ClusterTrainingRuntime{},
+		},
+		"add finalizer when clusterTrainingRuntime is used by trainJob": {
+			clTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
+				Obj(),
+			trainJobs: trainer.TrainJobList{
+				Items: []trainer.TrainJob{
+					*utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "trainJob").
+						RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "runtime").
+						Obj(),
+				},
+			},
+			wantClTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
+				Finalizers(constants.ResourceInUseFinalizer).
+				Obj(),
+		},
+		"no action when all TrainJobs use another ClusterTrainingRuntime": {
+			clTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
+				Obj(),
+			trainJobs: trainer.TrainJobList{
+				Items: []trainer.TrainJob{
+					*utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "trainJob").
+						RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "another").
+						Obj(),
+				},
+			},
+			wantClTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
+				Obj(),
+		},
+		"no action when runtime without finalizer is not used by any TrainJob": {
+			clTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
+				Obj(),
+			wantClTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
+				Obj(),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			var cancel func()
+			ctx, cancel = context.WithCancel(ctx)
+			t.Cleanup(cancel)
+			cli := utiltesting.NewClientBuilder().
+				WithObjects(tc.clTrainingRuntime).
+				WithLists(&tc.trainJobs).
+				WithIndex(&trainer.TrainJob{}, idxer.TrainJobClusterRuntimeRefKey, idxer.IndexTrainJobClusterTrainingRuntime).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, cli client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*trainer.TrainJob); !ok && errors.Is(tc.wantError, errorFailedGetClusterTrainingRuntime) {
+							return errorFailedGetClusterTrainingRuntime
+						}
+						return cli.Get(ctx, key, obj, opts...)
+					},
+				}).
+				Build()
+			r := NewClusterTrainingRuntimeReconciler(cli, nil)
+			clRuntimeKey := client.ObjectKeyFromObject(tc.clTrainingRuntime)
+			_, gotError := r.Reconcile(ctx, reconcile.Request{NamespacedName: clRuntimeKey})
+			if diff := cmp.Diff(tc.wantError, gotError, cmpopts.EquateErrors()); len(diff) != 0 {
+				t.Errorf("Unexpected Reconcile error (-want, +got): \n%s", diff)
+			}
+			var gotClRuntime trainer.ClusterTrainingRuntime
+			gotError = cli.Get(ctx, clRuntimeKey, &gotClRuntime)
+			if diff := cmp.Diff(tc.wantError, gotError, cmpopts.EquateErrors()); len(diff) != 0 {
+				t.Errorf("Unexpected GET error (-want, +got): \n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantClTrainingRuntime, &gotClRuntime,
+				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
+			); len(diff) != 0 {
+				t.Errorf("Unexpected ClusterTrainingRuntime: (-want, +got): \n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNotifyTrainJobUpdate_ClusterTrainingRuntimeReconciler(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		oldJob    *trainer.TrainJob
+		newJob    *trainer.TrainJob
+		wantEvent event.TypedGenericEvent[iter.Seq[types.NamespacedName]]
+	}{
+		"UPDATE Event: runtimeRef is ClusterTrainingRuntime": {
+			oldJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
+				Obj(),
+			newJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
+				SpecLabel("key", "value").
+				Obj(),
+			wantEvent: event.TypedGenericEvent[iter.Seq[types.NamespacedName]]{
+				Object: func(yield func(types.NamespacedName) bool) {
+					yield(types.NamespacedName{Name: "test-runtime"})
+				},
+			},
+		},
+		"UPDATE Event: runtimeRef is not ClusterTrainingRuntime": {
+			oldJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
+				Obj(),
+			newJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
+				SpecLabel("key", "value").
+				Obj(),
+		},
+		"CREATE Event: runtimeRef is ClusterTrainingRuntime": {
+			newJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
+				Obj(),
+			wantEvent: event.TypedGenericEvent[iter.Seq[types.NamespacedName]]{
+				Object: func(yield func(types.NamespacedName) bool) {
+					yield(types.NamespacedName{Name: "test-runtime"})
+				},
+			},
+		},
+		"CREATE Event: runtimeRef is not ClusterTrainingRuntime": {
+			newJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
+				Obj(),
+		},
+		"DELETE Event: runtimeRef is ClusterTrainingRuntime": {
+			oldJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
+				Obj(),
+			wantEvent: event.TypedGenericEvent[iter.Seq[types.NamespacedName]]{
+				Object: func(yield func(types.NamespacedName) bool) {
+					yield(types.NamespacedName{Name: "test-runtime"})
+				},
+			},
+		},
+		"DELETE Event: runtimeRef is not ClusterTrainingRuntime": {
+			oldJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
+				Obj(),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			logger, _ := ktesting.NewTestContext(t)
+			updateCh := make(chan event.TypedGenericEvent[iter.Seq[types.NamespacedName]], 1)
+			t.Cleanup(func() {
+				close(updateCh)
+			})
+			r := &ClusterTrainingRuntimeReconciler{
+				log:                        logger,
+				nonClRuntimeObjectUpdateCh: updateCh,
+			}
+			r.NotifyTrainJobUpdate(tc.oldJob, tc.newJob)
+			var got event.TypedGenericEvent[iter.Seq[types.NamespacedName]]
+			select {
+			case got = <-updateCh:
+			case <-time.After(time.Second):
+			}
+			if diff := cmp.Diff(tc.wantEvent, got, utiltesting.TrainJobUpdateReconcileRequestCmpOpts); len(diff) != 0 {
+				t.Errorf("Unexpected GenericEvent (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/util/testing/wrapper.go
+++ b/pkg/util/testing/wrapper.go
@@ -874,6 +874,16 @@ func MakeClusterTrainingRuntimeWrapper(name string) *ClusterTrainingRuntimeWrapp
 	}
 }
 
+func (r *ClusterTrainingRuntimeWrapper) Finalizers(f ...string) *ClusterTrainingRuntimeWrapper {
+	r.ObjectMeta.Finalizers = append(r.ObjectMeta.Finalizers, f...)
+	return r
+}
+
+func (r *ClusterTrainingRuntimeWrapper) DeletionTimestamp(t metav1.Time) *ClusterTrainingRuntimeWrapper {
+	r.ObjectMeta.DeletionTimestamp = &t
+	return r
+}
+
 func (r *ClusterTrainingRuntimeWrapper) RuntimeSpec(spec trainer.TrainingRuntimeSpec) *ClusterTrainingRuntimeWrapper {
 	r.Spec = spec
 	return r

--- a/pkg/util/trainjob/trainjob.go
+++ b/pkg/util/trainjob/trainjob.go
@@ -26,3 +26,8 @@ func RuntimeRefIsTrainingRuntime(ref trainer.RuntimeRef) bool {
 	return ptr.Equal(ref.APIGroup, &trainer.GroupVersion.Group) &&
 		ptr.Equal(ref.Kind, ptr.To(trainer.TrainingRuntimeKind))
 }
+
+func RuntimeRefIsClusterTrainingRuntime(ref trainer.RuntimeRef) bool {
+	return ptr.Equal(ref.APIGroup, &trainer.GroupVersion.Group) &&
+		ptr.Equal(ref.Kind, ptr.To(trainer.ClusterTrainingRuntimeKind))
+}

--- a/pkg/util/trainjob/trainjob_test.go
+++ b/pkg/util/trainjob/trainjob_test.go
@@ -53,3 +53,33 @@ func TestRuntimeRefIsTrainingRuntime(t *testing.T) {
 		})
 	}
 }
+
+func TestRuntimeRefIsClusterTrainingRuntime(t *testing.T) {
+	cases := map[string]struct {
+		ref  trainer.RuntimeRef
+		want bool
+	}{
+		"runtimeRef is ClusterTrainingRuntime": {
+			ref: trainer.RuntimeRef{
+				APIGroup: &trainer.GroupVersion.Group,
+				Kind:     ptr.To(trainer.ClusterTrainingRuntimeKind),
+			},
+			want: true,
+		},
+		"runtimeRef is not ClusterTrainingRuntime": {
+			ref: trainer.RuntimeRef{
+				APIGroup: &trainer.GroupVersion.Group,
+				Kind:     ptr.To(trainer.TrainingRuntimeKind),
+			},
+			want: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := RuntimeRefIsClusterTrainingRuntime(tc.ref)
+			if got != tc.want {
+				t.Errorf("Unexpected RuntimeRefIsClusterTrainingRuntime()\nwant: %v\n, want: %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/test/integration/controller/clustertrainingruntime_controller_test.go
+++ b/test/integration/controller/clustertrainingruntime_controller_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2025 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	trainer "github.com/kubeflow/trainer/pkg/apis/trainer/v1alpha1"
+	"github.com/kubeflow/trainer/pkg/constants"
+	utiltesting "github.com/kubeflow/trainer/pkg/util/testing"
+	"github.com/kubeflow/trainer/test/integration/framework"
+	"github.com/kubeflow/trainer/test/util"
+)
+
+var _ = ginkgo.Describe("ClusterTrainingRuntime controller", ginkgo.Ordered, func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeAll(func() {
+		fwk = &framework.Framework{}
+		cfg := fwk.Init()
+		ctx, k8sClient = fwk.RunManager(cfg, true)
+	})
+	ginkgo.AfterAll(func() {
+		fwk.Teardown()
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "Namespace",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "clustertrainingruntime-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).Should(gomega.Succeed())
+	})
+
+	ginkgo.When("Reconcile ClusterTrainingRuntime", func() {
+		var (
+			trainJob             *trainer.TrainJob
+			clTrainingRuntime    *trainer.ClusterTrainingRuntime
+			clTrainingRuntimeKey client.ObjectKey
+		)
+		ginkgo.BeforeEach(func() {
+			clTrainingRuntime = utiltesting.MakeClusterTrainingRuntimeWrapper("alpha").
+				Obj()
+			clTrainingRuntimeKey = client.ObjectKeyFromObject(clTrainingRuntime)
+			trainJob = utiltesting.MakeTrainJobWrapper(ns.Name, "alpha").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), clTrainingRuntime.Name).
+				Obj()
+		})
+		ginkgo.AfterEach(func() {
+			gomega.Expect(k8sClient.DeleteAllOf(ctx, &trainer.TrainJob{}, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			gomega.Expect(k8sClient.DeleteAllOf(ctx, &trainer.ClusterTrainingRuntime{})).Should(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				trainJobs := &trainer.TrainJobList{}
+				g.Expect(k8sClient.List(ctx, trainJobs, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+				g.Expect(trainJobs.Items).Should(gomega.HaveLen(0))
+				clRuntimes := &trainer.ClusterTrainingRuntimeList{}
+				g.Expect(k8sClient.List(ctx, clRuntimes)).Should(gomega.Succeed())
+				g.Expect(clRuntimes.Items).Should(gomega.HaveLen(0))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("ClusterTrainingRuntime obtains finalizer when TrainJob with ClusterTrainingRuntime is created", func() {
+			ginkgo.By("Creating a ClusterTrainingRuntime")
+			gomega.Expect(k8sClient.Create(ctx, clTrainingRuntime)).Should(gomega.Succeed())
+
+			ginkgo.By("Checking if the ClusterTrainingRuntime does not keep obtaining finalizers")
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, clTrainingRuntimeKey, clTrainingRuntime)).Should(gomega.Succeed())
+				g.Expect(clTrainingRuntime.ObjectMeta.Finalizers).Should(gomega.HaveLen(0))
+			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Creating a TrainJob")
+			gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+
+			ginkgo.By("Checking if the ClusterTrainingRuntime obtains finalizers")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, clTrainingRuntimeKey, clTrainingRuntime)).Should(gomega.Succeed())
+				g.Expect(clTrainingRuntime.ObjectMeta.Finalizers).Should(gomega.BeComparableTo(
+					[]string{constants.ResourceInUseFinalizer},
+				))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("ClusterTrainingRuntime can be deleted once referenced TrainJob is deleted", func() {
+			ginkgo.By("Creating a ClusterTrainingRuntime and TrainJob")
+			gomega.Expect(k8sClient.Create(ctx, clTrainingRuntime)).Should(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+
+			ginkgo.By("Checking if the ClusterTrainingRuntime obtains finalizers")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, clTrainingRuntimeKey, clTrainingRuntime)).Should(gomega.Succeed())
+				g.Expect(clTrainingRuntime.ObjectMeta.Finalizers).Should(gomega.BeComparableTo(
+					[]string{constants.ResourceInUseFinalizer},
+				))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Delete a TrainJob")
+			gomega.Expect(k8sClient.Delete(ctx, trainJob)).Should(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainJob), trainJob)).Should(utiltesting.BeNotFoundError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Checking if the ClusterTrainingRuntime keeps having finalizers")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, clTrainingRuntimeKey, clTrainingRuntime)).Should(gomega.Succeed())
+				g.Expect(clTrainingRuntime.ObjectMeta.Finalizers).Should(gomega.BeComparableTo(
+					[]string{constants.ResourceInUseFinalizer},
+				))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Checking if the ClusterTrainingRuntime can be deleted")
+			gomega.Expect(k8sClient.Delete(ctx, clTrainingRuntime)).Should(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, clTrainingRuntimeKey, clTrainingRuntime)).Should(utiltesting.BeNotFoundError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

I implemented the ClusterTrainingRuntime controller with the finalizer trainer.kubeflow.org/resource-in-use mechanism.
The event dispatching conditions are completely the same as TrainingRuntime. So, please see https://github.com/kubeflow/trainer/pull/2608 description for more details.

This PR depends on and is blocked by https://github.com/kubeflow/trainer/pull/2608.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes https://github.com/kubeflow/trainer/issues/2609

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
