### PR TITLE
feat: add framework-level validation for conflicting env vars across …

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -289,6 +289,14 @@ var (
 	// XGBoostReservedEnvNames is XGBoost reserved env names that should not be set by users.
 	XGBoostReservedEnvNames = sets.New(XGBoostEnvTrackerURI, XGBoostEnvTrackerPort, XGBoostEnvTaskID, XGBoostEnvNumWorker)
 
+	// MPIRunReservedEnvNames is the set of environment variable names reserved by the MPI plugin.
+	MPIRunReservedEnvNames = sets.New(
+		OpenMPIEnvHostFileLocation,
+		OpenMPIEnvKeyRSHArgs,
+		OpenMPIEnvKeepFQDNHostNames,
+		OpenMPIEnvDefaultSlots,
+	)
+
 	// ResourceInUseFinalizer is a finalizer for managed resources which is used by other resources.
 	ResourceInUseFinalizer = fmt.Sprintf("%s/resource-in-use", trainer.GroupVersion.Group)
 

--- a/pkg/runtime/framework/core/framework.go
+++ b/pkg/runtime/framework/core/framework.go
@@ -19,8 +19,10 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -121,6 +123,28 @@ func (f *Framework) RunCustomValidationPlugins(ctx context.Context, info *runtim
 			aggregatedErrors = append(aggregatedErrors, errs...)
 		}
 	}
