### PR TITLE
Nominate @Electronic-Waste as approver and @astefanutti as reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,13 @@
 approvers:
   - andreyvelich
+  - Electronic-Waste
   - gaocegege
   - Jeffwan
   - johnugeorge
   - tenzen-y
   - terrytangyuan
 reviewers:
-  - Electronic-Waste
+  - astefanutti
   - jinchihe
   - kuizhiqing
 emeritus_approvers:


### PR DESCRIPTION
I would like to nominate @Electronic-Waste as an approver and @astefanutti as a reviewer for Kubeflow Trainer project.

I believe that both of them perfectly fits [the requirements](https://www.kubeflow.org/docs/about/membership/):

- @Electronic-Waste being a reviewer for at least 3 months, @astefanutti being a member for at least 3 months.
- @Electronic-Waste made 1495 contributions and @astefanutti made 426 contributions in [the last year](https://kubeflow.devstats.cncf.io/d/66/developer-activity-counts-by-companies?orgId=1&var%5B%E2%80%A6%5Dubeflow%2Ftrainer&var-country_name=All&var-companies=All&var-period_name=Last%20year&var-metric=contributions&var-repogroup_name=All).
- Helping with GSoC, Kubeflow Trainer V2, and Kubeflow SDK.
- Driving the design and implementation of Kubeflow LLM Trainer

Thanks a lot @astefanutti and @Electronic-Waste for your consistent contributions to Kubeflow projects!
Looking forward to continue working with you 🎉 


/hold for review

/assign @kubeflow/wg-training-leads @tenzen-y @johnugeorge 