### PR TITLE
chore: Replace the deprecated intstr.FromInt with intstr.FromInt32

### DIFF
--- a/pkg/runtime/framework/plugins/torch/torch_test.go
+++ b/pkg/runtime/framework/plugins/torch/torch_test.go
@@ -1215,7 +1215,7 @@ func TestTorch(t *testing.T) {
 				Trainer(
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumNodes(1).
-						NumProcPerNode(intstr.FromInt(1)).
+						NumProcPerNode(intstr.FromInt32(1)).
 						Container(
 							"ghcr.io/kubeflow/trainer/torchtune-trainer",
 							[]string{"tune", "run"},
@@ -1299,7 +1299,7 @@ func TestTorch(t *testing.T) {
 				Trainer(
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumNodes(2).
-						NumProcPerNode(intstr.FromInt(8)).
+						NumProcPerNode(intstr.FromInt32(8)).
 						Container(
 							"ghcr.io/kubeflow/trainer/torchtune-trainer",
 							[]string{"tune", "run"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

The `FromInt` has already been deprecated.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
