### PR TITLE
feat: support multiple replicas for non-trainer replicatedJobs

### DIFF
--- a/pkg/runtime/core/trainingruntime.go
+++ b/pkg/runtime/core/trainingruntime.go
@@ -185,9 +185,8 @@ func (r *TrainingRuntime) newRuntimeInfo(
 	}
 
 	for i, rJob := range jobSetSpecApply.ReplicatedJobs {
-		// TODO: Support multiple replicas ('.template.spec.replicatedJobs[*].replicas') for replicated Jobs.
-		// REF: https://github.com/kubeflow/trainer/issues/2318
-		count := ptr.Deref(rJob.Template.Spec.Parallelism, 1)
+		replicas := ptr.Deref(rJob.Replicas, 1)
+		count := ptr.Deref(rJob.Template.Spec.Parallelism, 1) * replicas
 		var ancestor *string
 		if metadata := rJob.Template.ObjectMetaApplyConfiguration; metadata != nil && metadata.Labels != nil {
 			if labelAncestor, ok := metadata.Labels[constants.LabelTrainJobAncestor]; ok {

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -2141,6 +2141,102 @@ test-job-node-0-1.test-job slots=8
 				wantJobSetWithMergedGPU(metav1.NamespaceDefault, "test-job", "uid", resRequests, "4"),
 			},
 		},
+		"succeeded to build PodGroup and JobSet with multiple replicas for non-trainer replicatedJob.": {
+			trainingRuntime: testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "test-runtime").
+				RuntimeSpec(
+					testingutil.MakeTrainingRuntimeSpecWrapper(testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "test-runtime").Spec).
+						WithMLPolicy(
+							testingutil.MakeMLPolicyWrapper().
+								WithNumNodes(10).
+								Obj(),
+						).
+						PodGroupPolicyCoschedulingSchedulingTimeout(120).
+						Replicas(3, constants.DatasetInitializer).
+						Container(constants.DatasetInitializer, constants.DatasetInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+						Container(constants.ModelInitializer, constants.ModelInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+						Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+						Obj(),
+				).Obj(),
+			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				UID("uid").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
+				Trainer(
+					testingutil.MakeTrainJobTrainerWrapper().
+						NumNodes(10).
+						Obj(),
+				).
+				Obj(),
+			wantObjs: []runtime.Object{
+				testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
+					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
+					Replicas(3, constants.DatasetInitializer).
+					Replicas(1, constants.ModelInitializer, constants.Node, constants.Launcher).
+					Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Launcher).
+					Completions(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Launcher).
+					NumNodes(10).
+					Container(constants.DatasetInitializer, constants.DatasetInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					Container(constants.ModelInitializer, constants.ModelInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					PodLabel(schedulerpluginsv1alpha1.PodGroupLabel, "test-job").
+					Obj(),
+				testingutil.MakeSchedulerPluginsPodGroup(metav1.NamespaceDefault, "test-job").
+					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
+					MinMember(14). // 14 = 10 (trainer nodes) + 3 (DatasetInitializer replicas * 1 pod each) + 1 (ModelInitializer)
+					MinResources(corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("14"),
+					}).
+					SchedulingTimeout(120).
+					Obj(),
+			},
+		},
+		"succeeded to build PodGroup and JobSet with trainer replicatedJob Replicas ignored when NumNodes is set.": {
+			trainingRuntime: testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "test-runtime").
+				RuntimeSpec(
+					testingutil.MakeTrainingRuntimeSpecWrapper(testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "test-runtime").Spec).
+						WithMLPolicy(
+							testingutil.MakeMLPolicyWrapper().
+								WithNumNodes(100).
+								Obj(),
+						).
+						PodGroupPolicyCoschedulingSchedulingTimeout(120).
+						Replicas(4, constants.Node).
+						Container(constants.DatasetInitializer, constants.DatasetInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+						Container(constants.ModelInitializer, constants.ModelInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+						Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+						Obj(),
+				).Obj(),
+			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				UID("uid").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
+				Trainer(
+					testingutil.MakeTrainJobTrainerWrapper().
+						NumNodes(5).
+						Obj(),
+				).
+				Obj(),
+			wantObjs: []runtime.Object{
+				testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "test-job").
+					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
+					Replicas(4, constants.Node).
+					Replicas(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Launcher).
+					Parallelism(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Launcher).
+					Completions(1, constants.DatasetInitializer, constants.ModelInitializer, constants.Launcher).
+					NumNodes(5).
+					Container(constants.DatasetInitializer, constants.DatasetInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					Container(constants.ModelInitializer, constants.ModelInitializer, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, resRequests).
+					PodLabel(schedulerpluginsv1alpha1.PodGroupLabel, "test-job").
+					Obj(),
+				testingutil.MakeSchedulerPluginsPodGroup(metav1.NamespaceDefault, "test-job").
+					ControllerReference(trainer.SchemeGroupVersion.WithKind(trainer.TrainJobKind), "test-job", "uid").
+					MinMember(7). // 7 = 5 (NumNodes, NOT 5*4=20) + 1 (DatasetInitializer) + 1 (ModelInitializer)
+					MinResources(corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("7"),
+					}).
+					SchedulingTimeout(120).
+					Obj(),
+			},
+		},
 		// Failed test cases.
 		"missing trainingRuntime resource": {
 			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job-3").

--- a/pkg/runtime/framework/plugins/jobset/builder.go
+++ b/pkg/runtime/framework/plugins/jobset/builder.go
@@ -47,9 +47,9 @@ func (b *Builder) Initializer(trainJob *trainer.TrainJob) *Builder {
 		}
 		// Update values for the Dataset Initializer Job.
 		if ancestor, ok := jobMetadata.Labels[constants.LabelTrainJobAncestor]; ok && ancestor == constants.DatasetInitializer {
-			// TODO: Support multiple replicas ('.template.spec.replicatedJobs[*].replicas') for replicated Jobs.
-			// REF: https://github.com/kubeflow/trainer/issues/2318
-			b.Spec.ReplicatedJobs[i].Replicas = ptr.To[int32](1)
+			if b.Spec.ReplicatedJobs[i].Replicas == nil {
+				b.Spec.ReplicatedJobs[i].Replicas = ptr.To[int32](1)
+			}
 			for j, container := range rJob.Template.Spec.Template.Spec.Containers {
 				// Update values for the dataset initializer container.
 				if *container.Name == constants.DatasetInitializer && trainJob.Spec.Initializer != nil && trainJob.Spec.Initializer.Dataset != nil {
@@ -73,9 +73,9 @@ func (b *Builder) Initializer(trainJob *trainer.TrainJob) *Builder {
 		}
 		// Update values for the Model Initializer Job.
 		if ancestor, ok := jobMetadata.Labels[constants.LabelTrainJobAncestor]; ok && ancestor == constants.ModelInitializer {
-			// TODO: Support multiple replicas ('.template.spec.replicatedJobs[*].replicas') for replicated Jobs.
-			// REF: https://github.com/kubeflow/trainer/issues/2318
-			b.Spec.ReplicatedJobs[i].Replicas = ptr.To[int32](1)
+			if b.Spec.ReplicatedJobs[i].Replicas == nil {
+				b.Spec.ReplicatedJobs[i].Replicas = ptr.To[int32](1)
+			}
 			for j, container := range rJob.Template.Spec.Template.Spec.Containers {
 				// Update values for the model initializer container.
 				if *container.Name == constants.ModelInitializer && trainJob.Spec.Initializer != nil && trainJob.Spec.Initializer.Model != nil {
@@ -118,9 +118,9 @@ func (b *Builder) Trainer(info *runtime.Info, trainJob *trainer.TrainJob) *Build
 			ancestor = jobMetadata.Labels[constants.LabelTrainJobAncestor]
 		}
 		if ancestor == constants.AncestorTrainer {
-			// TODO: Support multiple replicas ('.template.spec.replicatedJobs[*].replicas') for replicated Jobs.
-			// REF: https://github.com/kubeflow/trainer/issues/2318
-			b.Spec.ReplicatedJobs[i].Replicas = ptr.To[int32](1)
+			if b.Spec.ReplicatedJobs[i].Replicas == nil {
+				b.Spec.ReplicatedJobs[i].Replicas = ptr.To[int32](1)
+			}
 			// Update values for the Trainer container.
 			for j, container := range rJob.Template.Spec.Template.Spec.Containers {
 				if *container.Name == constants.Node {

--- a/pkg/runtime/framework/plugins/jobset/builder_test.go
+++ b/pkg/runtime/framework/plugins/jobset/builder_test.go
@@ -121,7 +121,7 @@ func TestBuilderInitializer(t *testing.T) {
 								},
 							},
 							Name:     ptr.To("initializer-job"),
-							Replicas: ptr.To[int32](1),
+							Replicas: ptr.To[int32](3),
 						},
 					},
 				},
@@ -179,7 +179,7 @@ func TestBuilderInitializer(t *testing.T) {
 								},
 							},
 							Name:     ptr.To("initializer-job"),
-							Replicas: ptr.To[int32](1),
+							Replicas: ptr.To[int32](2),
 						},
 					},
 				},
@@ -272,7 +272,7 @@ func TestBuilderInitializer(t *testing.T) {
 								},
 							},
 							Name:     ptr.To("initializer-job"),
