### PR TITLE
feat(runtimes): Add Trainer Type and Framework Labels

### DIFF
--- a/manifests/base/runtimes/deepspeed_distributed.yaml
+++ b/manifests/base/runtimes/deepspeed_distributed.yaml
@@ -2,6 +2,9 @@ apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:
   name: deepspeed-distributed
+  labels:
+    trainer.kubeflow.org/trainer-type: custom
+    trainer.kubeflow.org/framework: deepspeed
 spec:
   mlPolicy:
     numNodes: 1

--- a/manifests/base/runtimes/mlx_distributed.yaml
+++ b/manifests/base/runtimes/mlx_distributed.yaml
@@ -2,6 +2,9 @@ apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:
   name: mlx-distributed
+  labels:
+    trainer.kubeflow.org/trainer-type: custom
+    trainer.kubeflow.org/framework: mlx
 spec:
   mlPolicy:
     numNodes: 1

--- a/manifests/base/runtimes/torch_distributed.yaml
+++ b/manifests/base/runtimes/torch_distributed.yaml
@@ -2,6 +2,9 @@ apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:
   name: torch-distributed
+  labels:
+    trainer.kubeflow.org/trainer-type: custom
+    trainer.kubeflow.org/framework: torch
 spec:
   mlPolicy:
     numNodes: 1

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -2,6 +2,9 @@ apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:
   name: torchtune-llama3.2-1b
+  labels:
+    trainer.kubeflow.org/trainer-type: builtin
+    trainer.kubeflow.org/framework: torchtune
 spec:
   mlPolicy:
     numNodes: 1

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -2,6 +2,9 @@ apiVersion: trainer.kubeflow.org/v1alpha1
 kind: ClusterTrainingRuntime
 metadata:
   name: torchtune-llama3.2-3b
+  labels:
+    trainer.kubeflow.org/trainer-type: builtin
+    trainer.kubeflow.org/framework: torchtune
 spec:
   mlPolicy:
     numNodes: 1


### PR DESCRIPTION
As we discussed in Slack and GitHub, we would like to introduce two labels to the runtime to define Trainer type and Framework:
```
trainer.kubeflow.org/trainer-type
trainer.kubeflow.org/framework
```

Ref: https://github.com/kubeflow/sdk/pull/31#issuecomment-3109920098,
https://cloud-native.slack.com/archives/C0742LDFZ4K/p1753710956860929

/assign @kubeflow/kubeflow-trainer-team @astefanutti @kramaranya