### PR TITLE
fix(api): update license path for kubeflow_trainer_api

### DIFF
--- a/api/python_api/pyproject.toml
+++ b/api/python_api/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.9"
 authors = [
   { name = "The Kubeflow Authors", email = "kubeflow-discuss@googlegroups.com" },
 ]
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 description = "Kubeflow Trainer API models for Kubernetes resources to interact with Kubeflow APIs."
 readme = "README.md"
 keywords = ["kubeflow", "trainer", "model training", "llm", "ai", "api"]


### PR DESCRIPTION
Updated license path for `kubeflow_trainer_api` package to follow https://peps.python.org/pep-0639/#add-string-value-to-license-key, because `license = { text = "Apache-2.0" }` table is now deprecated

/assign @andreyvelich 