### PR TITLE
fix: istio sidecar injection from annotations to labels

### DIFF
--- a/examples/pytorch/image-classification/create-pytorchjob.ipynb
+++ b/examples/pytorch/image-classification/create-pytorchjob.ipynb
@@ -132,7 +132,7 @@
     "        metadata=V1ObjectMeta(\n",
     "            name=name,\n",
     "            namespace=namespace,\n",
-    "            annotations={\n",
+    "            labels={\n",
     "                \"sidecar.istio.io/inject\": \"false\"\n",
     "            }\n",
     "        ),\n",

--- a/sdk/python/kubeflow/training/api/training_client_test.py
+++ b/sdk/python/kubeflow/training/api/training_client_test.py
@@ -171,7 +171,7 @@ def create_job(
         replicas=1,
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(
                 containers=[container],
@@ -188,7 +188,7 @@ def create_job(
             replicas=num_workers - 1,
             template=V1PodTemplateSpec(
                 metadata=V1ObjectMeta(
-                    annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                    labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
                 ),
                 spec=V1PodSpec(
                     containers=[container],

--- a/sdk/python/kubeflow/training/utils/utils.py
+++ b/sdk/python/kubeflow/training/utils/utils.py
@@ -256,7 +256,7 @@ def get_pod_template_spec(
     # Create Pod template spec. If the value is None, Pod doesn't have that parameter
     pod_template_spec = models.V1PodTemplateSpec(
         metadata=models.V1ObjectMeta(
-            annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+            labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
         ),
         spec=models.V1PodSpec(
             init_containers=init_containers,

--- a/sdk/python/test/e2e/test_e2e_jaxjob.py
+++ b/sdk/python/test/e2e/test_e2e_jaxjob.py
@@ -56,7 +56,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(
                 scheduler_name=utils.get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
@@ -110,7 +110,7 @@ def test_sdk_e2e(job_namespace):
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(containers=[container]),
         ),

--- a/sdk/python/test/e2e/test_e2e_mpijob.py
+++ b/sdk/python/test/e2e/test_e2e_mpijob.py
@@ -56,7 +56,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         restart_policy="Never",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(
                 containers=[launcher_container],
@@ -70,7 +70,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         restart_policy="Never",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(
                 containers=[worker_container],
@@ -124,7 +124,7 @@ def test_sdk_e2e(job_namespace):
         restart_policy="Never",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(containers=[launcher_container]),
         ),
@@ -135,7 +135,7 @@ def test_sdk_e2e(job_namespace):
         restart_policy="Never",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(containers=[worker_container]),
         ),

--- a/sdk/python/test/e2e/test_e2e_paddlejob.py
+++ b/sdk/python/test/e2e/test_e2e_paddlejob.py
@@ -56,7 +56,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(
                 scheduler_name=utils.get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
@@ -110,7 +110,7 @@ def test_sdk_e2e(job_namespace):
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(containers=[container]),
         ),

--- a/sdk/python/test/e2e/test_e2e_pytorchjob.py
+++ b/sdk/python/test/e2e/test_e2e_pytorchjob.py
@@ -56,7 +56,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(
                 scheduler_name=utils.get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
@@ -70,7 +70,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(
                 scheduler_name=utils.get_pod_spec_scheduler_name(GANG_SCHEDULER_NAME),
@@ -133,7 +133,7 @@ def test_sdk_e2e(job_namespace):
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(containers=[container]),
         ),
@@ -144,7 +144,7 @@ def test_sdk_e2e(job_namespace):
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(containers=[container]),
         ),
@@ -180,7 +180,7 @@ def test_sdk_e2e_managed_by(job_namespace):
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(containers=[container]),
         ),
@@ -191,7 +191,7 @@ def test_sdk_e2e_managed_by(job_namespace):
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(containers=[container]),
         ),

--- a/sdk/python/test/e2e/test_e2e_tfjob.py
+++ b/sdk/python/test/e2e/test_e2e_tfjob.py
@@ -57,7 +57,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         restart_policy="Never",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(
                 containers=[container],
@@ -111,7 +111,7 @@ def test_sdk_e2e(job_namespace):
         restart_policy="Never",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(containers=[container]),
         ),

--- a/sdk/python/test/e2e/test_e2e_xgboostjob.py
+++ b/sdk/python/test/e2e/test_e2e_xgboostjob.py
@@ -56,7 +56,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(
                 containers=[container],
@@ -70,7 +70,7 @@ def test_sdk_e2e_with_gang_scheduling(job_namespace):
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(
                 containers=[container],
@@ -124,7 +124,7 @@ def test_sdk_e2e(job_namespace):
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(containers=[container]),
         ),
@@ -135,7 +135,7 @@ def test_sdk_e2e(job_namespace):
         restart_policy="OnFailure",
         template=V1PodTemplateSpec(
             metadata=V1ObjectMeta(
-                annotations={constants.ISTIO_SIDECAR_INJECTION: "false"}
+                labels={constants.ISTIO_SIDECAR_INJECTION: "false"}
             ),
             spec=V1PodSpec(containers=[container]),
         ),


### PR DESCRIPTION
What this PR does / why we need it:

This PR fixes the Istio sidecar injection configuration by moving from using annotations to using labels in Katib components.


Related Comment: https://github.com/kubeflow/katib/pull/2527#discussion_r2074025080
Issue: https://github.com/kubeflow/manifests/issues/2798
Part of PR: https://github.com/kubeflow/manifests/pull/3044
