### PR TITLE
fix: teraform for oci gpu based vm

### DIFF
--- a/docs/proposals/2432-gpu-testing-on-llm-blueprints/OCI VM/bootstrap.sh
+++ b/docs/proposals/2432-gpu-testing-on-llm-blueprints/OCI VM/bootstrap.sh
@@ -39,6 +39,19 @@ sudo apt-get update -y
 sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 # -------------------------------
+# Install Kind and nvkind
+# -------------------------------
+
+# For AMD64 / x86_64
+[ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64
+chmod +x ./kind
+sudo mv ./kind /usr/local/bin/kind
+
+echo "Install nvkind"
+sudo go install github.com/NVIDIA/nvkind/cmd/nvkind@latest
+sudo cp /root/go/bin/nvkind /usr/local/bin/
+
+# -------------------------------
 # Install NVIDIA Container Toolkit
 # -------------------------------
 curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
@@ -70,6 +83,18 @@ KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
 curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
 sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 rm kubectl
+
+# Install NVIDIA Driver
+sudo apt update
+sudo apt install nvidia-driver-535 -y
+sudo apt install nvidia-utils-535
+
+## Privilaged access for docker to make sure Kind can access GPU resources
+alias docker="sudo docker"
+alias kubectl="sudo kubectl"
+alias kind="sudo kind"
+alias helm="sudo helm"
+alias nvkind="sudo nvkind"
 
 # Verify installs
 echo "✅ Installed versions:"

--- a/docs/proposals/2432-gpu-testing-on-llm-blueprints/OCI VM/main.tf
+++ b/docs/proposals/2432-gpu-testing-on-llm-blueprints/OCI VM/main.tf
@@ -125,6 +125,7 @@ resource "oci_core_instance" "gpu_vm" {
   source_details {
     source_type = "image"
     source_id   = data.oci_core_images.ubuntu_image.images[0].id
+    boot_volume_size_in_gbs = 512
   }
 
   metadata = {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the Terraform configuration and the `bootstrap.sh` script to align with the latest setup criteria.

Changes - 
- Boot volume to 512GB since default 47GB is very less and cause OOM issue.
- Moved nvidia driver and `nvidia/nvkind` installation to bootstrap script and alias tools to `sudo` system wide.

**Original PR:** https://github.com/kubeflow/trainer/pull/2689
**Related**: https://github.com/kubeflow/trainer/pull/2762

**Which issue(s) this PR fixes** 
Fixes 2809

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
