### PR TITLE
feat(controller): register TrainJobStatus server with controller manager healthz and readyz probes

### DIFF
--- a/cmd/trainer-controller-manager/main.go
+++ b/cmd/trainer-controller-manager/main.go
@@ -172,7 +172,7 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	
+
 	// Set up controllers and other components using goroutines to start the manager quickly.
 	go setupManagerComponents(mgr, runtimes, &cfg, certsReady, enableHTTP2, &statusServerReady)
 

--- a/cmd/trainer-controller-manager/main.go
+++ b/cmd/trainer-controller-manager/main.go
@@ -161,7 +161,6 @@ func main() {
 	// Set up controllers and other components using goroutines to start the manager quickly.
 	go setupManagerComponents(mgr, runtimes, &cfg, certsReady, enableHTTP2)
 
-
 	setupLog.Info("Starting manager")
 	if err = mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "Could not run manager")

--- a/cmd/trainer-controller-manager/main.go
+++ b/cmd/trainer-controller-manager/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"net/http"
 	"os"
+	"sync/atomic"
 
 	zaplog "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -155,14 +156,25 @@ func main() {
 	// AddHealthzCheck/AddReadyzCheck return errors if called after the manager
 	// has already started, which is what was happening when this was inside
 	// the setupManagerComponents goroutine.
