### PR TITLE
fix(ci): skip stdlib from OSV-Scanner auto-fix

### DIFF
--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -128,6 +128,13 @@ jobs:
             echo ""
             echo "=== Processing: $pkg $current_ver -> $fix_ver ($advisory_id) ==="
 
+            # stdlib vulnerabilities require a Go toolchain update (go directive in go.mod),
+            # which is a project-wide decision — skip auto-fix, rely on SARIF/Security tab.
+            if [ "$pkg" = "stdlib" ]; then
+              echo "Skipping stdlib ($advisory_id): requires manual Go version bump to ${fix_ver}"
+              continue
+            fi
+
             # Snapshot go.mod/go.sum so a failure only reverts this iteration, not prior fixes
             cp go.mod go.mod.bak
             cp go.sum go.sum.bak


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Following on from the first run of this [action](https://github.com/kubeflow/trainer/actions/runs/26139022388) this change is required. 
OSV-Scanner reports Go standard library vulnerabilities under the synthetic package name "stdlib", but `go get stdlib@v<version>` fails because it's not a real module. Stdlib fixes require bumping the go directive in go.mod, which is a project-wide toolchain decision.

Skip stdlib in the auto-fix loop and rely on the SARIF upload to surface these in the GitHub Security tab instead.

cc @andreyvelich 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
