### PR TITLE
feat(docs): Introduce latest news to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,30 @@
 # Kubeflow Trainer
 
-[![Build Status](https://github.com/kubeflow/trainer/actions/workflows/test-go.yaml/badge.svg?branch=master)](https://github.com/kubeflow/trainer/actions/workflows/test-go.yaml?branch=master)
+[![Join Slack](https://img.shields.io/badge/Join_Slack-blue?logo=slack)](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels)
 [![Coverage Status](https://coveralls.io/repos/github/kubeflow/trainer/badge.svg?branch=master)](https://coveralls.io/github/kubeflow/trainer?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubeflow/trainer)](https://goreportcard.com/report/github.com/kubeflow/trainer)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10435/badge)](https://www.bestpractices.dev/projects/10435)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kubeflow/trainer)
 
 <h1 align="center">
     <img src="./docs/images/trainer-logo.svg" alt="logo" width="200">
   <br>
 </h1>
+
+Latest News 🔥
+
+- [2025/07] PyTorch on Kubernetes: Kubeflow Trainer Joins the PyTorch Ecosystem. Find the
+  announcement in [the PyTorch blog post](https://pytorch.org/blog/pytorch-on-kubernetes-kubeflow-trainer-joins-the-pytorch-ecosystem/).
+- [2025/07] Kubeflow Trainer v2.0 has been releases. Check out
+  [the blog post announcement](https://blog.kubeflow.org/trainer/intro/) and [the
+  release notes](https://github.com/kubeflow/trainer/releases/tag/v2.0.0).
+- [2025/04] From High Performance Computing To AI Workloads on Kubernetes: MPI Runtime in
+  Kubeflow TrainJob. See the [KubeCon + CloudNativeCon talk](https://youtu.be/Fnb1a5Kaxgo)
+
+<details>
+<summary>More</summary>
+
+</details>
 
 ## Overview
 
@@ -37,7 +53,7 @@ The following KubeCon + CloudNativeCon 2024 talk provides an overview of Kubeflo
 
 ## Getting Started
 
-Please check [the official Kubeflow documentation](https://www.kubeflow.org/docs/components/trainer/getting-started)
+Please check [the official Kubeflow Trainer documentation](https://www.kubeflow.org/docs/components/trainer/getting-started)
 to install and get started with Kubeflow Trainer.
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ Latest News 🔥
 - [2025/04] From High Performance Computing To AI Workloads on Kubernetes: MPI Runtime in
   Kubeflow TrainJob. See the [KubeCon + CloudNativeCon London talk](https://youtu.be/Fnb1a5Kaxgo)
 
-<details>
-<summary>More</summary>
-
-</details>
-
 ## Overview
 
 Kubeflow Trainer is a Kubernetes-native project designed for large language models (LLMs)
@@ -34,7 +29,7 @@ various frameworks, including PyTorch, JAX, TensorFlow, and others.
 
 You can integrate other ML libraries such as [HuggingFace](https://huggingface.co),
 [DeepSpeed](https://github.com/microsoft/DeepSpeed), or [Megatron-LM](https://github.com/NVIDIA/Megatron-LM)
-with Kubeflow Training to orchestrate their ML training on Kubernetes.
+with Kubeflow Trainer to run them on Kubernetes.
 
 Kubeflow Trainer enables you to effortlessly develop your LLMs with the
 [Kubeflow Python SDK](https://github.com/kubeflow/sdk/), and build Kubernetes-native Training

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Latest News 🔥
 
 - [2025/07] PyTorch on Kubernetes: Kubeflow Trainer Joins the PyTorch Ecosystem. Find the
   announcement in [the PyTorch blog post](https://pytorch.org/blog/pytorch-on-kubernetes-kubeflow-trainer-joins-the-pytorch-ecosystem/).
-- [2025/07] Kubeflow Trainer v2.0 has been releases. Check out
+- [2025/07] Kubeflow Trainer v2.0 has been officially released. Check out
   [the blog post announcement](https://blog.kubeflow.org/trainer/intro/) and [the
   release notes](https://github.com/kubeflow/trainer/releases/tag/v2.0.0).
 - [2025/04] From High Performance Computing To AI Workloads on Kubernetes: MPI Runtime in
-  Kubeflow TrainJob. See the [KubeCon + CloudNativeCon talk](https://youtu.be/Fnb1a5Kaxgo)
+  Kubeflow TrainJob. See the [KubeCon + CloudNativeCon London talk](https://youtu.be/Fnb1a5Kaxgo)
 
 <details>
 <summary>More</summary>


### PR DESCRIPTION
I've added latest news to the Kubeflow Trainer readme, it would be nice to share updates with our users.
If you want to add more items, please let me know!

Also, I updated the README badges to remove Go status and to add Slack + DeepWiki

/assign @kubeflow/kubeflow-trainer-team @kramaranya @kubeflow/wg-training-leads @astefanutti @franciscojavierarceo @szaher 