+	var statusServerReady atomic.Bool
 	if features.Enabled(features.TrainJobStatus) {
-		if err := statusserver.SetupServer(mgr, cfg.StatusServer, enableHTTP2); err != nil {
-			setupLog.Error(err, "Could not create runtime status server")
+		if err := mgr.AddHealthzCheck("status-server", healthz.Ping); err != nil {
+			setupLog.Error(err, "unable to set up status server health check")
+			os.Exit(1)
+		}
+		if err := mgr.AddReadyzCheck("status-server", func(_ *http.Request) error {
+			if !statusServerReady.Load() {
+				return errors.New("status server is not ready")
+			}
+			return nil
+		}); err != nil {
+			setupLog.Error(err, "unable to set up status server ready check")
 			os.Exit(1)
 		}
 	}
+	
 	// Set up controllers and other components using goroutines to start the manager quickly.
-	go setupManagerComponents(mgr, runtimes, &cfg, certsReady, enableHTTP2)
+	go setupManagerComponents(mgr, runtimes, &cfg, certsReady, enableHTTP2, &statusServerReady)
 
 	setupLog.Info("Starting manager")
 	if err = mgr.Start(ctx); err != nil {
@@ -171,7 +183,7 @@ func main() {
 	}
 }
 
-func setupManagerComponents(mgr ctrl.Manager, runtimes map[string]runtime.Runtime, cfg *configapi.Configuration, certsReady <-chan struct{}, enableHTTP2 bool) {
+func setupManagerComponents(mgr ctrl.Manager, runtimes map[string]runtime.Runtime, cfg *configapi.Configuration, certsReady <-chan struct{}, enableHTTP2 bool, statusServerReady *atomic.Bool) {
 	setupLog.Info("Waiting for certificate generation to complete")
 	<-certsReady
 	setupLog.Info("Certs ready")
@@ -183,6 +195,13 @@ func setupManagerComponents(mgr ctrl.Manager, runtimes map[string]runtime.Runtim
 	if failedWebhook, err := webhooks.Setup(mgr, runtimes); err != nil {
 		setupLog.Error(err, "Could not create webhook", "webhook", failedWebhook)
 		os.Exit(1)
+	}
+	if features.Enabled(features.TrainJobStatus) {
+		if err := statusserver.SetupServer(mgr, cfg.StatusServer, enableHTTP2); err != nil {
+			setupLog.Error(err, "Could not create runtime status server")
+			os.Exit(1)
+		}
+		statusServerReady.Store(true)
 	}
 }
 

--- a/cmd/trainer-controller-manager/main.go
+++ b/cmd/trainer-controller-manager/main.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"net/http"
 	"os"
-	"sync/atomic"
 
 	zaplog "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -152,29 +151,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Register status server before goroutine starts and before mgr.Start().
-	// AddHealthzCheck/AddReadyzCheck return errors if called after the manager
-	// has already started, which is what was happening when this was inside
-	// the setupManagerComponents goroutine.
-	var statusServerReady atomic.Bool
 	if features.Enabled(features.TrainJobStatus) {
-		if err := mgr.AddHealthzCheck("status-server", healthz.Ping); err != nil {
-			setupLog.Error(err, "unable to set up status server health check")
-			os.Exit(1)
-		}
-		if err := mgr.AddReadyzCheck("status-server", func(_ *http.Request) error {
-			if !statusServerReady.Load() {
-				return errors.New("status server is not ready")
-			}
-			return nil
-		}); err != nil {
-			setupLog.Error(err, "unable to set up status server ready check")
+		if err := statusserver.RegisterProbes(mgr, cfg.StatusServer); err != nil {
+			setupLog.Error(err, "unable to register status server probes")
 			os.Exit(1)
 		}
 	}
 
 	// Set up controllers and other components using goroutines to start the manager quickly.
-	go setupManagerComponents(mgr, runtimes, &cfg, certsReady, enableHTTP2, &statusServerReady)
+	go setupManagerComponents(mgr, runtimes, &cfg, certsReady, enableHTTP2)
+
 
 	setupLog.Info("Starting manager")
 	if err = mgr.Start(ctx); err != nil {
@@ -183,7 +169,7 @@ func main() {
 	}
 }
 
-func setupManagerComponents(mgr ctrl.Manager, runtimes map[string]runtime.Runtime, cfg *configapi.Configuration, certsReady <-chan struct{}, enableHTTP2 bool, statusServerReady *atomic.Bool) {
+func setupManagerComponents(mgr ctrl.Manager, runtimes map[string]runtime.Runtime, cfg *configapi.Configuration, certsReady <-chan struct{}, enableHTTP2 bool) {
 	setupLog.Info("Waiting for certificate generation to complete")
 	<-certsReady
 	setupLog.Info("Certs ready")
@@ -201,7 +187,6 @@ func setupManagerComponents(mgr ctrl.Manager, runtimes map[string]runtime.Runtim
 			setupLog.Error(err, "Could not create runtime status server")
 			os.Exit(1)
 		}
-		statusServerReady.Store(true)
 	}
 }
 

--- a/cmd/trainer-controller-manager/main.go
+++ b/cmd/trainer-controller-manager/main.go
@@ -150,6 +150,17 @@ func main() {
 		setupLog.Error(err, "Could not initialize runtimes")
 		os.Exit(1)
 	}
+
+	// Register status server before goroutine starts and before mgr.Start().
+	// AddHealthzCheck/AddReadyzCheck return errors if called after the manager
+	// has already started, which is what was happening when this was inside
+	// the setupManagerComponents goroutine.
+	if features.Enabled(features.TrainJobStatus) {
+		if err := statusserver.SetupServer(mgr, cfg.StatusServer, enableHTTP2); err != nil {
+			setupLog.Error(err, "Could not create runtime status server")
+			os.Exit(1)
+		}
+	}
 	// Set up controllers and other components using goroutines to start the manager quickly.
 	go setupManagerComponents(mgr, runtimes, &cfg, certsReady, enableHTTP2)
 
@@ -172,13 +183,6 @@ func setupManagerComponents(mgr ctrl.Manager, runtimes map[string]runtime.Runtim
 	if failedWebhook, err := webhooks.Setup(mgr, runtimes); err != nil {
 		setupLog.Error(err, "Could not create webhook", "webhook", failedWebhook)
 		os.Exit(1)
-	}
-
-	if features.Enabled(features.TrainJobStatus) {
-		if err := statusserver.SetupServer(mgr, cfg.StatusServer, enableHTTP2); err != nil {
-			setupLog.Error(err, "Could not create runtime status server")
-			os.Exit(1)
-		}
 	}
 }
 

--- a/cmd/trainer-controller-manager/main.go
+++ b/cmd/trainer-controller-manager/main.go
@@ -144,6 +144,16 @@ func main() {
 		setupLog.Error(err, "Could not initialize runtimes")
 		os.Exit(1)
 	}
+
+	// The status server probes must be registered before the manager starts,
+	// because controller-runtime rejects check registrations afterwards.
+	if features.Enabled(features.TrainJobStatus) {
+		if err := statusserver.RegisterProbes(mgr, cfg.StatusServer); err != nil {
+			setupLog.Error(err, "Could not register runtime status server probes")
+			os.Exit(1)
+		}
+	}
+
 	// Set up controllers and other components using goroutines to start the manager quickly.
 	go setupManagerComponents(mgr, runtimes, &cfg, certsReady)
 

--- a/pkg/statusserver/server.go
+++ b/pkg/statusserver/server.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/http"
 	"time"
 
@@ -32,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
@@ -213,24 +211,6 @@ func (s *Server) handleTrainJobRuntimeStatus(w http.ResponseWriter, r *http.Requ
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(updateRequest); err != nil {
 		s.log.Error(err, "Failed to write TrainJob status", "namespace", namespace, "name", trainJobName)
-	}
-}
-
-// StartedChecker returns a healthz.Checker that dials the status server over TLS.
-// Returns an error until the server is actively accepting connections.
-func (s *Server) StartedChecker() healthz.Checker {
-	tlsCfg := &tls.Config{InsecureSkipVerify: true} //nolint:gosec
-	return func(_ *http.Request) error {
-		conn, err := tls.DialWithDialer(
-			&net.Dialer{Timeout: 10 * time.Second},
-			"tcp",
-			s.httpServer.Addr,
-			tlsCfg,
-		)
-		if err != nil {
-			return fmt.Errorf("status server not reachable at %s: %w", s.httpServer.Addr, err)
-		}
-		return conn.Close()
 	}
 }
 

--- a/pkg/statusserver/server.go
+++ b/pkg/statusserver/server.go
@@ -23,8 +23,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -32,12 +32,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	trainerv1alpha1ac "github.com/kubeflow/trainer/v2/pkg/client/applyconfiguration/trainer/v1alpha1"
 )
+
 
 const (
 	shutdownTimeout = 5 * time.Second
@@ -57,8 +59,8 @@ type Server struct {
 	httpServer *http.Server
 	client     client.Client
 	authorizer TokenAuthorizer
-	ready      atomic.Bool
 }
+
 
 var (
 	_ manager.Runnable               = &Server{}
@@ -124,7 +126,6 @@ func (s *Server) Start(ctx context.Context) error {
 	go func() {
 		defer close(serverShutdown)
 		<-ctx.Done()
-		s.ready.Store(false)
 		s.log.Info("Shutting down runtime status server")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
@@ -133,8 +134,6 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	}()
 
-	s.ready.Store(true)
-	defer s.ready.Store(false)
 	s.log.Info("Starting runtime status server with TLS", "address", s.httpServer.Addr)
 	if err := s.httpServer.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return fmt.Errorf("runtime status server failed: %w", err)
@@ -146,14 +145,6 @@ func (s *Server) Start(ctx context.Context) error {
 func (s *Server) NeedLeaderElection() bool {
 	// server needs to run on all replicas
 	return false
-}
-
-// Check implements healthz.Checker and returns an error if the status server is not ready.
-func (s *Server) Check(_ *http.Request) error {
-	if !s.ready.Load() {
-		return fmt.Errorf("runtime status server is not ready")
-	}
-	return nil
 }
 
 // handleTrainJobRuntimeStatus handles POST requests to update TrainJob status.
@@ -224,6 +215,24 @@ func (s *Server) handleTrainJobRuntimeStatus(w http.ResponseWriter, r *http.Requ
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(updateRequest); err != nil {
 		s.log.Error(err, "Failed to write TrainJob status", "namespace", namespace, "name", trainJobName)
+	}
+}
+
+// StartedChecker returns a healthz.Checker that dials the status server over TLS.
+// Returns an error until the server is actively accepting connections.
+func (s *Server) StartedChecker() healthz.Checker {
+	tlsCfg := &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	return func(_ *http.Request) error {
+		conn, err := tls.DialWithDialer(
+			&net.Dialer{Timeout: 10 * time.Second},
+			"tcp",
+			s.httpServer.Addr,
+			tlsCfg,
+		)
+		if err != nil {
+			return fmt.Errorf("status server not reachable at %s: %w", s.httpServer.Addr, err)
+		}
+		return conn.Close()
 	}
 }
 

--- a/pkg/statusserver/server.go
+++ b/pkg/statusserver/server.go
@@ -40,7 +40,6 @@ import (
 	trainerv1alpha1ac "github.com/kubeflow/trainer/v2/pkg/client/applyconfiguration/trainer/v1alpha1"
 )
 
-
 const (
 	shutdownTimeout = 5 * time.Second
 
@@ -60,7 +59,6 @@ type Server struct {
 	client     client.Client
 	authorizer TokenAuthorizer
 }
-
 
 var (
 	_ manager.Runnable               = &Server{}

--- a/pkg/statusserver/server.go
+++ b/pkg/statusserver/server.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -56,6 +57,7 @@ type Server struct {
 	httpServer *http.Server
 	client     client.Client
 	authorizer TokenAuthorizer
+	ready      atomic.Bool
 }
 
 var (
@@ -120,7 +122,9 @@ func (s *Server) Start(ctx context.Context) error {
 	// Handle graceful shutdown in background
 	serverShutdown := make(chan struct{})
 	go func() {
+		defer close(serverShutdown)
 		<-ctx.Done()
+		s.ready.Store(false)
 		s.log.Info("Shutting down runtime status server")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
@@ -129,11 +133,12 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	}()
 
+	s.ready.Store(true)
+	defer s.ready.Store(false)
 	s.log.Info("Starting runtime status server with TLS", "address", s.httpServer.Addr)
 	if err := s.httpServer.ListenAndServeTLS("", ""); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return fmt.Errorf("runtime status server failed: %w", err)
 	}
-
 	<-serverShutdown
 	return nil
 }
@@ -141,6 +146,14 @@ func (s *Server) Start(ctx context.Context) error {
 func (s *Server) NeedLeaderElection() bool {
 	// server needs to run on all replicas
 	return false
+}
+
+// Check implements healthz.Checker and returns an error if the status server is not ready.
+func (s *Server) Check(_ *http.Request) error {
+	if !s.ready.Load() {
+		return fmt.Errorf("runtime status server is not ready")
+	}
+	return nil
 }
 
 // handleTrainJobRuntimeStatus handles POST requests to update TrainJob status.

--- a/pkg/statusserver/server.go
+++ b/pkg/statusserver/server.go
@@ -120,6 +120,7 @@ func (s *Server) Start(ctx context.Context) error {
 	// Handle graceful shutdown in background
 	serverShutdown := make(chan struct{})
 	go func() {
+		defer close(serverShutdown)
 		<-ctx.Done()
 		s.log.Info("Shutting down runtime status server")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)

--- a/pkg/statusserver/server_test.go
+++ b/pkg/statusserver/server_test.go
@@ -154,35 +154,3 @@ func TestServerErrorResponses(t *testing.T) {
 		})
 	}
 }
-
-func TestStartedChecker(t *testing.T) {
-	// Start a real TLS test server to simulate the status server being up.
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-
-	srv, err := NewServer(
-		nil,
-		&configapi.StatusServer{Port: ptr.To[int32](8080)},
-		&tls.Config{},
-		fakeAuthorizer{},
-	)
-	if err != nil {
-		t.Fatalf("NewServer() error: %v", err)
-	}
-	// Point the server's address to the test TLS server.
-	srv.httpServer.Addr = ts.Listener.Addr().String()
-
-	checker := srv.StartedChecker()
-
-	// Server is running: checker should return nil.
-	if err := checker(nil); err != nil {
-		t.Errorf("StartedChecker() = %v, want nil when server is running", err)
-	}
-
-	// Stop the server: checker should return an error.
-	ts.Close()
-	if err := checker(nil); err == nil {
-		t.Error("StartedChecker() = nil, want error when server is stopped")
-	}
-}

--- a/pkg/statusserver/server_test.go
+++ b/pkg/statusserver/server_test.go
@@ -155,7 +155,12 @@ func TestServerErrorResponses(t *testing.T) {
 	}
 }
 
-func TestServerCheck(t *testing.T) {
+func TestStartedChecker(t *testing.T) {
+	// Start a real TLS test server to simulate the status server being up.
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
 	srv, err := NewServer(
 		nil,
 		&configapi.StatusServer{Port: ptr.To[int32](8080)},
@@ -165,21 +170,19 @@ func TestServerCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer() error: %v", err)
 	}
+	// Point the server's address to the test TLS server.
+	srv.httpServer.Addr = ts.Listener.Addr().String()
 
-	// Before ready: Check should return error
-	if err := srv.Check(nil); err == nil {
-		t.Error("Check() = nil, want error before server is ready")
+	checker := srv.StartedChecker()
+
+	// Server is running: checker should return nil.
+	if err := checker(nil); err != nil {
+		t.Errorf("StartedChecker() = %v, want nil when server is running", err)
 	}
 
-	// After marking ready: Check should return nil
-	srv.ready.Store(true)
-	if err := srv.Check(nil); err != nil {
-		t.Errorf("Check() = %v, want nil after server is ready", err)
-	}
-
-	// After marking not ready: Check should return error again
-	srv.ready.Store(false)
-	if err := srv.Check(nil); err == nil {
-		t.Error("Check() = nil, want error after server marked not ready")
+	// Stop the server: checker should return an error.
+	ts.Close()
+	if err := checker(nil); err == nil {
+		t.Error("StartedChecker() = nil, want error when server is stopped")
 	}
 }

--- a/pkg/statusserver/server_test.go
+++ b/pkg/statusserver/server_test.go
@@ -154,3 +154,32 @@ func TestServerErrorResponses(t *testing.T) {
 		})
 	}
 }
+
+func TestServerCheck(t *testing.T) {
+	srv, err := NewServer(
+		nil,
+		&configapi.StatusServer{Port: ptr.To[int32](8080)},
+		&tls.Config{},
+		fakeAuthorizer{},
+	)
+	if err != nil {
+		t.Fatalf("NewServer() error: %v", err)
+	}
+
+	// Before ready: Check should return error
+	if err := srv.Check(nil); err == nil {
+		t.Error("Check() = nil, want error before server is ready")
+	}
+
+	// After marking ready: Check should return nil
+	srv.ready.Store(true)
+	if err := srv.Check(nil); err != nil {
+		t.Errorf("Check() = %v, want nil after server is ready", err)
+	}
+
+	// After marking not ready: Check should return error again
+	srv.ready.Store(false)
+	if err := srv.Check(nil); err == nil {
+		t.Error("Check() = nil, want error after server marked not ready")
+	}
+}

--- a/pkg/statusserver/server_test.go
+++ b/pkg/statusserver/server_test.go
@@ -22,10 +22,12 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,6 +65,74 @@ func newTestServer(t *testing.T, cfg *configapi.StatusServer, authorizer TokenAu
 	}
 
 	return httptest.NewServer(srv.httpServer.Handler)
+}
+
+// serverLifecycleTimeout bounds how long the server lifecycle test waits for the server to
+// start serving and to stop again.
+const serverLifecycleTimeout = 30 * time.Second
+
+// TestServerStartReturnsAfterContextCancel guards the invariant that Start returns
+// once its context is cancelled. Nothing but Start's own goroutine closes the
+// shutdown channel it waits on, so a regression there leaves the server runnable
+// blocked forever and the manager never finishes stopping.
+func TestServerStartReturnsAfterContextCancel(t *testing.T) {
+	// Reuse the localhost certificate httptest ships with, so that the server can
+	// serve real TLS without this test having to mint a certificate of its own.
+	certSrv := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(certSrv.Close)
+
+	srv, err := NewServer(
+		utiltesting.NewClientBuilder().Build(),
+		&configapi.StatusServer{Port: ptr.To(freeLoopbackPort(t))},
+		&tls.Config{Certificates: certSrv.TLS.Certificates},
+		fakeAuthorizer{authorized: true},
+	)
+	if err != nil {
+		t.Fatalf("NewServer() error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan error, 1)
+	go func() { stopped <- srv.Start(ctx) }()
+
+	// Wait for the server to serve before stopping it, so that the shutdown path
+	// under test is the one that runs in production.
+	isServing := probeChecker(srv.httpServer.Addr)
+	deadline := time.Now().Add(serverLifecycleTimeout)
+	for isServing(nil) != nil {
+		if time.Now().After(deadline) {
+			t.Fatal("Timed out waiting for the status server to accept TLS connections")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	cancel()
+
+	select {
+	case err := <-stopped:
+		if err != nil {
+			t.Errorf("Start() error after context cancellation: %v", err)
+		}
+	case <-time.After(serverLifecycleTimeout):
+		t.Fatal("Start() did not return after its context was cancelled")
+	}
+}
+
+// freeLoopbackPort reserves a port from the kernel and releases it again, so the
+// caller can bind it. This is racy in principle but reliable enough for a test.
+func freeLoopbackPort(t *testing.T) int32 {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Failed to reserve a free port: %v", err)
+	}
+	port := int32(ln.Addr().(*net.TCPAddr).Port)
+	if err := ln.Close(); err != nil {
+		t.Fatalf("Failed to release the reserved port: %v", err)
+	}
+
+	return port
 }
 
 func TestServerErrorResponses(t *testing.T) {

--- a/pkg/statusserver/setup.go
+++ b/pkg/statusserver/setup.go
@@ -58,7 +58,7 @@ func SetupServer(mgr ctrl.Manager, cfg *configapi.StatusServer, enableHTTP2 bool
 
 // RegisterProbes registers the status server with the manager's healthz and readyz probes.
 // Must be called before mgr.Start(). Uses a TLS dial to verify the server is reachable,
-// following the same pattern as the webhook server's StartedChecker.
+// following the same pattern as the webhook server probe.
 func RegisterProbes(mgr ctrl.Manager, cfg *configapi.StatusServer) error {
 	addr := fmt.Sprintf(":%d", *cfg.Port)
 	tlsCfg := &tls.Config{InsecureSkipVerify: true} //nolint:gosec

--- a/pkg/statusserver/setup.go
+++ b/pkg/statusserver/setup.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/util/cert"
@@ -47,6 +48,12 @@ func SetupServer(mgr ctrl.Manager, cfg *configapi.StatusServer, enableHTTP2 bool
 	server, err := NewServer(cli, cfg, tlsConfig, authorizer)
 	if err != nil {
 		return err
+	}
+	if err := mgr.AddHealthzCheck("status-server", healthz.Ping); err != nil {
+		return fmt.Errorf("failed to add status server healthz check: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("status-server", healthz.Checker(server.Check)); err != nil {
+		return fmt.Errorf("failed to add status server readyz check: %w", err)
 	}
 	return mgr.Add(server)
 }

--- a/pkg/statusserver/setup.go
+++ b/pkg/statusserver/setup.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/util/cert"
@@ -48,12 +47,6 @@ func SetupServer(mgr ctrl.Manager, cfg *configapi.StatusServer, enableHTTP2 bool
 	server, err := NewServer(cli, cfg, tlsConfig, authorizer)
 	if err != nil {
 		return err
-	}
-	if err := mgr.AddHealthzCheck("status-server", healthz.Ping); err != nil {
-		return fmt.Errorf("failed to add status server healthz check: %w", err)
-	}
-	if err := mgr.AddReadyzCheck("status-server", healthz.Checker(server.Check)); err != nil {
-		return fmt.Errorf("failed to add status server readyz check: %w", err)
 	}
 	return mgr.Add(server)
 }

--- a/pkg/statusserver/setup.go
+++ b/pkg/statusserver/setup.go
@@ -17,11 +17,16 @@ limitations under the License.
 package statusserver
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net"
+	"net/http"
+	"time"
 
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/util/cert"
@@ -49,6 +54,33 @@ func SetupServer(mgr ctrl.Manager, cfg *configapi.StatusServer, enableHTTP2 bool
 		return err
 	}
 	return mgr.Add(server)
+}
+
+// RegisterProbes registers the status server with the manager's healthz and readyz probes.
+// Must be called before mgr.Start(). Uses a TLS dial to verify the server is reachable,
+// following the same pattern as the webhook server's StartedChecker.
+func RegisterProbes(mgr ctrl.Manager, cfg *configapi.StatusServer) error {
+	addr := fmt.Sprintf(":%d", *cfg.Port)
+	tlsCfg := &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	checker := healthz.Checker(func(_ *http.Request) error {
+		conn, err := tls.DialWithDialer(
+			&net.Dialer{Timeout: 10 * time.Second},
+			"tcp",
+			addr,
+			tlsCfg,
+		)
+		if err != nil {
+			return fmt.Errorf("status server not reachable at %s: %w", addr, err)
+		}
+		return conn.Close()
+	})
+	if err := mgr.AddHealthzCheck("status-server", checker); err != nil {
+		return fmt.Errorf("unable to set up status server health check: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("status-server", checker); err != nil {
+		return fmt.Errorf("unable to set up status server ready check: %w", err)
+	}
+	return nil
 }
 
 func createClient(mgr ctrl.Manager, cfg *configapi.StatusServer) (client.Client, error) {

--- a/pkg/statusserver/setup.go
+++ b/pkg/statusserver/setup.go
@@ -17,15 +17,25 @@ limitations under the License.
 package statusserver
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net"
+	"net/http"
+	"time"
 
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/util/cert"
 )
+
+// probeDialTimeout bounds how long a probe waits for the status server to
+// complete a TLS handshake. It matches the timeout controller-runtime uses for
+// the webhook server probe.
+const probeDialTimeout = 10 * time.Second
 
 func SetupServer(mgr ctrl.Manager, cfg *configapi.StatusServer, tlsOpts *configapi.TLSOptions) error {
 	tlsConfig, err := cert.SetupTLSConfig(mgr, tlsOpts)
@@ -49,6 +59,48 @@ func SetupServer(mgr ctrl.Manager, cfg *configapi.StatusServer, tlsOpts *configa
 		return err
 	}
 	return mgr.Add(server)
+}
+
+// RegisterProbes wires the runtime status server into the manager's healthz and
+// readyz endpoints, so that Kubernetes restarts the controller if the server dies
+// and training nodes only send status updates once it is able to serve them.
+//
+// It must be called before mgr.Start(), because controller-runtime rejects check
+// registrations once the manager is running.
+func RegisterProbes(mgr ctrl.Manager, cfg *configapi.StatusServer) error {
+	if cfg == nil || cfg.Port == nil {
+		return fmt.Errorf("status server port is required to register probes")
+	}
+	checker := probeChecker(fmt.Sprintf(":%d", *cfg.Port))
+	if err := mgr.AddHealthzCheck("status-server-healthz", checker); err != nil {
+		return fmt.Errorf("unable to set up status server health check: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("status-server-readyz", checker); err != nil {
+		return fmt.Errorf("unable to set up status server ready check: %w", err)
+	}
+	return nil
+}
+
+// probeChecker returns a health checker that reports the status server as healthy
+// once it accepts a TLS connection on addr.
+func probeChecker(addr string) healthz.Checker {
+	// The probe only verifies that the local status server is accepting TLS
+	// connections, it never exchanges data with it or acts on its identity.
+	// Dialing ":<port>" also gives no server name to validate the serving
+	// certificate against, so certificate verification is deliberately skipped
+	// here, the same way controller-runtime does it for the webhook server probe:
+	// https://github.com/kubernetes-sigs/controller-runtime/blob/v0.24.1/pkg/webhook/server.go#L274-L276
+	tlsCfg := &tls.Config{InsecureSkipVerify: true} //nolint:gosec // local liveness dial only, see comment above
+	return func(_ *http.Request) error {
+		conn, err := tls.DialWithDialer(&net.Dialer{Timeout: probeDialTimeout}, "tcp", addr, tlsCfg)
+		if err != nil {
+			return fmt.Errorf("status server is not reachable at %s: %w", addr, err)
+		}
+		if err := conn.Close(); err != nil {
+			return fmt.Errorf("status server is not reachable at %s: closing connection: %w", addr, err)
+		}
+		return nil
+	}
 }
 
 func createClient(mgr ctrl.Manager, cfg *configapi.StatusServer) (client.Client, error) {

--- a/pkg/statusserver/setup_test.go
+++ b/pkg/statusserver/setup_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statusserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/utils/ptr"
+
+	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
+)
+
+func TestProbeChecker(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	checker := probeChecker(srv.Listener.Addr().String())
+
+	if err := checker(nil); err != nil {
+		t.Fatalf("Unexpected error from probe checker while the server is serving: %v", err)
+	}
+
+	srv.Close()
+
+	if err := checker(nil); err == nil {
+		t.Error("Expected an error from probe checker after the server stopped, got nil")
+	}
+}
+
+func TestRegisterProbesValidatesConfig(t *testing.T) {
+	cases := map[string]*configapi.StatusServer{
+		"nil config":                      nil,
+		"empty config":                    {},
+		"config without an explicit port": {QPS: ptr.To[float32](5)},
+	}
+	for name, cfg := range cases {
+		t.Run(name, func(t *testing.T) {
+			// The manager is never dereferenced, the port validation runs first.
+			if err := RegisterProbes(nil, cfg); err == nil {
+				t.Error("Expected an error when the status server port is unset, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
 ## What this PR does / why we need it

  The TrainJobStatus server added in #3227 runs in the same process as the controller manager, but it was never registered with the manager's `/healthz` and `/readyz` probes. That left two gaps:

  - If the status server died mid-job, the controller pod stayed `Running` and nothing told the kubelet otherwise.
  - Training nodes had no way to know the server was ready before sending their first status update, so early updates could fail silently while TLS and the OIDC provider were still initializing.

  This follows the same pattern the webhook server already uses in this process.

  ## Changes

  **`pkg/statusserver/setup.go`**

  Adds `RegisterProbes(mgr, cfg)`, which registers one checker on both `status-server-healthz` and `status-server-readyz`. The checker dials the server's TLS listener with `tls.DialWithDialer`, so it only reports healthy once the server is actually accepting connections, the same way [controller-runtime probes the webhook server](https://github.com/kubernetes-sigs/controller-runtime/blob/v0.24.1/pkg/webhook/server.go#L273-L296). Certificate verification is skipped, with a comment explaining why: the probe only confirms the local listener is up, and dialing `:<port>` gives no server name to validate the serving certificate against.

  **`cmd/trainer-controller-manager/main.go`**

  Calls `RegisterProbes` synchronously before `mgr.Start()`, guarded by the `TrainJobStatus` feature gate. controller-runtime rejects check registrations once the manager is running, so this cannot live inside the `setupManagerComponents` goroutine.

  **`pkg/statusserver/server.go`**

  Closes the shutdown channel unconditionally with `defer`. `Start()` waits on `serverShutdown` after `ListenAndServeTLS` returns, but nothing ever closed it, so a graceful shutdown blocked forever and the manager never finished stopping.

  **Tests**

  `setup_test.go` covers `probeChecker` against a real TLS server (healthy while serving, error once stopped) plus the config validation in `RegisterProbes`.
  `server_test.go` adds `TestServerStartReturnsAfterContextCancel`, which starts the real status server, waits for the probe to report it serving, cancels the context, and asserts `Start()` returns. I confirmed that test fails against the unfixed shutdown channel, so the bug cannot quietly come back.

  ## Notes

  `RegisterProbes` only runs when the `TrainJobStatus` feature gate is enabled, so default deployments are unaffected.

  Rebased onto current master. `SetupServer` now takes `cfg.TLS` following #3339, which the previous revision of this branch predated.

  Fixes #3337

  ## Checklist

  - [x] Docs included if any changes are user facing

  No docs change needed. This is an internal health signaling improvement with no new user facing API surface.