-							Replicas: ptr.To[int32](1),
+							Replicas: ptr.To[int32](3),
 						},
 					},
 				},
@@ -318,14 +318,74 @@ func TestBuilderInitializer(t *testing.T) {
 								},
 							},
 							Name:     ptr.To("initializer-job"),
-							Replicas: ptr.To[int32](1),
+							Replicas: ptr.To[int32](2),
 						},
 					},
 				},
 			},
 		},
-		"dataset initializer ancestor with nil Initializer spec sets replicas to 1": {
+		"dataset initializer ancestor with nil Initializer spec leaves replicas unmodified": {
 			jobSet: makeJobSet(constants.DatasetInitializer, constants.DatasetInitializer, 3, "initializer-job"),
+			trainJob: &trainer.TrainJob{
+				Spec: trainer.TrainJobSpec{
+					Initializer: nil,
+				},
+			},
+			wantJobSet: &jobsetv1alpha2ac.JobSetApplyConfiguration{
+				Spec: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
+					ReplicatedJobs: []jobsetv1alpha2ac.ReplicatedJobApplyConfiguration{
+						{
+							Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+								Spec: &batchv1ac.JobSpecApplyConfiguration{
+									Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+										Spec: &corev1ac.PodSpecApplyConfiguration{
+											Containers: []corev1ac.ContainerApplyConfiguration{
+												{
+													Name: ptr.To(constants.DatasetInitializer),
+												},
+											},
+										},
+									},
+								},
+								ObjectMetaApplyConfiguration: &metav1ac.ObjectMetaApplyConfiguration{
+									Labels: map[string]string{
+										constants.LabelTrainJobAncestor: constants.DatasetInitializer,
+									},
+								},
+							},
+							Name:     ptr.To("initializer-job"),
+							Replicas: ptr.To[int32](3),
+						},
+					},
+				},
+			},
+		},
+		"dataset initializer ancestor with nil replicas defaults to 1": {
+			jobSet: &jobsetv1alpha2ac.JobSetApplyConfiguration{
+				Spec: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
+					ReplicatedJobs: []jobsetv1alpha2ac.ReplicatedJobApplyConfiguration{
+						{
+							Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+								Spec: &batchv1ac.JobSpecApplyConfiguration{
+									Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+										Spec: &corev1ac.PodSpecApplyConfiguration{
+											Containers: []corev1ac.ContainerApplyConfiguration{
+												*corev1ac.Container().WithName(constants.DatasetInitializer),
+											},
+										},
+									},
+								},
+								ObjectMetaApplyConfiguration: &metav1ac.ObjectMetaApplyConfiguration{
+									Labels: map[string]string{
+										constants.LabelTrainJobAncestor: constants.DatasetInitializer,
+									},
+								},
+							},
+							Name: ptr.To("initializer-job"),
+						},
+					},
+				},
+			},
 			trainJob: &trainer.TrainJob{
 				Spec: trainer.TrainJobSpec{
 					Initializer: nil,
@@ -472,7 +532,7 @@ func TestBuilderTrainer(t *testing.T) {
 								},
 							},
 							Name:     ptr.To(constants.Node),
-							Replicas: ptr.To[int32](1),
+							Replicas: ptr.To[int32](4),
 						},
 					},
 				},
