### PR TITLE
Tag Docker images with GitHub release tags

### DIFF
--- a/.github/workflows/template-publish-image/action.yaml
+++ b/.github/workflows/template-publish-image/action.yaml
@@ -81,6 +81,7 @@ runs:
       with:
         images: ${{ inputs.image }}
         tags: |
+          type=ref,event=tag
           type=raw,latest
           type=sha
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**: 
Added `type=ref,event=tag` to the Docker metadata action configuration. Now when we push release tags, images get tagged with the actual version. For example, if we push `v2.0.0-rc.0` tag, it would create images tagged as `v2.0.0-rc.0` as well.

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing

cc @andreyvelich 