### PR TITLE
chore(ci): Ignore generated files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+**/zz_generated.*.go linguist-generated=true
+api/** linguist-generated=true
+pkg/client/** linguist-generated=true


### PR DESCRIPTION
I added `.gitattributes` to ignore generated files like in k/k: https://github.com/kubernetes/kubernetes/blob/master/.gitattributes

/assign @kubeflow/kubeflow-trainer-team 