@@ -559,7 +619,7 @@ func TestBuilderTrainer(t *testing.T) {
 								},
 							},
 							Name:     ptr.To(constants.Node),
-							Replicas: ptr.To[int32](1),
+							Replicas: ptr.To[int32](4),
 						},
 					},
 				},
@@ -584,10 +644,71 @@ func TestBuilderTrainer(t *testing.T) {
 				},
 			},
 			info:       &runtime.Info{},
-			wantJobSet: makeJobSet(constants.AncestorTrainer, constants.Node, 1, constants.Node),
+			wantJobSet: makeJobSet(constants.AncestorTrainer, constants.Node, 2, constants.Node),
 		},
-		"trainer ancestor with nil Trainer spec sets replicas to 1": {
+		"trainer ancestor with nil Trainer spec leaves replicas unmodified": {
 			jobSet: makeJobSet(constants.AncestorTrainer, constants.Node, 5, constants.Node),
+			trainJob: &trainer.TrainJob{
+				Spec: trainer.TrainJobSpec{
+					Trainer: nil,
+				},
+			},
+			info: &runtime.Info{},
+			wantJobSet: &jobsetv1alpha2ac.JobSetApplyConfiguration{
+				Spec: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
+					ReplicatedJobs: []jobsetv1alpha2ac.ReplicatedJobApplyConfiguration{
+						{
+							Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+								Spec: &batchv1ac.JobSpecApplyConfiguration{
+									Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+										Spec: &corev1ac.PodSpecApplyConfiguration{
+											Containers: []corev1ac.ContainerApplyConfiguration{
+												{
+													Name: ptr.To(constants.Node),
+												},
+											},
+										},
+									},
+								},
+								ObjectMetaApplyConfiguration: &metav1ac.ObjectMetaApplyConfiguration{
+									Labels: map[string]string{
+										constants.LabelTrainJobAncestor: constants.AncestorTrainer,
+									},
+								},
+							},
+							Name:     ptr.To(constants.Node),
+							Replicas: ptr.To[int32](5),
+						},
+					},
+				},
+			},
+		},
+		"trainer ancestor with nil replicas defaults to 1": {
+			jobSet: &jobsetv1alpha2ac.JobSetApplyConfiguration{
+				Spec: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
+					ReplicatedJobs: []jobsetv1alpha2ac.ReplicatedJobApplyConfiguration{
+						{
+							Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+								Spec: &batchv1ac.JobSpecApplyConfiguration{
+									Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+										Spec: &corev1ac.PodSpecApplyConfiguration{
+											Containers: []corev1ac.ContainerApplyConfiguration{
+												*corev1ac.Container().WithName(constants.Node),
+											},
+										},
+									},
+								},
+								ObjectMetaApplyConfiguration: &metav1ac.ObjectMetaApplyConfiguration{
+									Labels: map[string]string{
+										constants.LabelTrainJobAncestor: constants.AncestorTrainer,
+									},
+								},
+							},
+							Name: ptr.To(constants.Node),
+						},
+					},
+				},
+			},
 			trainJob: &trainer.TrainJob{
 				Spec: trainer.TrainJobSpec{
 					Trainer: nil,
@@ -721,7 +842,7 @@ func TestBuilderTrainer(t *testing.T) {
 								},
 							},
 							Name:     ptr.To(constants.Node),
-							Replicas: ptr.To[int32](1),
+							Replicas: ptr.To[int32](3),
 						},
 					},
 				},

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -333,8 +333,22 @@ func (j *JobSet) Build(ctx context.Context, info *runtime.Info, trainJob *traine
 
 	for psIdx, ps := range info.TemplateSpec.PodSets {
 		if ps.Count != nil {
-			jobSetSpec.ReplicatedJobs[psIdx].Template.Spec.Parallelism = ps.Count
-			jobSetSpec.ReplicatedJobs[psIdx].Template.Spec.Completions = ps.Count
+			rJob := &jobSetSpec.ReplicatedJobs[psIdx]
+			jobMetadata := rJob.Template.ObjectMetaApplyConfiguration
+			isTrainer := jobMetadata != nil && jobMetadata.Labels != nil &&
+				jobMetadata.Labels[constants.LabelTrainJobAncestor] == constants.AncestorTrainer
+			if isTrainer {
+				// For trainer: count = NumNodes, use directly as Parallelism/Completions.
+				rJob.Template.Spec.Parallelism = ps.Count
+				rJob.Template.Spec.Completions = ps.Count
+			} else {
+				// For non-trainer: count = parallelism * replicas.
+				// Parallelism/Completions must be per-replica, not total pod count.
+				replicas := ptr.Deref(rJob.Replicas, 1)
+				perReplica := *ps.Count / replicas
+				rJob.Template.Spec.Parallelism = &perReplica
+				rJob.Template.Spec.Completions = &perReplica
+			}
 		}
 		apply.UpsertVolumes(&jobSetSpec.ReplicatedJobs[psIdx].Template.Spec.Template.Spec.Volumes, ps.Volumes...)
 		for containerIdx, container := range ps.Containers {

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -345,6 +345,9 @@ func (j *JobSet) Build(ctx context.Context, info *runtime.Info, trainJob *traine
 				// For non-trainer: count = parallelism * replicas.
 				// Parallelism/Completions must be per-replica, not total pod count.
 				replicas := ptr.Deref(rJob.Replicas, 1)
+				if replicas < 1 {
+					return nil, fmt.Errorf("replicatedJob %s has invalid replicas %d: must be greater than or equal to 1", ptr.Deref(rJob.Name, ""), replicas)
+				}
 				perReplica := *ps.Count / replicas
 				rJob.Template.Spec.Parallelism = &perReplica
 				rJob.Template.Spec.Completions = &perReplica

--- a/pkg/runtime/framework/plugins/jobset/jobset_test.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset_test.go
@@ -2393,6 +2393,34 @@ func TestBuild(t *testing.T) {
 				},
 			},
 		},
+		"non-trainer replicatedJob with zero replicas errors instead of dividing by zero": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{{
+						Name:  constants.DatasetInitializer,
+						Count: ptr.To[int32](4),
+					}},
+					ObjApply: jobsetv1alpha2ac.JobSetSpec().
+						WithReplicatedJobs(jobsetv1alpha2ac.ReplicatedJob().
+							WithName(constants.DatasetInitializer).
+							WithReplicas(0).
+							WithTemplate(batchv1ac.JobTemplateSpec().
+								WithSpec(batchv1ac.JobSpec().
+									WithTemplate(corev1ac.PodTemplateSpec().
+										WithSpec(corev1ac.PodSpec().
+											WithContainers(corev1ac.Container().WithName(constants.DatasetInitializer)),
+										),
+									),
+								),
+							),
+						),
+				},
+				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
+			},
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "trainJob").
+				Obj(),
+			wantError: fmt.Errorf("replicatedJob %s has invalid replicas %d: must be greater than or equal to 1", constants.DatasetInitializer, 0),
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/webhooks/trainingruntime_webhook.go
+++ b/pkg/webhooks/trainingruntime_webhook.go
@@ -76,7 +76,7 @@ func validateReplicatedJobs(rJobs []jobsetv1alpha2.ReplicatedJob) field.ErrorLis
 		}
 
 		if labelAncestor, ok := rJob.Template.Labels[constants.LabelTrainJobAncestor]; ok && ancestors.Has(labelAncestor) {
-			if rJob.Replicas != 1 {
+			if labelAncestor == constants.AncestorTrainer && rJob.Replicas != 1 {
 				allErrs = append(allErrs, field.Invalid(rJobsPath.Index(idx).Child("replicas"), rJob.Replicas, rJobReplicasErrorMsg))
 			}
 

--- a/pkg/webhooks/trainingruntime_webhook.go
+++ b/pkg/webhooks/trainingruntime_webhook.go
@@ -33,6 +33,7 @@ import (
 
 const (
 	rJobReplicasErrorMsg       = "always must be 1"
+	rJobReplicasMinErrorMsg    = "must be greater than or equal to 1"
 	rJobContainerNamesErrorMsg = "must contain the required container for the ancestor: %s"
 )
 
@@ -76,8 +77,12 @@ func validateReplicatedJobs(rJobs []jobsetv1alpha2.ReplicatedJob) field.ErrorLis
 		}
 
 		if labelAncestor, ok := rJob.Template.Labels[constants.LabelTrainJobAncestor]; ok && ancestors.Has(labelAncestor) {
-			if labelAncestor == constants.AncestorTrainer && rJob.Replicas != 1 {
-				allErrs = append(allErrs, field.Invalid(rJobsPath.Index(idx).Child("replicas"), rJob.Replicas, rJobReplicasErrorMsg))
+			if labelAncestor == constants.AncestorTrainer {
+				if rJob.Replicas != 1 {
+					allErrs = append(allErrs, field.Invalid(rJobsPath.Index(idx).Child("replicas"), rJob.Replicas, rJobReplicasErrorMsg))
+				}
+			} else if rJob.Replicas < 1 {
+				allErrs = append(allErrs, field.Invalid(rJobsPath.Index(idx).Child("replicas"), rJob.Replicas, rJobReplicasMinErrorMsg))
 			}
 
 			// Validate replicated job contains the required containers.

--- a/pkg/webhooks/trainingruntime_webhook_test.go
+++ b/pkg/webhooks/trainingruntime_webhook_test.go
@@ -52,10 +52,6 @@ func TestValidateReplicatedJobs(t *testing.T) {
 				Replicas(2, constants.Launcher, constants.Node, constants.DatasetInitializer, constants.ModelInitializer).
 				Obj().Spec.ReplicatedJobs,
 			wantError: field.ErrorList{
-				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(0).Child("replicas"),
-					"2", ""),
-				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(1).Child("replicas"),
-					"2", ""),
 				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(3).Child("replicas"),
 					"2", ""),
 			},

--- a/pkg/webhooks/trainingruntime_webhook_test.go
+++ b/pkg/webhooks/trainingruntime_webhook_test.go
@@ -56,6 +56,17 @@ func TestValidateReplicatedJobs(t *testing.T) {
 					"2", ""),
 			},
 		},
