### PR TITLE
chore: Remove tool.hatch.build.targets.wheel from pyproject

### DIFF
--- a/api/python_api/pyproject.toml
+++ b/api/python_api/pyproject.toml
@@ -35,8 +35,5 @@ Source = "https://github.com/kubeflow/trainer"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.hatch.build.targets.wheel]
-packages = ["kubeflow_trainer_api"]
-
 [tool.hatch.version]
 path = "kubeflow_trainer_api/__init__.py"


### PR DESCRIPTION
Since we have a single package, I removed the redundant hatch build target from pyproject.toml, because hatchling finds the package on its own -- https://hatch.pypa.io/1.9/plugins/builder/wheel/#default-file-selection

/assign @andreyvelich @astefanutti 