### PR TITLE
fix(api): Fix license path for Kubeflow Trainer Python API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,10 @@ __debug_bin
 # The default output for various artifacts (e.g. Jupyter Notebooks after Papermill execution).
 artifacts
 
-# Python cache files
+# Python cache files / packaging
 __pycache__/
 *.egg-info/
+dist/
 
 # Coverage
 cover.out

--- a/api/python_api/pyproject.toml
+++ b/api/python_api/pyproject.toml
@@ -1,14 +1,11 @@
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
 [project]
 name = "kubeflow_trainer_api"
 dynamic = ["version"]
+requires-python = ">=3.9"
 authors = [
   { name = "The Kubeflow Authors", email = "kubeflow-discuss@googlegroups.com" },
 ]
-license = { file = "../../LICENSE" }
+license = { text = "Apache-2.0" }
 description = "Kubeflow Trainer API models for Kubernetes resources to interact with Kubeflow APIs."
 readme = "README.md"
 keywords = ["kubeflow", "trainer", "model training", "llm", "ai", "api"]
@@ -16,7 +13,6 @@ classifiers = [
   "Intended Audience :: Developers",
   "Intended Audience :: Education",
   "Intended Audience :: Science/Research",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -34,6 +30,10 @@ dependencies = ["pydantic>=2.10.0"]
 Homepage = "https://github.com/kubeflow/trainer"
 Documentation = "https://www.kubeflow.org/docs/components/trainer/"
 Source = "https://github.com/kubeflow/trainer"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["kubeflow_trainer_api"]


### PR DESCRIPTION
While trying to publish `kubeflow_trainer_api` to PyPI, I get this error:

```
OSError: License file does not exist: ../../LICENSE
```

All files must be local to the Python project that we want to publish.

We should also update the Kubeflow SDK: https://github.com/kubeflow/sdk/blob/main/python/pyproject.toml

/assign @kubeflow/kubeflow-trainer-team @astefanutti @kramaranya @szaher @briangallagher @eoinfennessy 