+		"invalid non-trainer replicas below one": {
+			rJobs: testingutil.MakeJobSetWrapper("ns", "valid").
+				Replicas(1, constants.Node).
+				Obj().Spec.ReplicatedJobs,
+			wantError: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(0).Child("replicas"),
+					"0", ""),
+				field.Invalid(field.NewPath("spec").Child("template").Child("spec").Child("replicatedJobs").Index(1).Child("replicas"),
+					"0", ""),
+			},
+		},
 		"missing required container in replicatedJobs": {
 			rJobs: testingutil.MakeJobSetWrapper("ns", "valid").
 				Replicas(1, constants.Launcher, constants.Node, constants.DatasetInitializer, constants.ModelInitializer).


### PR DESCRIPTION
## Description

Resolves #2318 (partial).

Currently, `newRuntimeInfo()` in `trainingruntime.go` derives pod count only from `Template.Spec.Parallelism`, effectively assuming `replicas=1`. This PR reads `.replicas` from each replicatedJob and uses it to correctly compute pod counts and configure the JobSet.

## Changes

- **trainingruntime.go**: Read `replicas` from each replicatedJob and multiply with `parallelism` for PodGroup `MinMember` count. The trainer ancestor case uses `NumNodes` directly and is unaffected.
- **builder.go**: Preserve the `Replicas` field from the runtime template instead of unconditionally overwriting with `1`.
- **jobset.go**: Split `Parallelism`/`Completions` assignment in `Build()` - trainer uses `count` directly, non-trainer divides by `replicas` to get the per-replica value.

## Testing

Added two test cases to `TestTrainingRuntimeNewObjects`:
- Non-trainer replicatedJob with `replicas=3`: verifies pod count multiplication, correct `Parallelism=1`, `Replicas=3`, and `MinMember=14`
- Trainer replicatedJob with `replicas=4` and `NumNodes=5`: verifies `NumNodes` takes precedence (`MinMember=7`, not `5*4=20`)

## Notes

Endpoint generation in `IdentifyPodNetwork` for multi-replica non-trainer jobs is not addressed here. Initializer jobs do not participate in training network topology, so this is currently harmless and tracked by the existing TODO comment referencing #2318.