### PR TITLE
chore: update github runners to oci gh arc runners

### DIFF
--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -13,8 +13,7 @@ jobs:
   build-and-publish:
     name: Build and Publish Images
     if: github.repository == 'kubeflow/trainer'
-    runs-on:
-      labels: ubuntu-latest-16-cores
+    runs-on: oracle-vm-16cpu-64gb-x86-64
 
     env:
       SHOULD_PUBLISH: ${{ github.event_name == 'push' }}

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -6,8 +6,7 @@ on:
 jobs:
   e2e-test:
     name: E2E Test
-    runs-on:
-      labels: ubuntu-latest-16-cores
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     env:
       GOPATH: ${{ github.workspace }}/go
     defaults:


### PR DESCRIPTION
**What this PR does / why we need it**:

CNCF has hosted ephemeral GitHub runners on Oracle that we want projects to use instead of the GitHub-hosted ones, which now incur a cost to use.

Please direct any questions to me, @jeefy, @krook, and @RobertKielty. You can also join `#cncf-ci-infra` channel on CNCF Slack.

