### PR TITLE
chore: Nominate @astefanutti as Kubeflow Trainer approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - andreyvelich
+  - astefanutti
   - Electronic-Waste
   - gaocegege
   - Jeffwan
@@ -7,7 +8,6 @@ approvers:
   - tenzen-y
   - terrytangyuan
 reviewers:
-  - astefanutti
   - jinchihe
   - kuizhiqing
 emeritus_approvers:


### PR DESCRIPTION
I would like to nominate @astefanutti as Kubeflow Trainer approver.

Antonin has helped a lot with the development of this project, and he perfectly fits all of the requirements: https://www.kubeflow.org/docs/about/membership/#approver

- Contributor to more than 100 PRs: https://github.com/kubeflow/trainer/pulls?page=1&q=is%3Apr+commenter%3Aastefanutti
- DevStats: https://kubeflow.devstats.cncf.io/d/66/developer-activity-counts-by-companies?orgId=1&var-period_name=Last%202%20years&var-metric=contributions&var-repogroup_name=All&var-country_name=All&var-companies=All

Thanks a lot for all of your contributions @astefanutti 🎉 

/hold for WG leads to review

/assign @tenzen-y @Electronic-Waste @johnugeorge @terrytangyuan @kubeflow/wg-training-leads 