### PR TITLE
fix(controller): Fix RBAC permissions for TrainJob controller

### DIFF
--- a/manifests/base/rbac/role.yaml
+++ b/manifests/base/rbac/role.yaml
@@ -61,8 +61,6 @@ rules:
   resources:
   - trainjobs
   verbs:
-  - create
-  - delete
   - get
   - list
   - patch

--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -66,7 +66,7 @@ func NewTrainJobReconciler(client client.Client, recorder record.EventRecorder, 
 	}
 }
 
-// +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainjobs,verbs=create;get;list;watch;update;patch;delete
+// +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainjobs,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainjobs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainjobs/finalizers,verbs=get;update;patch
 


### PR DESCRIPTION
TrainJob controller doesn't require `create and delete` RBAC.

Ref: https://github.com/kubeflow/trainer/pull/2608#discussion_r2068580203

/assign @tenzen-y @astefanutti 