### PR TITLE
fix: only request environment if `gpu-runner` label is present

### DIFF
--- a/.github/workflows/test-e2e-gpu.yaml
+++ b/.github/workflows/test-e2e-gpu.yaml
@@ -27,7 +27,7 @@ jobs:
 
   gpu-e2e-test:
     name: GPU E2E Test
-    runs-on: arc-akash
+    runs-on: oracle-vm-16cpu-a10gpu-240gb
     needs: check-label
     if: needs.check-label.outputs.skip == 'false'   # only run if label present
     environment: gpu-tests

--- a/.github/workflows/test-e2e-gpu.yaml
+++ b/.github/workflows/test-e2e-gpu.yaml
@@ -9,70 +9,64 @@ permissions:
   pull-requests: read
 
 jobs:
-  gpu-e2e-test:
-    name: GPU E2E Test
-    runs-on: oracle-vm-16cpu-a10gpu-240gb
-
-    # Maintainers have to approve the use of secrets
-    environment: gpu-tests
-
-    env:
-      GOPATH: ${{ github.workspace }}/go
-
-    defaults:
-      run:
-        working-directory: ${{ env.GOPATH }}/src/github.com/kubeflow/trainer
-
-    strategy:
-      fail-fast: false
-      matrix:
-        kubernetes-version: ["1.33.1"]
-
+  check-label:
+    name: Check GPU Label
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check-label.outputs.skip }}
     steps:
-      - name: Check GPU label
-        id: check-label
+      - id: check-label
         run: |
           if [[ "${{ join(github.event.pull_request.labels.*.name, ',') }}" != *"ok-to-test-gpu-runner"* ]]; then
             echo "✅ Skipping GPU E2E tests (label not present)."
             echo "skip=true" >> $GITHUB_OUTPUT
-            exit 0
           else
             echo "Label found. Requesting environment approval to run GPU tests."
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
+  gpu-e2e-test:
+    name: GPU E2E Test
+    runs-on: arc-akash
+    needs: check-label
+    if: needs.check-label.outputs.skip == 'false'   # only run if label present
+    environment: gpu-tests
+    env:
+      GOPATH: ${{ github.workspace }}/go
+    defaults:
+      run:
+        working-directory: ${{ env.GOPATH }}/src/github.com/kubeflow/trainer
+    strategy:
+      fail-fast: false
+      matrix:
+        kubernetes-version: ["1.33.1"]
+    steps:
       - name: Check out code
-        if: steps.check-label.outputs.skip == 'false'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: ${{ env.GOPATH }}/src/github.com/kubeflow/trainer
 
       - name: Setup Go
-        if: steps.check-label.outputs.skip == 'false'
         uses: actions/setup-go@v5
         with:
           go-version-file: ${{ env.GOPATH }}/src/github.com/kubeflow/trainer/go.mod
 
       - name: Setup Python
-        if: steps.check-label.outputs.skip == 'false'
         uses: actions/setup-python@v5
         with:
           python-version: 3.11
 
       - name: Install dependencies
-        if: steps.check-label.outputs.skip == 'false'
         run: |
           pip install papermill==2.6.0 jupyter==1.1.1 ipykernel==6.29.5
           pip install git+https://github.com/kubeflow/sdk.git@main
 
       - name: Setup cluster with GPU support using nvidia/kind
-        if: steps.check-label.outputs.skip == 'false'
         run: |
           make test-e2e-setup-gpu-cluster K8S_VERSION=${{ matrix.kubernetes-version }}
 
       - name: Run e2e test on GPU cluster
-        if: steps.check-label.outputs.skip == 'false'
         run: |
           mkdir -p artifacts/notebooks
           make test-e2e-notebook NOTEBOOK_INPUT=./examples/torchtune/llama3_2/alpaca-trainjob-yaml.ipynb NOTEBOOK_OUTPUT=./artifacts/notebooks/${{ matrix.kubernetes-version }}_alpaca-trainjob-yaml.ipynb TIMEOUT=900


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes https://github.com/kubeflow/trainer/pull/2829 to ask for environment access only if `ok-to-test-gpu-label` is present in the PR.

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
