### PR TITLE
feat: support Merge runtime container args with TrainJob args

### DIFF
--- a/pkg/runtime/core/clustertrainingruntime_test.go
+++ b/pkg/runtime/core/clustertrainingruntime_test.go
@@ -98,7 +98,7 @@ func TestClusterTrainingRuntimeNewObjects(t *testing.T) {
 					NumNodes(100).
 					Container(constants.DatasetInitializer, constants.DatasetInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 					Container(constants.ModelInitializer, constants.ModelInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
-					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
+					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob", "runtime"}, resRequests).
 					DependsOn(constants.Node,
 						[]jobsetv1alpha2.DependsOn{
 							{

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -159,7 +159,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer).
 					Completions(1, constants.DatasetInitializer, constants.ModelInitializer).
 					NumNodes(100).
-					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
+					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob", "runtime"}, resRequests).
 					Env(constants.Node, constants.Node,
 						[]corev1.EnvVar{
 							{
@@ -314,7 +314,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							},
 						}...,
 					).
-					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
+					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob", "runtime"}, resRequests).
 					Env(constants.Node, constants.Node,
 						[]corev1.EnvVar{
 							{
@@ -441,7 +441,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					NumNodes(100).
 					InitContainer(constants.DatasetInitializer, "override-init-container", "test:runtime").
 					InitContainer(constants.Node, "override-init-container", "test:runtime").
-					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
+					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob", "runtime"}, resRequests).
 					Container(constants.Node, "override-container", "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 					Volumes(constants.DatasetInitializer,
 						corev1.Volume{
@@ -556,7 +556,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					NumNodes(100).
 					InitContainer(constants.DatasetInitializer, "override-init-container", "test:runtime").
 					InitContainer(constants.Node, "override-init-container", "test:runtime").
-					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
+					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob", "runtime"}, resRequests).
 					Container(constants.Node, "override-container", "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 					Tolerations(constants.DatasetInitializer,
 						corev1.Toleration{
@@ -619,7 +619,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					NumNodes(100).
 					InitContainer(constants.DatasetInitializer, "override-init-container", "test:runtime").
 					InitContainer(constants.Node, "override-init-container", "test:runtime").
-					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
+					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob", "runtime"}, resRequests).
 					Container(constants.Node, "override-container", "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 					NodeSelector(constants.DatasetInitializer,
 						map[string]string{
@@ -682,7 +682,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					NumNodes(100).
 					InitContainer(constants.DatasetInitializer, "override-init-container", "test:runtime").
 					InitContainer(constants.Node, "override-init-container", "test:runtime").
-					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
+					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob", "runtime"}, resRequests).
 					Container(constants.Node, "override-container", "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
 					SchedulingGates(constants.DatasetInitializer, corev1.PodSchedulingGate{
 						Name: "kueue.x-k8s.io/admission",
@@ -955,7 +955,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 					Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer).
 					Completions(1, constants.DatasetInitializer, constants.ModelInitializer).
 					NumNodes(100).
-					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob"}, resRequests).
+					Container(constants.Node, constants.Node, "test:trainjob", []string{"trainjob"}, []string{"trainjob", "runtime"}, resRequests).
 					ContainerTrainerPorts([]corev1.ContainerPort{{ContainerPort: constants.ContainerTrainerPort}}).
 					Env(constants.Node, constants.Node,
 						[]corev1.EnvVar{
@@ -1095,6 +1095,7 @@ func TestTrainingRuntimeNewObjects(t *testing.T) {
 							"batch_size=32",
 							"epochs=10",
 							"loss=torchtune.modules.loss.CEWithChunkedOutputLoss",
+							"runtime",
 						},
 						resRequests,
 					).


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements intelligent container arguments merging functionality in the JobSet builder. Previously, TrainJob args would completely override runtime args, which could lead to loss of important runtime-specific parameters. 

**Key Changes:**
- Added `mergeContainerArgs` function in `pkg/runtime/framework/plugins/jobset/builder.go` that merges TrainJob args with runtime args
- TrainJob args are placed first, followed by runtime args, preserving the priority of user-specified parameters while maintaining runtime functionality
- Updated test expectations across multiple test cases to reflect the new merging behavior
- Maintains backward compatibility while providing more flexible argument handling

**Benefits:**
- Prevents accidental loss of runtime-specific arguments
- Allows users to specify additional arguments without breaking runtime functionality  
- Provides more predictable and intuitive behavior when combining TrainJob and runtime configurations
- Supports complex scenarios like TorchTune where both user args and runtime args are needed