### PR TITLE
fix(sdk): Fix bad arg passed to `get_args_using_torchtune_config`

### DIFF
--- a/sdk/kubeflow/trainer/utils/utils.py
+++ b/sdk/kubeflow/trainer/utils/utils.py
@@ -412,7 +412,9 @@ def get_trainer_crd_from_builtin_trainer(
     # Parse args in the TorchTuneConfig to the Trainer, preparing for the mutation of
     # the torchtune config in the runtime plugin.
     # Ref:https://github.com/kubeflow/trainer/tree/master/docs/proposals/2401-llm-trainer-v2
-    trainer_crd.command, trainer_crd.args = get_args_using_torchtune_config(trainer)
+    trainer_crd.command, trainer_crd.args = get_args_using_torchtune_config(
+        trainer.config
+    )
 
     return trainer_crd
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

The datatype for the arg provided to this function should be of type `TorchTuneConfig`, but prior to this change an arg of type `BuiltinTrainer` was provided.

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
