### PR TITLE
chore: deflake test to ensure runtime is created before creating trainjob

### DIFF
--- a/test/integration/controller/clustertrainingruntime_controller_test.go
+++ b/test/integration/controller/clustertrainingruntime_controller_test.go
@@ -107,6 +107,9 @@ var _ = ginkgo.Describe("ClusterTrainingRuntime controller", ginkgo.Ordered, fun
 		ginkgo.It("ClusterTrainingRuntime can be deleted once referenced TrainJob is deleted", func() {
 			ginkgo.By("Creating a ClusterTrainingRuntime and TrainJob")
 			gomega.Expect(k8sClient.Create(ctx, clTrainingRuntime)).Should(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clTrainingRuntime), clTrainingRuntime)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
 
 			ginkgo.By("Checking if the ClusterTrainingRuntime obtains finalizers")

--- a/test/integration/controller/trainingruntime_controller_test.go
+++ b/test/integration/controller/trainingruntime_controller_test.go
@@ -99,6 +99,9 @@ var _ = ginkgo.Describe("TrainingRuntime controller", ginkgo.Ordered, func() {
 		ginkgo.It("TrainingRuntime can be deleted once referenced TrainJob is deleted", func() {
 			ginkgo.By("Creating a TrainingRuntime and TrainJob")
 			gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), trainingRuntime)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
 
 			ginkgo.By("Checking if the TrainingRuntime obtains finalizers")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Fix flaky test observed at https://github.com/kubeflow/trainer/actions/runs/17310878465/job/49144635225. It appears that the TrainJob is being created before the TrainingRuntime is actually ready. This change ensures that a TrainJob is only created after confirming the TrainingRuntime has been created. A similar test case exists for ClusterTrainingRuntime, which has also been updated accordingly.

```console
TrainingRuntime controller when Reconcile TrainingRuntime TrainingRuntime can be deleted once referenced TrainJob is deleted
/home/runner/work/trainer/trainer/go/src/github.com/kubeflow/trainer/test/integration/controller/trainingruntime_controller_test.go:99
  2025-08-29T00:08:50Z	LEVEL(-5)	Reconciling	{"controller": "trainingruntime_controller", "namespace": "trainingruntime-mx5cw", "name": "alpha", "reconcileID": "7fdb6cb5-3d0d-48db-a659-c028f3a6f8d9"}
  2025-08-29T00:08:50Z	LEVEL(-2)	Reconciling TrainingRuntime	{"controller": "trainingruntime_controller", "namespace": "trainingruntime-mx5cw", "name": "alpha", "reconcileID": "7fdb6cb5-3d0d-48db-a659-c028f3a6f8d9", "trainingRuntime": {"name":"alpha","namespace":"trainingruntime-mx5cw"}}
  STEP: Creating a TrainingRuntime and TrainJob @ 08/29/25 00:08:50.34
  2025-08-29T00:08:50Z	LEVEL(-5)	admission	received request	{"webhookGroup": "trainer.kubeflow.org", "webhookKind": "TrainingRuntime", "TrainingRuntime": {"name":"alpha","namespace":"trainingruntime-5kwwq"}, "namespace": "trainingruntime-5kwwq", "name": "alpha", "resource": {"group":"trainer.kubeflow.org","version":"v1alpha1","resource":"trainingruntimes"}, "user": "admin", "requestID": "cae571f9-9e16-49cc-b917-dbb3d6225418"}
  2025-08-29T00:08:50Z	LEVEL(-5)	admission.trainingruntime-webhook	Validating create	{"webhookGroup": "trainer.kubeflow.org", "webhookKind": "TrainingRuntime", "TrainingRuntime": {"name":"alpha","namespace":"trainingruntime-5kwwq"}, "namespace": "trainingruntime-5kwwq", "name": "alpha", "resource": {"group":"trainer.kubeflow.org","version":"v1alpha1","resource":"trainingruntimes"}, "user": "admin", "requestID": "cae571f9-9e16-49cc-b917-dbb3d6225418", "trainingRuntime": {"name":"alpha","namespace":"trainingruntime-5kwwq"}}
  2025-08-29T00:08:50Z	LEVEL(-5)	admission	wrote response	{"webhookGroup": "trainer.kubeflow.org", "webhookKind": "TrainingRuntime", "code": 200, "reason": "", "message": "", "requestID": "cae571f9-9e16-49cc-b917-dbb3d6225418", "allowed": true}
  2025-08-29T00:08:50Z	LEVEL(-5)	admission	received request	{"webhookGroup": "trainer.kubeflow.org", "webhookKind": "TrainingRuntime", "TrainingRuntime": {"name":"alpha","namespace":"trainingruntime-mx5cw"}, "namespace": "trainingruntime-mx5cw", "name": "alpha", "resource": {"group":"trainer.kubeflow.org","version":"v1alpha1","resource":"trainingruntimes"}, "user": "admin", "requestID": "fc11535f-33bd-4828-9bbb-f2356136237e"}
  2025-08-29T00:08:50Z	LEVEL(-5)	admission	wrote response	{"webhookGroup": "trainer.kubeflow.org", "webhookKind": "TrainingRuntime", "code": 200, "reason": "", "message": "", "requestID": "fc11535f-33bd-4828-9bbb-f2356136237e", "allowed": true}
  2025-08-29T00:08:50Z	LEVEL(-5)	Reconcile successful	{"controller": "trainingruntime_controller", "namespace": "trainingruntime-mx5cw", "name": "alpha", "reconcileID": "7fdb6cb5-3d0d-48db-a659-c028f3a6f8d9"}
  2025-08-29T00:08:50Z	LEVEL(-5)	admission	received request	{"webhookGroup": "trainer.kubeflow.org", "webhookKind": "TrainJob", "TrainJob": {"name":"alpha","namespace":"trainingruntime-5kwwq"}, "namespace": "trainingruntime-5kwwq", "name": "alpha", "resource": {"group":"trainer.kubeflow.org","version":"v1alpha1","resource":"trainjobs"}, "user": "admin", "requestID": "64815f5a-f7c5-4697-b3b5-f97388306bcc"}
  2025-08-29T00:08:50Z	LEVEL(-5)	admission.trainJob-webhook	Validating create	{"webhookGroup": "trainer.kubeflow.org", "webhookKind": "TrainJob", "TrainJob": {"name":"alpha","namespace":"trainingruntime-5kwwq"}, "namespace": "trainingruntime-5kwwq", "name": "alpha", "resource": {"group":"trainer.kubeflow.org","version":"v1alpha1","resource":"trainjobs"}, "user": "admin", "requestID": "64815f5a-f7c5-4697-b3b5-f97388306bcc", "TrainJob": {"name":"alpha","namespace":"trainingruntime-5kwwq"}}
  2025-08-29T00:08:50Z	LEVEL(-5)	admission	wrote response	{"webhookGroup": "trainer.kubeflow.org", "webhookKind": "TrainJob", "code": 403, "reason": "Forbidden", "message": "spec.runtimeRef: Invalid value: {\"name\":\"alpha\",\"apiGroup\":\"trainer.kubeflow.org\",\"kind\":\"TrainingRuntime\"}: TrainingRuntime.trainer.kubeflow.org \"alpha\" not found: specified trainingRuntime must be created before the TrainJob is created", "requestID": "64815f5a-f7c5-4697-b3b5-f97388306bcc", "allowed": false}
  [FAILED] in [It] - /home/runner/work/trainer/trainer/go/src/github.com/kubeflow/trainer/test/integration/controller/trainingruntime_controller_test.go:102 @ 08/29/25 00:08:50.349
  2025-08-29T00:08:50Z	LEVEL(-5)	Reconciling	{"controller": "trainingruntime_controller", "namespace": "trainingruntime-5kwwq", "name": "alpha", "reconcileID": "03a7caf5-0120-45af-adc9-c4a384f7e10f"}
  2025-08-29T00:08:50Z	LEVEL(-2)	Reconciling TrainingRuntime	{"controller": "trainingruntime_controller", "namespace": "trainingruntime-5kwwq", "name": "alpha", "reconcileID": "03a7caf5-0120-45af-adc9-c4a384f7e10f", "trainingRuntime": {"name":"alpha","namespace":"trainingruntime-5kwwq"}}
  2025-08-29T00:08:50Z	LEVEL(-5)	Reconcile successful	{"controller": "trainingruntime_controller", "namespace": "trainingruntime-5kwwq", "name": "alpha", "reconcileID": "03a7caf5-0120-45af-adc9-c4a384f7e10f"}
  2025-08-29T00:08:50Z	LEVEL(-5)	Reconciling	{"controller": "trainingruntime_controller", "namespace": "trainingruntime-mx5cw", "name": "alpha", "reconcileID": "a86e99f7-157b-4ac7-82db-8da6604edc70"}
  2025-08-29T00:08:50Z	LEVEL(-5)	Reconcile successful	{"controller": "trainingruntime_controller", "namespace": "trainingruntime-mx5cw", "name": "alpha", "reconcileID": "a86e99f7-157b-4ac7-82db-8da6604edc70"}
  STEP: tearing down the test environment @ 08/29/25 00:08:50.436
  2025-08-29T00:08:50Z	INFO	Stopping and waiting for non leader election runnables
  2025-08-29T00:08:50Z	INFO	Stopping and waiting for leader election runnables
  2025-08-29T00:08:50Z	INFO	Stopping and waiting for warmup runnables
  2025-08-29T00:08:50Z	INFO	Shutdown signal received, waiting for all workers to finish	{"controller": "trainjob_controller"}
  2025-08-29T00:08:50Z	INFO	Shutdown signal received, waiting for all workers to finish	{"controller": "trainingruntime_controller"}
  2025-08-29T00:08:50Z	INFO	Shutdown signal received, waiting for all workers to finish	{"controller": "clustertrainingruntime_controller"}
  2025-08-29T00:08:50Z	INFO	All workers finished	{"controller": "trainjob_controller"}
  2025-08-29T00:08:50Z	INFO	All workers finished	{"controller": "trainingruntime_controller"}
  2025-08-29T00:08:50Z	INFO	All workers finished	{"controller": "clustertrainingruntime_controller"}
  2025-08-29T00:08:50Z	INFO	Stopping and waiting for caches
  2025-08-29T00:08:50Z	ERROR	controller-runtime.certwatcher	error re-watching file	{"cert": "/tmp/envtest-serving-certs-3959224419/tls.crt", "key": "/tmp/envtest-serving-certs-3959224419/tls.key", "error": "no such file or directory"}
  sigs.k8s.io/controller-runtime/pkg/certwatcher.(*CertWatcher).handleEvent
  	/home/runner/work/trainer/trainer/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.0/pkg/certwatcher/certwatcher.go:235
  sigs.k8s.io/controller-runtime/pkg/certwatcher.(*CertWatcher).Watch
  	/home/runner/work/trainer/trainer/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.0/pkg/certwatcher/certwatcher.go:159
  2025-08-29T00:08:50Z	LEVEL(-3)	controller-runtime.cache	Stopping reflector	{"type": "*v1.ConfigMap", "resyncPeriod": "10h56m23.240830802s", "reflector": "pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:290"}
  2025-08-29T00:08:50Z	LEVEL(-3)	controller-runtime.cache	Stopping reflector	{"type": "*v1alpha2.JobSet", "resyncPeriod": "10h35m43.437193363s", "reflector": "pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:290"}
  2025-08-29T00:08:50Z	LEVEL(-3)	controller-runtime.cache	Stopping reflector	{"type": "*v1.RuntimeClass", "resyncPeriod": "9h8m41.38265032s", "reflector": "pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:290"}
  2025-08-29T00:08:50Z	DEBUG	controller-runtime.certwatcher	certificate event	{"cert": "/tmp/envtest-serving-certs-3959224419/tls.crt", "key": "/tmp/envtest-serving-certs-3959224419/tls.key", "event": "CHMOD         \"/tmp/envtest-serving-certs-3959224419/tls.crt\""}
  2025-08-29T00:08:50Z	LEVEL(-3)	controller-runtime.cache	Stopping reflector	{"type": "*v1.LimitRange", "resyncPeriod": "10h23m55.956315105s", "reflector": "pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:290"}
  2025-08-29T00:08:50Z	ERROR	controller-runtime.certwatcher	error re-reading certificate	{"cert": "/tmp/envtest-serving-certs-3959224419/tls.crt", "key": "/tmp/envtest-serving-certs-3959224419/tls.key", "error": "open /tmp/envtest-serving-certs-3959224419/tls.crt: no such file or directory"}
  sigs.k8s.io/controller-runtime/pkg/certwatcher.(*CertWatcher).handleEvent
  	/home/runner/work/trainer/trainer/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.0/pkg/certwatcher/certwatcher.go:243
  sigs.k8s.io/controller-runtime/pkg/certwatcher.(*CertWatcher).Watch
  	/home/runner/work/trainer/trainer/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.0/pkg/certwatcher/certwatcher.go:159
  2025-08-29T00:08:50Z	LEVEL(-3)	controller-runtime.cache	Stopping reflector	{"type": "*v1alpha1.PodGroup", "resyncPeriod": "10h55m29.20611106s", "reflector": "pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:290"}
  2025-08-29T00:08:50Z	LEVEL(-3)	controller-runtime.cache	Stopping reflector	{"type": "*v1alpha1.TrainJob", "resyncPeriod": "10h48m20.029379059s", "reflector": "pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:290"}
  2025-08-29T00:08:50Z	LEVEL(-3)	controller-runtime.cache	Stopping reflector	{"type": "*v1.Secret", "resyncPeriod": "9h22m46.72114053s", "reflector": "pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:290"}
  2025-08-29T00:08:50Z	LEVEL(-3)	controller-runtime.cache	Stopping reflector	{"type": "*v1alpha1.TrainingRuntime", "resyncPeriod": "9h9m24.554829398s", "reflector": "pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:290"}
  2025-08-29T00:08:50Z	LEVEL(-3)	controller-runtime.cache	Stopping reflector	{"type": "*v1alpha1.ClusterTrainingRuntime", "resyncPeriod": "9h14m44.242742845s", "reflector": "pkg/mod/k8s.io/client-go@v0.34.0/tools/cache/reflector.go:290"}
  2025-08-29T00:08:50Z	INFO	Stopping and waiting for webhooks
  2025-08-29T00:08:50Z	ERROR	controller-runtime.certwatcher	error re-watching file	{"cert": "/tmp/envtest-serving-certs-3959224419/tls.crt", "key": "/tmp/envtest-serving-certs-3959224419/tls.key", "error": "no such file or directory"}
  sigs.k8s.io/controller-runtime/pkg/certwatcher.(*CertWatcher).handleEvent
  	/home/runner/work/trainer/trainer/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.0/pkg/certwatcher/certwatcher.go:235
  sigs.k8s.io/controller-runtime/pkg/certwatcher.(*CertWatcher).Watch
  	/home/runner/work/trainer/trainer/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.0/pkg/certwatcher/certwatcher.go:159
  2025-08-29T00:08:50Z	DEBUG	controller-runtime.certwatcher	certificate event	{"cert": "/tmp/envtest-serving-certs-3959224419/tls.crt", "key": "/tmp/envtest-serving-certs-3959224419/tls.key", "event": "REMOVE        \"/tmp/envtest-serving-certs-3959224419/tls.crt\""}
  2025-08-29T00:08:50Z	INFO	controller-runtime.webhook	Shutting down webhook server with timeout of 1 minute
  2025-08-29T00:08:50Z	ERROR	controller-runtime.certwatcher	error re-reading certificate	{"cert": "/tmp/envtest-serving-certs-3959224419/tls.crt", "key": "/tmp/envtest-serving-certs-3959224419/tls.key", "error": "open /tmp/envtest-serving-certs-3959224419/tls.crt: no such file or directory"}
  sigs.k8s.io/controller-runtime/pkg/certwatcher.(*CertWatcher).handleEvent
  	/home/runner/work/trainer/trainer/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.0/pkg/certwatcher/certwatcher.go:243
  sigs.k8s.io/controller-runtime/pkg/certwatcher.(*CertWatcher).Watch
  	/home/runner/work/trainer/trainer/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.0/pkg/certwatcher/certwatcher.go:159
  2025-08-29T00:08:51Z	INFO	Stopping and waiting for HTTP servers
  2025-08-29T00:08:51Z	INFO	Wait completed, proceeding to shutdown the manager
• [FAILED] [1.191 seconds]
TrainingRuntime controller when Reconcile TrainingRuntime [It] TrainingRuntime can be deleted once referenced TrainJob is deleted
/home/runner/work/trainer/trainer/go/src/github.com/kubeflow/trainer/test/integration/controller/trainingruntime_controller_test.go:99

  [FAILED] Expected success, but got an error:
      <*errors.StatusError | 0xc0008937c0>: 
      admission webhook "validator.trainjob.trainer.kubeflow.org" denied the request: spec.runtimeRef: Invalid value: {"name":"alpha","apiGroup":"trainer.kubeflow.org","kind":"TrainingRuntime"}: TrainingRuntime.trainer.kubeflow.org "alpha" not found: specified trainingRuntime must be created before the TrainJob is created
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "admission webhook \"validator.trainjob.trainer.kubeflow.org\" denied the request: spec.runtimeRef: Invalid value: {\"name\":\"alpha\",\"apiGroup\":\"trainer.kubeflow.org\",\"kind\":\"TrainingRuntime\"}: TrainingRuntime.trainer.kubeflow.org \"alpha\" not found: specified trainingRuntime must be created before the TrainJob is created",
              Reason: "Forbidden",
              Details: nil,
              Code: 403,
          },
      }
  In [It] at: /home/runner/work/trainer/trainer/go/src/github.com/kubeflow/trainer/test/integration/controller/trainingruntime_controller_test.go:102 @ 08/29/25 00:08:50.349
```

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
