### PR TITLE
chore(runtimes): update torchtune CTRs with multiple dependson feature in jobset v0.9.0

### DIFF
--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml
@@ -34,9 +34,6 @@ spec:
                       persistentVolumeClaim:
                         claimName: torchtune-llama3.2-1b
         - name: model-initializer
-          dependsOn:
-            - name: dataset-initializer
-              status: Complete
           template:
             metadata:
               labels:
@@ -59,6 +56,8 @@ spec:
                         claimName: torchtune-llama3.2-1b
         - name: node
           dependsOn:
+            - name: dataset-initializer
+              status: Complete
             - name: model-initializer
               status: Complete
           template:

--- a/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
+++ b/manifests/base/runtimes/torchtune/llama3_2/llama3_2_3B.yaml
@@ -34,9 +34,6 @@ spec:
                       persistentVolumeClaim:
                         claimName: torchtune-llama3.2-3b
         - name: model-initializer
-          dependsOn:
-            - name: dataset-initializer
-              status: Complete
           template:
             metadata:
               labels:
@@ -59,6 +56,8 @@ spec:
                         claimName: torchtune-llama3.2-3b
         - name: node
           dependsOn:
+            - name: dataset-initializer
+              status: Complete
             - name: model-initializer
               status: Complete
           template:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

In https://github.com/kubeflow/trainer/pull/2590, the training task needs to wait for both model initializer and dataset initializer. However, former jobset (`<v0.9.0`) does not support specifying multiple items, which is blocking our implementation.

Currently, jobset has been upgraded to `v0.9.0` and includes Multiple DependsOn feature: https://github.com/kubernetes-sigs/jobset/pull/878. This PR adds the support for this new feature.

/cc @kubeflow/kubeflow-trainer-team @kannon92 @rudeigerc @kramaranya @szaher 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #2592

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
