### PR TITLE
feat: add HF token and allow gpu workflow to run from pull request

### DIFF
--- a/.github/workflows/test-e2e-gpu.yaml
+++ b/.github/workflows/test-e2e-gpu.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   gpu-e2e-test:
     name: GPU E2E Test
-    runs-on: oracle-vm-16cpu-a10gpu-240gb
+    runs-on: self-hosted
 
     env:
       GOPATH: ${{ github.workspace }}/go

--- a/.github/workflows/test-e2e-gpu.yaml
+++ b/.github/workflows/test-e2e-gpu.yaml
@@ -1,7 +1,7 @@
 name: GPU E2E Test
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize, labeled]
 
 jobs:
@@ -11,6 +11,7 @@ jobs:
 
     env:
       GOPATH: ${{ github.workspace }}/go
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
     defaults:
       run:
         working-directory: ${{ env.GOPATH }}/src/github.com/kubeflow/trainer

--- a/.github/workflows/test-e2e-gpu.yaml
+++ b/.github/workflows/test-e2e-gpu.yaml
@@ -38,6 +38,7 @@ jobs:
         if: steps.check-label.outputs.skip == 'false'
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           path: ${{ env.GOPATH }}/src/github.com/kubeflow/trainer
 
       - name: Setup Go


### PR DESCRIPTION
**What this PR does / why we need it**:
- Use `HF_TOKEN` from upstream repo.
- We want the action to run on incoming PRs when maintainers add the ok-to-test-gpu-runner label. Since in https://github.com/kubeflow/trainer/pull/2762 we cant have that.

**Which issue(s) this PR fixes** :
Fixes #2814

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
