### PR TITLE
feat: add validation for ReplicatedJobPatch name

### DIFF
--- a/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -549,8 +549,9 @@ spec:
                                         minLength: 1
                                         type: string
                                         x-kubernetes-validations:
-                                        - message: name must match RFC 1035 DNS label
-                                            format
+                                        - message: name must consist of lowercase
+                                            alphanumeric characters or '-', and must
+                                            start and end with an alphanumeric character
                                           rule: self.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
                                       template:
                                         description: template patches the Job template

--- a/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -548,6 +548,10 @@ spec:
                                         maxLength: 253
                                         minLength: 1
                                         type: string
+                                        x-kubernetes-validations:
+                                        - message: name must match RFC 1035 DNS label
+                                            format
+                                          rule: self.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
                                       template:
                                         description: template patches the Job template
                                           for this replicated job.

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -549,8 +549,9 @@ spec:
                                         minLength: 1
                                         type: string
                                         x-kubernetes-validations:
-                                        - message: name must match RFC 1035 DNS label
-                                            format
+                                        - message: name must consist of lowercase
+                                            alphanumeric characters or '-', and must
+                                            start and end with an alphanumeric character
                                           rule: self.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
                                       template:
                                         description: template patches the Job template

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -548,6 +548,10 @@ spec:
                                         maxLength: 253
                                         minLength: 1
                                         type: string
+                                        x-kubernetes-validations:
+                                        - message: name must match RFC 1035 DNS label
+                                            format
+                                          rule: self.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
                                       template:
                                         description: template patches the Job template
                                           for this replicated job.

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -346,6 +346,7 @@ type JobSetSpecPatch struct {
 type ReplicatedJobPatch struct {
 	// name is the name of the replicated job to patch.
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')", message="name must match RFC 1035 DNS label format"
 	// +kubebuilder:validation:MaxLength=253
 	// +required
 	Name string `json:"name,omitempty"`

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -346,7 +346,7 @@ type JobSetSpecPatch struct {
 type ReplicatedJobPatch struct {
 	// name is the name of the replicated job to patch.
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')", message="name must match RFC 1035 DNS label format"
+	// +kubebuilder:validation:XValidation:rule="self.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')", message="name must consist of lowercase alphanumeric characters or '-', and must start and end with an alphanumeric character"
 	// +kubebuilder:validation:MaxLength=253
 	// +required
 	Name string `json:"name,omitempty"`

--- a/test/integration/webhooks/trainjob_test.go
+++ b/test/integration/webhooks/trainjob_test.go
@@ -299,6 +299,64 @@ var _ = ginkgo.Describe("TrainJob Webhook", ginkgo.Ordered, func() {
 				},
 				gomega.Succeed(),
 			),
+			ginkgo.Entry("Should fail with invalid replicated job name",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
+						RuntimePatches([]trainer.RuntimePatch{
+							{
+								Manager: "test.io/manager",
+								TrainingRuntimeSpec: &trainer.TrainingRuntimeSpecPatch{
+									Template: &trainer.JobSetTemplatePatch{
+										Spec: &trainer.JobSetSpecPatch{
+											ReplicatedJobs: []trainer.ReplicatedJobPatch{
+												{
+													Name: "-bad-name",
+												},
+											},
+										},
+									},
+								},
+							},
+						}).
+						Obj()
+				},
+				testingutil.BeInvalidError(),
+			),
+
+			ginkgo.Entry("Should succeed with valid replicated job name",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
+						RuntimePatches([]trainer.RuntimePatch{
+							{
+								Manager: "test.io/manager",
+								TrainingRuntimeSpec: &trainer.TrainingRuntimeSpecPatch{
+									Template: &trainer.JobSetTemplatePatch{
+										Spec: &trainer.JobSetSpecPatch{
+											ReplicatedJobs: []trainer.ReplicatedJobPatch{
+												{
+													Name: "node",
+													Template: &trainer.JobTemplatePatch{
+														Spec: &trainer.JobSpecPatch{
+															Template: &trainer.PodTemplatePatch{
+																Spec: &trainer.PodSpecPatch{
+																	ServiceAccountName: ptr.To("custom-sa"),
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						}).
+						Obj()
+				},
+				gomega.Succeed(),
+			),
 		)
 		ginkgo.DescribeTable("RFC1035-compliant TrainJob name validation", func(trainJob func() *trainer.TrainJob, errorMatcher gomega.OmegaMatcher) {
 			gomega.Expect(k8sClient.Create(ctx, trainJob())).Should(errorMatcher)


### PR DESCRIPTION
- Add CEL/XValidation rule for ReplicatedJobPatch.name.
- Add integration tests for replicated job name validation.


This prevents invalid replicated job identifiers from being accepted into the API and aligns validation behavior with existing Kubernetes CRD validation conventions.