+
+	// Check for cross-plugin env conflicts.
+	pluginReservedEnvs := map[string]sets.Set[string]{}
+	for _, plugin := range f.customValidationPlugins {
+		if reserver, ok := plugin.(framework.EnvVarsReserverPlugin); ok {
+			pluginReservedEnvs[plugin.Name()] = reserver.ReservedEnvVarNames()
+		}
+	}
+	pluginNames := sets.List(sets.KeySet(pluginReservedEnvs))
+	for i, nameA := range pluginNames {
+		for _, nameB := range pluginNames[i+1:] {
+			overlap := pluginReservedEnvs[nameA].Intersection(pluginReservedEnvs[nameB])
+			for _, envVar := range sets.List(overlap) {
+				aggregatedErrors = append(aggregatedErrors, field.Invalid(
+					field.NewPath("spec"),
+					envVar,
+					fmt.Sprintf("env var %q is reserved by both %s and %s plugins", envVar, nameA, nameB),
+				))
+			}
+		}
+	}
+
 	return aggregatedWarnings, aggregatedErrors
 }
 

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	batchv1ac "k8s.io/client-go/applyconfigurations/batch/v1"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
@@ -464,6 +465,18 @@ func TestRunCustomValidationPlugins(t *testing.T) {
 		"an empty registry": {
 			oldObj: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").Obj(),
 			newObj: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").Obj(),
+		},
+		"cross-plugin env conflict is detected": {
+			registry: fwkplugins.Registry{
+				"FakeEnvReserverA": newFakeEnvReserverA,
+				"FakeEnvReserverB": newFakeEnvReserverB,
+			},
+			oldObj: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").Obj(),
+			newObj: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").Obj(),
+			wantError: field.ErrorList{
+				field.Invalid(field.NewPath("spec"), "SHARED_ENV_VAR",
+					`env var "SHARED_ENV_VAR" is reserved by both FakeEnvReserverA and FakeEnvReserverB plugins`),
+			},
 		},
 	}
 	for name, tc := range cases {
@@ -2306,6 +2319,38 @@ func TestWatchExtensionPlugins(t *testing.T) {
 }
 
 type fakeTrainJobStatusPlugin struct{}
+
+type fakeEnvReserverA struct{}
+
+var _ framework.CustomValidationPlugin = (*fakeEnvReserverA)(nil)
+var _ framework.EnvVarsReserverPlugin = (*fakeEnvReserverA)(nil)
+
+func (f *fakeEnvReserverA) Name() string { return "FakeEnvReserverA" }
+func (f *fakeEnvReserverA) Validate(_ context.Context, _ *runtime.Info, _, _ *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
+	return nil, nil
+}
+func (f *fakeEnvReserverA) ReservedEnvVarNames() sets.Set[string] {
+	return sets.New("SHARED_ENV_VAR")
+}
+func newFakeEnvReserverA(_ context.Context, _ client.Client, _ client.FieldIndexer, _ *configapi.Configuration) (framework.Plugin, error) {
+	return &fakeEnvReserverA{}, nil
+}
+
+type fakeEnvReserverB struct{}
+
+var _ framework.CustomValidationPlugin = (*fakeEnvReserverB)(nil)
+var _ framework.EnvVarsReserverPlugin = (*fakeEnvReserverB)(nil)
+
+func (f *fakeEnvReserverB) Name() string { return "FakeEnvReserverB" }
+func (f *fakeEnvReserverB) Validate(_ context.Context, _ *runtime.Info, _, _ *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
+	return nil, nil
+}
+func (f *fakeEnvReserverB) ReservedEnvVarNames() sets.Set[string] {
+	return sets.New("SHARED_ENV_VAR")
+}
+func newFakeEnvReserverB(_ context.Context, _ client.Client, _ client.FieldIndexer, _ *configapi.Configuration) (framework.Plugin, error) {
+	return &fakeEnvReserverB{}, nil
+}
 
 var _ framework.TrainJobStatusPlugin = (*fakeTrainJobStatusPlugin)(nil)
 

--- a/pkg/runtime/framework/interface.go
+++ b/pkg/runtime/framework/interface.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -34,6 +35,14 @@ type Plugin interface {
 type CustomValidationPlugin interface {
 	Plugin
 	Validate(ctx context.Context, info *runtime.Info, oldObj, newObj *trainer.TrainJob) (admission.Warnings, field.ErrorList)
+}
+
+// EnvVarsReserverPlugin is an optional interface that plugins can implement
+// to expose the set of environment variable names they reserve.
+// Used for cross-plugin env conflict detection during TrainJob validation.
+type EnvVarsReserverPlugin interface {
+	Plugin
+	ReservedEnvVarNames() sets.Set[string]
 }
 
 type WatchExtensionPlugin interface {

--- a/pkg/runtime/framework/plugins/mpi/mpi.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
@@ -47,6 +48,8 @@ import (
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework"
 )
+
+var _ framework.EnvVarsReserverPlugin = (*MPI)(nil)
 
 // TODO : Support MPICH and IntelMPI implementations.
 
@@ -76,15 +79,34 @@ func (m *MPI) Name() string {
 	return Name
 }
 
-// TODO (andreyvelich): Add validation to check that TrainJob doesn't have MPI envs.
-// TODO (andreyvelich): We should validate that envs from different plugins don't conflict with each other.
-// Ref: https://github.com/kubeflow/trainer/pull/2308#discussion_r1823229940
+func (m *MPI) ReservedEnvVarNames() sets.Set[string] {
+	return constants.MPIRunReservedEnvNames
+}
+
 func (m *MPI) Validate(_ context.Context, runtimeInfo *runtime.Info, _, newJobObj *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
 	var allErrs field.ErrorList
 	if runtimeInfo == nil || runtimeInfo.RuntimePolicy.MLPolicySource == nil || runtimeInfo.RuntimePolicy.MLPolicySource.MPI == nil {
 		return nil, allErrs
 	}
 	specPath := field.NewPath("spec")
+
+	// Validate that user-provided envs don't conflict with MPI-reserved envs.
+	if trainJobTrainer := newJobObj.Spec.Trainer; trainJobTrainer != nil {
+		mpiEnvs := sets.New[string]()
+		for _, env := range trainJobTrainer.Env {
+			if constants.MPIRunReservedEnvNames.Has(env.Name) {
+				mpiEnvs.Insert(env.Name)
+			}
+		}
+		if mpiEnvs.Len() > 0 {
+			trainerEnvsPath := specPath.Child("trainer").Child("env")
+			allErrs = append(allErrs, field.Invalid(
+				trainerEnvsPath,
+				trainJobTrainer.Env,
+				fmt.Sprintf("must not have reserved MPI envs, invalid envs configured: %v", sets.List(mpiEnvs)),
+			))
+		}
+	}
 	// validate PodSet configurations based on NumNodes and RunLauncherAsNode.
 	if trainJobTrainer := newJobObj.Spec.Trainer; trainJobTrainer != nil && ptr.Deref(trainJobTrainer.NumNodes, 1) >= 2 && ptr.Deref(runtimeInfo.RuntimePolicy.MLPolicySource.MPI.RunLauncherAsNode, false) {
 		if runtimeInfo.FindPodSetByName(constants.Launcher) == nil || runtimeInfo.FindPodSetByName(constants.Node) == nil {

--- a/pkg/runtime/framework/plugins/mpi/mpi_test.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/klog/v2/ktesting"
@@ -986,6 +987,51 @@ func TestValidate(t *testing.T) {
 			wantError: field.ErrorList{
 				field.Invalid(field.NewPath("spec").Child("trainer", "numNodes"), ptr.To(int32(2)), "must have 1 when MPI trainingRuntime with enabled runLauncherAsNode does not have either launcher and node"),
 			},
+		},
+		"user sets MPI-reserved env fails": {
+			info: runtime.NewInfo(
+				runtime.WithMLPolicySource(utiltesting.MakeMLPolicyWrapper().
+					WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+						MPIPolicy(ptr.To[int32](1), trainer.MPIImplementationOpenMPI, nil, nil).
+						Obj(),
+					).
+					Obj(),
+				),
+			),
+			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				Trainer(utiltesting.MakeTrainJobTrainerWrapper().
+					Env(corev1.EnvVar{
+						Name:  constants.OpenMPIEnvHostFileLocation,
+						Value: "custom-value",
+					}).
+					Obj(),
+				).
+				Obj(),
+			wantError: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec").Child("trainer").Child("env"),
+					[]corev1.EnvVar{{Name: constants.OpenMPIEnvHostFileLocation, Value: "custom-value"}},
+					fmt.Sprintf("must not have reserved MPI envs, invalid envs configured: %v",
+						sets.List(sets.New(constants.OpenMPIEnvHostFileLocation))),
+				),
+			},
+		},
+		"user sets non-reserved env passes": {
+			info: runtime.NewInfo(
+				runtime.WithMLPolicySource(utiltesting.MakeMLPolicyWrapper().
+					WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+						MPIPolicy(ptr.To[int32](1), trainer.MPIImplementationOpenMPI, nil, nil).
+						Obj(),
+					).
+					Obj(),
+				),
+			),
+			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				Trainer(utiltesting.MakeTrainJobTrainerWrapper().
+					Env(corev1.EnvVar{Name: "MY_CUSTOM_VAR", Value: "value"}).
+					Obj(),
+				).
+				Obj(),
 		},
 	}
 	for name, tc := range cases {

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -42,6 +42,7 @@ type Torch struct{}
 
 var _ framework.EnforceMLPolicyPlugin = (*Torch)(nil)
 var _ framework.CustomValidationPlugin = (*Torch)(nil)
+var _ framework.EnvVarsReserverPlugin = (*Torch)(nil)
 
 const Name = "Torch"
 
@@ -51,6 +52,10 @@ func New(context.Context, client.Client, client.FieldIndexer, *configapi.Configu
 
 func (t *Torch) Name() string {
 	return Name
+}
+
+func (t *Torch) ReservedEnvVarNames() sets.Set[string] {
+	return constants.TorchRunReservedEnvNames
 }
 
 func (t *Torch) Validate(_ context.Context, runtimeInfo *runtime.Info, _, newObj *trainer.TrainJob) (admission.Warnings, field.ErrorList) {


### PR DESCRIPTION
## What this PR does / why we need it

Adds framework-level validation to detect conflicts between environment variables managed by different runtime plugins (MPI, Torch), and between plugin-reserved envs and user-provided envs in a TrainJob.

## Changes

- Add `MPIRunReservedEnvNames` constant for OpenMPI reserved env vars
- Add user-env conflict validation to MPI plugin (mirrors existing Torch pattern)
- Add `EnvVarsReserverPlugin` interface for plugins to expose reserved env var names
- Implement `ReservedEnvVarNames()` on MPI and Torch plugins
- Add cross-plugin env conflict detection in `RunCustomValidationPlugins`
- Add unit tests for MPI env validation

## Which issue(s) this PR fixes

Closes #3147