### PR TITLE
feat(operator): add generic EnforceInfrastructurePlugin interface

### DIFF
--- a/pkg/runtime/core/trainingruntime.go
+++ b/pkg/runtime/core/trainingruntime.go
@@ -129,7 +129,7 @@ func (r *TrainingRuntime) RuntimeInfo(
 		return nil, err
 	}
 
-	if err = r.framework.RunPodNetworkPlugins(info, trainJob); err != nil {
+	if err = r.framework.RunEnforceInfrastructurePlugins(info, trainJob); err != nil {
 		return nil, err
 	}
 

--- a/pkg/runtime/framework/core/framework.go
+++ b/pkg/runtime/framework/core/framework.go
@@ -40,9 +40,9 @@ type Framework struct {
 	plugins                      map[string]framework.Plugin
 	enforceMLPlugins             []framework.EnforceMLPolicyPlugin
 	enforcePodGroupPolicyPlugins []framework.EnforcePodGroupPolicyPlugin
+	enforceInfrastructurePlugins []framework.EnforceInfrastructurePlugin
 	customValidationPlugins      []framework.CustomValidationPlugin
 	watchExtensionPlugins        []framework.WatchExtensionPlugin
-	podNetworkPlugins            []framework.PodNetworkPlugin
 	componentBuilderPlugins      []framework.ComponentBuilderPlugin
 	trainJobStatusPlugin         framework.TrainJobStatusPlugin
 }
@@ -68,14 +68,14 @@ func New(ctx context.Context, c client.Client, r fwkplugins.Registry, indexer cl
 		if p, ok := plugin.(framework.EnforcePodGroupPolicyPlugin); ok {
 			f.enforcePodGroupPolicyPlugins = append(f.enforcePodGroupPolicyPlugins, p)
 		}
+		if p, ok := plugin.(framework.EnforceInfrastructurePlugin); ok {
+			f.enforceInfrastructurePlugins = append(f.enforceInfrastructurePlugins, p)
+		}
 		if p, ok := plugin.(framework.CustomValidationPlugin); ok {
 			f.customValidationPlugins = append(f.customValidationPlugins, p)
 		}
 		if p, ok := plugin.(framework.WatchExtensionPlugin); ok {
 			f.watchExtensionPlugins = append(f.watchExtensionPlugins, p)
-		}
-		if p, ok := plugin.(framework.PodNetworkPlugin); ok {
-			f.podNetworkPlugins = append(f.podNetworkPlugins, p)
 		}
 		if p, ok := plugin.(framework.ComponentBuilderPlugin); ok {
 			f.componentBuilderPlugins = append(f.componentBuilderPlugins, p)
@@ -91,6 +91,7 @@ func New(ctx context.Context, c client.Client, r fwkplugins.Registry, indexer cl
 	return f, nil
 }
 
+// RunEnforceMLPolicyPlugins runs all plugins that implement EnforceMLPolicyPlugin.
 func (f *Framework) RunEnforceMLPolicyPlugins(info *runtime.Info, trainJob *trainer.TrainJob) error {
 	for _, plugin := range f.enforceMLPlugins {
 		if err := plugin.EnforceMLPolicy(info, trainJob); err != nil {
@@ -100,9 +101,22 @@ func (f *Framework) RunEnforceMLPolicyPlugins(info *runtime.Info, trainJob *trai
 	return nil
 }
 
+// RunEnforcePodGroupPolicyPlugins runs all plugins that implement EnforcePodGroupPolicyPlugin.
 func (f *Framework) RunEnforcePodGroupPolicyPlugins(info *runtime.Info, trainJob *trainer.TrainJob) error {
 	for _, plugin := range f.enforcePodGroupPolicyPlugins {
 		if err := plugin.EnforcePodGroupPolicy(info, trainJob); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RunEnforceInfrastructurePlugins runs all plugins that implement
+// EnforceInfrastructurePlugin. It runs after the ML policy and PodGroup policy
+// phases, which implementations may rely on.
+func (f *Framework) RunEnforceInfrastructurePlugins(info *runtime.Info, trainJob *trainer.TrainJob) error {
+	for _, plugin := range f.enforceInfrastructurePlugins {
+		if err := plugin.EnforceInfrastructure(info, trainJob); err != nil {
 			return err
 		}
 	}
@@ -124,15 +138,8 @@ func (f *Framework) RunCustomValidationPlugins(ctx context.Context, info *runtim
 	return aggregatedWarnings, aggregatedErrors
 }
 
-func (f *Framework) RunPodNetworkPlugins(info *runtime.Info, trainJob *trainer.TrainJob) error {
-	for _, plugin := range f.podNetworkPlugins {
-		if err := plugin.IdentifyPodNetwork(info, trainJob); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
+// RunComponentBuilderPlugins runs all plugins that implement ComponentBuilderPlugin
+// and aggregates the Kubernetes resources they build.
 func (f *Framework) RunComponentBuilderPlugins(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
 	var objs []apiruntime.ApplyConfiguration
 	for _, plugin := range f.componentBuilderPlugins {

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -118,7 +118,7 @@ func TestNew(t *testing.T) {
 					&jobset.JobSet{},
 					&mpi.MPI{},
 				},
-				podNetworkPlugins: []framework.PodNetworkPlugin{
+				enforceInfrastructurePlugins: []framework.EnforceInfrastructurePlugin{
 					&jobset.JobSet{},
 				},
 				componentBuilderPlugins: []framework.ComponentBuilderPlugin{
@@ -2571,7 +2571,7 @@ func TestTrainJobStatusPlugins(t *testing.T) {
 	}
 }
 
-func TestPodNetworkPlugins(t *testing.T) {
+func TestEnforceInfrastructurePlugins(t *testing.T) {
 	cases := map[string]struct {
 		registry        fwkplugins.Registry
 		runtimeInfo     *runtime.Info
@@ -2671,7 +2671,7 @@ func TestPodNetworkPlugins(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = fwk.RunPodNetworkPlugins(tc.runtimeInfo, tc.trainJob)
+			err = fwk.RunEnforceInfrastructurePlugins(tc.runtimeInfo, tc.trainJob)
 			if diff := cmp.Diff(tc.wantError, err); len(diff) != 0 {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}

--- a/pkg/runtime/framework/interface.go
+++ b/pkg/runtime/framework/interface.go
@@ -51,9 +51,29 @@ type EnforceMLPolicyPlugin interface {
 	EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) error
 }
 
-type PodNetworkPlugin interface {
+// EnforceInfrastructurePlugin updates runtime.Info with infrastructure concerns
+// that every TrainJob needs regardless of how it was configured: things the
+// platform must wire up, rather than things the user asked for.
+//
+// Use this interface when the plugin is not driven by a policy field. The
+// sibling interfaces are each scoped to one field of the TrainingRuntime spec
+// and activate only when a user sets it:
+//
+//   - EnforceMLPolicyPlugin        for .spec.mlPolicy (e.g. Torch, JAX)
+//   - EnforcePodGroupPolicyPlugin  for .spec.podGroupPolicy (e.g. Coscheduling)
+//
+// If you cannot name the spec field that switches your plugin on, it belongs
+// here. Current implementations are JobSet, which derives Pod-to-Pod network
+// endpoints from the PodSets, and TrainJobStatus, which injects status-server
+// configuration; neither corresponds to anything the user declares.
+//
+// Ordering is load-bearing: this phase runs after EnforceMLPolicyPlugin and
+// EnforcePodGroupPolicyPlugin, so implementations may rely on runtime.Info
+// already being shaped by those plugins. JobSet, for example, reads
+// PodSets[].Count after the ML policy has set it.
+type EnforceInfrastructurePlugin interface {
 	Plugin
-	IdentifyPodNetwork(info *runtime.Info, trainJob *trainer.TrainJob) error
+	EnforceInfrastructure(info *runtime.Info, trainJob *trainer.TrainJob) error
 }
 
 type ComponentBuilderPlugin interface {

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -65,7 +65,7 @@ type JobSet struct {
 }
 
 var _ framework.WatchExtensionPlugin = (*JobSet)(nil)
-var _ framework.PodNetworkPlugin = (*JobSet)(nil)
+var _ framework.EnforceInfrastructurePlugin = (*JobSet)(nil)
 var _ framework.ComponentBuilderPlugin = (*JobSet)(nil)
 var _ framework.TrainJobStatusPlugin = (*JobSet)(nil)
 var _ framework.CustomValidationPlugin = (*JobSet)(nil)
@@ -269,7 +269,7 @@ func (j *JobSet) ReconcilerBuilders() []runtime.ReconcilerBuilder {
 	}
 }
 
-func (j *JobSet) IdentifyPodNetwork(info *runtime.Info, trainJob *trainer.TrainJob) error {
+func (j *JobSet) EnforceInfrastructure(info *runtime.Info, trainJob *trainer.TrainJob) error {
 	if info == nil || trainJob == nil {
 		return nil
 	}

--- a/pkg/runtime/framework/plugins/jobset/jobset_test.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset_test.go
@@ -322,7 +322,7 @@ func TestJobSet(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to initialize JobSet plugin: %v", err)
 			}
-			err = p.(framework.PodNetworkPlugin).IdentifyPodNetwork(tc.info, tc.trainJob)
+			err = p.(framework.EnforceInfrastructurePlugin).EnforceInfrastructure(tc.info, tc.trainJob)
 			if diff := cmp.Diff(tc.wantError, err, cmpopts.EquateErrors()); len(diff) != 0 {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}
@@ -331,7 +331,7 @@ func TestJobSet(t *testing.T) {
 				cmpopts.SortMaps(func(a, b string) bool { return a < b }),
 				utiltesting.PodSetEndpointsCmpOpts,
 			); len(diff) != 0 {
-				t.Errorf("Unexpected Info from IdentifyPodNetwork (-want,+got):\n%s", diff)
+				t.Errorf("Unexpected Info from EnforceInfrastructure (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/runtime/framework/plugins/trainjobstatus/trainjobstatus.go
+++ b/pkg/runtime/framework/plugins/trainjobstatus/trainjobstatus.go
@@ -63,7 +63,7 @@ type Status struct {
 }
 
 var _ framework.ComponentBuilderPlugin = (*Status)(nil)
-var _ framework.EnforceMLPolicyPlugin = (*Status)(nil)
+var _ framework.EnforceInfrastructurePlugin = (*Status)(nil)
 
 func New(_ context.Context, c client.Client, _ client.FieldIndexer, cfg *configapi.Configuration) (framework.Plugin, error) {
 	return &Status{client: c, cfg: cfg}, nil
@@ -73,7 +73,7 @@ func (p *Status) Name() string {
 	return Name
 }
 
-func (p *Status) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) error {
+func (p *Status) EnforceInfrastructure(info *runtime.Info, trainJob *trainer.TrainJob) error {
 	if info == nil || trainJob == nil {
 		return nil
 	}

--- a/pkg/runtime/framework/plugins/trainjobstatus/trainjobstatus_test.go
+++ b/pkg/runtime/framework/plugins/trainjobstatus/trainjobstatus_test.go
@@ -40,7 +40,7 @@ import (
 	utiltesting "github.com/kubeflow/trainer/v2/pkg/util/testing"
 )
 
-func TestEnforceMLPolicy(t *testing.T) {
+func TestEnforceInfrastructure(t *testing.T) {
 	cases := map[string]struct {
 		info      *runtime.Info
 		trainJob  *trainer.TrainJob
@@ -284,16 +284,16 @@ func TestEnforceMLPolicy(t *testing.T) {
 				t.Fatalf("Failed to initialize Status plugin: %v", err)
 			}
 
-			err = p.(framework.EnforceMLPolicyPlugin).EnforceMLPolicy(tc.info, tc.trainJob)
+			err = p.(framework.EnforceInfrastructurePlugin).EnforceInfrastructure(tc.info, tc.trainJob)
 			if diff := gocmp.Diff(tc.wantError, err, cmpopts.EquateErrors()); len(diff) != 0 {
-				t.Errorf("Unexpected error from EnforceMLPolicy (-want, +got): %s", diff)
+				t.Errorf("Unexpected error from EnforceInfrastructure (-want, +got): %s", diff)
 			}
 
 			if diff := gocmp.Diff(tc.wantInfo, tc.info,
 				cmpopts.SortSlices(func(a, b string) bool { return a < b }),
 				cmpopts.SortMaps(func(a, b int) bool { return a < b }),
 			); len(diff) != 0 {
-				t.Errorf("Unexpected info from EnforceMLPolicy (-want, +got): %s", diff)
+				t.Errorf("Unexpected info from EnforceInfrastructure (-want, +got): %s", diff)
 			}
 		})
 	}

--- a/proposals/2170-kubeflow-trainer-v2/README.md
+++ b/proposals/2170-kubeflow-trainer-v2/README.md
@@ -1842,7 +1842,13 @@ On the other hand, the Internal APIs are not exposed and could not add any opera
       to any kind of resources like PodSpec.
     - `EnforceMLPolicy`: This configure MachineLearning framework specific parameters (e.x, specified in TrainingRuntime `.spec.mlPolicy`)
       to any kind of resources like PodSpec.
-    - `PodNetwork`: This identifies Pod-to-Pod communication network endpoints for each Pod and stores them to `RuntimeInfo`.
+    - `EnforceInfrastructure`: This updates the `RuntimeInfo` object with infrastructure concerns that every TrainJob needs
+      regardless of how it was configured, such as identifying Pod-to-Pod network endpoints or injecting status-server configuration.
+      Unlike `EnforcePodGroupPolicy` and `EnforceMLPolicy`, which are each scoped to a single TrainingRuntime spec field
+      (`.spec.podGroupPolicy` and `.spec.mlPolicy` respectively) and activate only when a user sets it, this extension point is not
+      driven by any policy API. If a plugin cannot name the spec field that switches it on, it belongs here.
+      This phase runs after `EnforcePodGroupPolicy` and `EnforceMLPolicy`, so plugins may rely on `RuntimeInfo` already being
+      shaped by them.
     - `ComponentBuilder`: This builds Kubernetes resources leveraging `RuntimeInfo` and `TrainJob`.
       `RuntimeInfo` is abstracted objects extracted from runtimes like TrainingRuntime and ClusterTrainingRuntime.
 - `PostExecution Phase`:


### PR DESCRIPTION
## What this PR does

  Introduces `EnforceInfrastructurePlugin`, a plugin interface for plugins that need to update the `runtime.Info` object with infrastructure concerns every TrainJob needs, rather than with settings a user declared through a policy API.

  ## Why this is needed

  The existing plugin interfaces, `EnforceMLPolicyPlugin` and `EnforcePodGroupPolicyPlugin`, are each scoped to a single field of the TrainingRuntime spec and activate only when a user sets it (e.g. Torch activates when `.spec.mlPolicy.torch` is set). That works for policy-driven plugins.

  Two existing plugins had no such field to key off:

  - **TrainJobStatus** - was registered as an `EnforceMLPolicyPlugin` despite having no relation to ML policy. A workaround with no semantic meaning.
  - **JobSet** - was registered as a `PodNetworkPlugin` (`IdentifyPodNetwork`), a name overly specific to network concerns that obscured the plugin's actual role.

  As discussed in #3227, the right fix is one generic interface rather than a new narrowly-named interface per use case.

  The decision rule the new interface documents: **the sibling interfaces are each switched on by a spec field the user sets. If a plugin cannot name the spec field that switches it on, it belongs here.**

  ## Changes

  - Add `EnforceInfrastructurePlugin` interface to `pkg/runtime/framework/interface.go`
  - Remove `PodNetworkPlugin` interface (fully replaced)
  - Add `enforceInfrastructurePlugins` slice to `Framework` and wire up registration in `New()`
  - Add `RunEnforceInfrastructurePlugins()`, replacing `RunPodNetworkPlugins()`
  - Migrate JobSet plugin: `IdentifyPodNetwork` → `EnforceInfrastructure`
  - Migrate TrainJobStatus plugin: `EnforceMLPolicy` → `EnforceInfrastructure`
  - Document in the godoc **when** to reach for this extension point, and that it runs **after** `EnforceMLPolicyPlugin` and `EnforcePodGroupPolicyPlugin`, an ordering implementations rely on (JobSet reads `PodSets[].Count` after the ML policy has shaped it)
  - Mirror that guidance in the KEP (`proposals/2170-kubeflow-trainer-v2/README.md`)
  - Add godoc to the sibling runners (`RunEnforceMLPolicyPlugins`, `RunEnforcePodGroupPolicyPlugins`, `RunComponentBuilderPlugins`) for consistency
  - Update all corresponding tests

  ## Related

  - Follow-up to #3227 (discussion between @andreyvelich and @astefanutti on the need for a generic interface)
  - Aligns with the per-job network policy work in #3120
  - Closes #3347