### PR TITLE
fix(sdk): Fix type annotation for `train` method's `trainer` parameter

### DIFF
--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -153,7 +153,7 @@ class TrainerClient:
         self,
         runtime: types.Runtime = types.DEFAULT_RUNTIME,
         initializer: Optional[types.Initializer] = None,
-        trainer: Union[types.CustomTrainer, types.BuiltinTrainer, None] = None,
+        trainer: Optional[Union[types.CustomTrainer, types.BuiltinTrainer]] = None,
     ) -> str:
         """
         Create the TrainJob. You can configure these types of training task:

--- a/sdk/kubeflow/trainer/api/trainer_client.py
+++ b/sdk/kubeflow/trainer/api/trainer_client.py
@@ -18,7 +18,7 @@ import queue
 import random
 import string
 import uuid
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import kubeflow.trainer.models as models
 from kubeflow.trainer.constants import constants
@@ -153,20 +153,21 @@ class TrainerClient:
         self,
         runtime: types.Runtime = types.DEFAULT_RUNTIME,
         initializer: Optional[types.Initializer] = None,
-        trainer: Optional[types.CustomTrainer] = None,
+        trainer: Union[types.CustomTrainer, types.BuiltinTrainer, None] = None,
     ) -> str:
         """
         Create the TrainJob. You can configure these types of training task:
 
         - Custom Training Task: Training with a self-contained function that encapsulates
             the entire model training process, e.g. `CustomTrainer`.
+        - Builtin Training Task: Configures a post-training job using torchtune.
 
         Args:
             runtime (`types.Runtime`): Reference to one of existing Runtimes.
             initializer (`Optional[types.Initializer]`):
                 Configuration for the dataset and model initializers.
-            trainer (`Optional[types.CustomTrainer]`):
-                Configuration for Custom Training Task.
+            trainer (`Union[types.CustomTrainer, types.BuiltinTrainer, None]`):
+                Configuration for Custom or Builtin Training Task.
 
         Returns:
             str: The unique name of the TrainJob that has been generated.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Previously, the type annotation `Optional[types.CustomTrainer]` was specified for the `trainer` parameter. This change adds `types.BuiltinTrainer` to the union type, as this is a valid type for this parameter.

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
