### PR TITLE
feat(manifests): add optional Grafana dashboard for controller observability

### DIFF
--- a/charts/kubeflow-trainer/README.md
+++ b/charts/kubeflow-trainer/README.md
@@ -95,16 +95,26 @@ manager:
 
 ### Grafana dashboard
 
-The chart can optionally install a default Grafana dashboard (as a ConfigMap) for controller health and TrainJob lifecycle observability.
-This is disabled by default and is intended for clusters that run Grafana with a dashboard sidecar that imports dashboards from labeled ConfigMaps.
+The chart can optionally install Grafana dashboards (as ConfigMaps) for controller health and TrainJob lifecycle observability.
+Dashboards are disabled by default and are intended for clusters that run Grafana with a dashboard sidecar that imports dashboards from labeled ConfigMaps.
+
+To enable all dashboards:
 
 ```bash
 helm install kubeflow-trainer oci://ghcr.io/kubeflow/charts/kubeflow-trainer \
   --version 2.1.0 \
-  --set grafanaDashboard.enabled=true
+  --set grafanaDashboard.defaultEnabled=true
 ```
 
- > **Prerequisite:** Prometheus must be configured to scrape the controller's
+To enable specific dashboards:
+
+```bash
+helm install kubeflow-trainer oci://ghcr.io/kubeflow/charts/kubeflow-trainer \
+  --version 2.1.0 \
+  --set grafanaDashboard.controllerHealth.enabled=true
+```
+
+> **Prerequisite:** Prometheus must be configured to scrape the controller's
 > metrics endpoint (port 8443, HTTPS). The chart does not include a ServiceMonitor.
 
 If your Grafana sidecar uses a different label selector, override `grafanaDashboard.labels` accordingly.
@@ -144,9 +154,11 @@ If your Grafana sidecar uses a different label selector, override `grafanaDashbo
 | manager.config.statusServer.qps | int | `5` | QPS rate limit for the TrainJob Status Server api client |
 | manager.config.statusServer.burst | int | `10` | Burst rate limit for the TrainJob Status Server api client |
 | webhook.failurePolicy | string | `"Fail"` | Specifies how unrecognized errors are handled. Available options are `Ignore` or `Fail`. |
-| grafanaDashboard.enabled | bool | `false` | Whether to install the default Grafana dashboard ConfigMap. Intended for environments running Grafana with sidecar dashboard auto-discovery. |
-| grafanaDashboard.labels | object | `{"grafana_dashboard":"1"}` | Labels applied to the dashboard ConfigMap. Match your Grafana sidecar label selector. |
-| grafanaDashboard.annotations | object | `{}` | Annotations applied to the dashboard ConfigMap. Use to set Grafana folder: grafana_folder: "Kubeflow" |
+| grafanaDashboard.defaultEnabled | bool | `false` | Enable all default Grafana dashboards when set to true. Individual dashboard settings will be ignored if this is enabled. Intended for environments running Grafana with sidecar dashboard auto-discovery. |
+| grafanaDashboard.labels | object | `{"grafana_dashboard":"1"}` | Labels applied to the dashboard ConfigMaps. Match your Grafana sidecar label selector. |
+| grafanaDashboard.annotations | object | `{}` | Annotations applied to the dashboard ConfigMaps. Use to set Grafana folder: grafana_folder: "Kubeflow" |
+| grafanaDashboard.controllerHealth | object | `{"enabled":false}` | Controller health and TrainJob lifecycle dashboard |
+| grafanaDashboard.controllerHealth.enabled | bool | `false` | Enable deployment of the controller health dashboard |
 | dataCache.enabled | bool | `false` | Enable/disable data cache support (LWS dependency, ClusterRole). Set to `true` to install data cache components. |
 | dataCache.lws.install | bool | `true` | Whether to install LeaderWorkerSet as a dependency. Set to `false` if LeaderWorkerSet is already installed in the cluster. |
 | dataCache.lws.fullnameOverride | string | `"lws"` | String to fully override LeaderWorkerSet release name. |

--- a/charts/kubeflow-trainer/README.md
+++ b/charts/kubeflow-trainer/README.md
@@ -93,6 +93,22 @@ manager:
     traffic.sidecar.istio.io/excludeInboundPorts: "9443"
 ```
 
+### Grafana dashboard
+
+The chart can optionally install a default Grafana dashboard (as a ConfigMap) for controller health and TrainJob lifecycle observability.
+This is disabled by default and is intended for clusters that run Grafana with a dashboard sidecar that imports dashboards from labeled ConfigMaps.
+
+```bash
+helm install kubeflow-trainer oci://ghcr.io/kubeflow/charts/kubeflow-trainer \
+  --version 2.1.0 \
+  --set grafanaDashboard.enabled=true
+```
+
+ > **Prerequisite:** Prometheus must be configured to scrape the controller's
+> metrics endpoint (port 8443, HTTPS). The chart does not include a ServiceMonitor.
+
+If your Grafana sidecar uses a different label selector, override `grafanaDashboard.labels` accordingly.
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -128,6 +144,9 @@ manager:
 | manager.config.statusServer.qps | int | `5` | QPS rate limit for the TrainJob Status Server api client |
 | manager.config.statusServer.burst | int | `10` | Burst rate limit for the TrainJob Status Server api client |
 | webhook.failurePolicy | string | `"Fail"` | Specifies how unrecognized errors are handled. Available options are `Ignore` or `Fail`. |
+| grafanaDashboard.enabled | bool | `false` | Whether to install the default Grafana dashboard ConfigMap. Intended for environments running Grafana with sidecar dashboard auto-discovery. |
+| grafanaDashboard.labels | object | `{"grafana_dashboard":"1"}` | Labels applied to the dashboard ConfigMap. Match your Grafana sidecar label selector. |
+| grafanaDashboard.annotations | object | `{}` | Annotations applied to the dashboard ConfigMap. Use to set Grafana folder: grafana_folder: "Kubeflow" |
 | dataCache.enabled | bool | `false` | Enable/disable data cache support (LWS dependency, ClusterRole). Set to `true` to install data cache components. |
 | dataCache.lws.install | bool | `true` | Whether to install LeaderWorkerSet as a dependency. Set to `false` if LeaderWorkerSet is already installed in the cluster. |
 | dataCache.lws.fullnameOverride | string | `"lws"` | String to fully override LeaderWorkerSet release name. |

--- a/charts/kubeflow-trainer/README.md.gotmpl
+++ b/charts/kubeflow-trainer/README.md.gotmpl
@@ -113,16 +113,26 @@ manager:
 
 ### Grafana dashboard
 
-The chart can optionally install a default Grafana dashboard (as a ConfigMap) for controller health and TrainJob lifecycle observability.
-This is disabled by default and is intended for clusters that run Grafana with a dashboard sidecar that imports dashboards from labeled ConfigMaps.
+The chart can optionally install Grafana dashboards (as ConfigMaps) for controller health and TrainJob lifecycle observability.
+Dashboards are disabled by default and are intended for clusters that run Grafana with a dashboard sidecar that imports dashboards from labeled ConfigMaps.
+
+To enable all dashboards:
 
 ```bash
 helm install kubeflow-trainer oci://ghcr.io/kubeflow/charts/kubeflow-trainer \
   --version 2.1.0 \
-  --set grafanaDashboard.enabled=true
+  --set grafanaDashboard.defaultEnabled=true
 ```
 
- > **Prerequisite:** Prometheus must be configured to scrape the controller's
+To enable specific dashboards:
+
+```bash
+helm install kubeflow-trainer oci://ghcr.io/kubeflow/charts/kubeflow-trainer \
+  --version 2.1.0 \
+  --set grafanaDashboard.controllerHealth.enabled=true
+```
+
+> **Prerequisite:** Prometheus must be configured to scrape the controller's
 > metrics endpoint (port 8443, HTTPS). The chart does not include a ServiceMonitor.
 
 If your Grafana sidecar uses a different label selector, override `grafanaDashboard.labels` accordingly.

--- a/charts/kubeflow-trainer/README.md.gotmpl
+++ b/charts/kubeflow-trainer/README.md.gotmpl
@@ -122,6 +122,9 @@ helm install kubeflow-trainer oci://ghcr.io/kubeflow/charts/kubeflow-trainer \
   --set grafanaDashboard.enabled=true
 ```
 
+ > **Prerequisite:** Prometheus must be configured to scrape the controller's
+> metrics endpoint (port 8443, HTTPS). The chart does not include a ServiceMonitor.
+
 If your Grafana sidecar uses a different label selector, override `grafanaDashboard.labels` accordingly.
 
 {{ template "chart.valuesSection" . }}

--- a/charts/kubeflow-trainer/README.md.gotmpl
+++ b/charts/kubeflow-trainer/README.md.gotmpl
@@ -111,6 +111,19 @@ manager:
     traffic.sidecar.istio.io/excludeInboundPorts: "9443"
 ```
 
+### Grafana dashboard
+
+The chart can optionally install a default Grafana dashboard (as a ConfigMap) for controller health and TrainJob lifecycle observability.
+This is disabled by default and is intended for clusters that run Grafana with a dashboard sidecar that imports dashboards from labeled ConfigMaps.
+
+```bash
+helm install kubeflow-trainer oci://ghcr.io/kubeflow/charts/kubeflow-trainer \
+  --version 2.1.0 \
+  --set grafanaDashboard.enabled=true
+```
+
+If your Grafana sidecar uses a different label selector, override `grafanaDashboard.labels` accordingly.
+
 {{ template "chart.valuesSection" . }}
 
 {{- define "chart.maintainersTable" -}}

--- a/charts/kubeflow-trainer/dashboards/kubeflow-trainer-dashboard.json
+++ b/charts/kubeflow-trainer/dashboards/kubeflow-trainer-dashboard.json
@@ -585,7 +585,7 @@
           "value": ".*"
         },
         "datasource": {
-          "type": "prometheus",
+        "regex": "",
           "uid": "${datasource}"
         },
         "definition": "label_values(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\"}, controller)",

--- a/charts/kubeflow-trainer/dashboards/kubeflow-trainer-dashboard.json
+++ b/charts/kubeflow-trainer/dashboards/kubeflow-trainer-dashboard.json
@@ -1,0 +1,619 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Controller Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Whether Prometheus can scrape the controller-manager target.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "Down"
+                },
+                "1": {
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max(up{namespace=~\"$namespace\", job=~\"$job\"})",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Controller scrape up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Go goroutines in the controller-manager process.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max(go_goroutines{namespace=~\"$namespace\", job=~\"$job\"})",
+          "legendFormat": "goroutines",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutines",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Resident memory usage of the controller-manager process.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max(process_resident_memory_bytes{namespace=~\"$namespace\", job=~\"$job\"})",
+          "legendFormat": "rss",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory (RSS)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total reconcile rate per controller and result.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by(controller, result) (rate(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\", controller=~\"$controller\"}[5m]))",
+          "legendFormat": "{{controller}} / {{result}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconciles / sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "P95 reconcile duration by controller (seconds).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by(le, controller) (rate(controller_runtime_reconcile_time_seconds_bucket{namespace=~\"$namespace\", job=~\"$job\", controller=~\"$controller\"}[5m])))",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile duration p95",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 7,
+      "panels": [],
+      "title": "Queue & Backlog",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Workqueue depth by queue name (client-go workqueue).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max by(name) (workqueue_depth{namespace=~\"$namespace\", job=~\"$job\"})",
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Workqueue depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Rate at which items are re-queued (retries) per workqueue.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by(name) (rate(workqueue_retries_total{namespace=~\"$namespace\", job=~\"$job\"}[5m]))",
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Workqueue retries / sec",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 10,
+      "panels": [],
+      "title": "TrainJob Lifecycle",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "TrainJob controller reconcile rate by result.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by(result) (rate(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\", controller=\"trainjob_controller\"}[5m]))",
+          "legendFormat": "{{result}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "TrainJob reconciles / sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "TrainJob controller reconcile error rate.",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\", controller=\"trainjob_controller\", result=\"error\"}[5m]))",
+          "legendFormat": "errors",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "TrainJob reconcile errors / sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "P95 TrainJob reconcile duration (seconds).",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(controller_runtime_reconcile_time_seconds_bucket{namespace=~\"$namespace\", job=~\"$job\", controller=\"trainjob_controller\"}[5m])))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "TrainJob reconcile duration p95",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "kubeflow",
+    "trainer",
+    "observability",
+    "controller-runtime"
+  ],
+  "templating": {
+    "list": [
+      {
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": ".*"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(up, namespace)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(up, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": ".*"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(up{namespace=~\"$namespace\"}, job)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(up{namespace=~\"$namespace\"}, job)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": ".*trainer.*",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": ".*"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\"}, controller)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Controller",
+        "multi": true,
+        "name": "controller",
+        "options": [],
+        "query": {
+          "query": "label_values(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\"}, controller)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Kubeflow Trainer - Controller Health & TrainJob Lifecycle",
+  "uid": "kubeflow-trainer-controller",
+  "version": 1,
+  "weekStart": ""
+}

--- a/charts/kubeflow-trainer/dashboards/kubeflow-trainer-dashboard.json
+++ b/charts/kubeflow-trainer/dashboards/kubeflow-trainer-dashboard.json
@@ -574,7 +574,7 @@
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": ".*trainer.*",
+        "regex": "",
         "sort": 1,
         "type": "query"
       },
@@ -585,7 +585,7 @@
           "value": ".*"
         },
         "datasource": {
-        "regex": "",
+          "type": "prometheus",
           "uid": "${datasource}"
         },
         "definition": "label_values(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\"}, controller)",

--- a/charts/kubeflow-trainer/dashboards/kubeflow-trainer-dashboard.json
+++ b/charts/kubeflow-trainer/dashboards/kubeflow-trainer-dashboard.json
@@ -223,7 +223,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by(controller, result) (rate(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\", controller=~\"$controller\"}[5m]))",
+          "expr": "sum by(controller, result) (rate(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\", controller=~\"$controller\"}[$__rate_interval]))",
           "legendFormat": "{{controller}} / {{result}}",
           "range": true,
           "refId": "A"
@@ -264,7 +264,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le, controller) (rate(controller_runtime_reconcile_time_seconds_bucket{namespace=~\"$namespace\", job=~\"$job\", controller=~\"$controller\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by(le, controller) (rate(controller_runtime_reconcile_time_seconds_bucket{namespace=~\"$namespace\", job=~\"$job\", controller=~\"$controller\"}[$__rate_interval])))",
           "legendFormat": "{{controller}}",
           "range": true,
           "refId": "A"
@@ -359,7 +359,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by(name) (rate(workqueue_retries_total{namespace=~\"$namespace\", job=~\"$job\"}[5m]))",
+          "expr": "sum by(name) (rate(workqueue_retries_total{namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))",
           "legendFormat": "{{name}}",
           "range": true,
           "refId": "A"
@@ -413,7 +413,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by(result) (rate(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\", controller=\"trainjob_controller\"}[5m]))",
+          "expr": "sum by(result) (rate(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\", controller=\"trainjob_controller\"}[$__rate_interval]))",
           "legendFormat": "{{result}}",
           "range": true,
           "refId": "A"
@@ -454,7 +454,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum(rate(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\", controller=\"trainjob_controller\", result=\"error\"}[5m]))",
+          "expr": "sum(rate(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\", controller=\"trainjob_controller\", result=\"error\"}[$__rate_interval]))",
           "legendFormat": "errors",
           "range": true,
           "refId": "A"
@@ -495,7 +495,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(controller_runtime_reconcile_time_seconds_bucket{namespace=~\"$namespace\", job=~\"$job\", controller=\"trainjob_controller\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(controller_runtime_reconcile_time_seconds_bucket{namespace=~\"$namespace\", job=~\"$job\", controller=\"trainjob_controller\"}[$__rate_interval])))",
           "legendFormat": "p95",
           "range": true,
           "refId": "A"

--- a/charts/kubeflow-trainer/templates/grafana/configmap.yaml
+++ b/charts/kubeflow-trainer/templates/grafana/configmap.yaml
@@ -1,0 +1,36 @@
+{{- /*
+Copyright 2026 The Kubeflow authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{- if .Values.grafanaDashboard.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "trainer.fullname" . }}-grafana-dashboard
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "trainer.labels" . | nindent 4 }}
+    app.kubernetes.io/component: grafana-dashboard
+    {{- with .Values.grafanaDashboard.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.grafanaDashboard.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  kubeflow-trainer-dashboard.json: |-
+{{ .Files.Get "dashboards/kubeflow-trainer-dashboard.json" | nindent 4 }}
+{{- end }}

--- a/charts/kubeflow-trainer/templates/grafana/configmap.yaml
+++ b/charts/kubeflow-trainer/templates/grafana/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright The Kubeflow authors.
+Copyright The Kubeflow Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/templates/grafana/configmap.yaml
+++ b/charts/kubeflow-trainer/templates/grafana/configmap.yaml
@@ -1,5 +1,5 @@
 {{- /*
-Copyright 2026 The Kubeflow authors.
+Copyright The Kubeflow authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */ -}}
 
-{{- if .Values.grafanaDashboard.enabled }}
+{{- if or .Values.grafanaDashboard.defaultEnabled .Values.grafanaDashboard.controllerHealth.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/kubeflow-trainer/tests/grafana/configmap_test.yaml
+++ b/charts/kubeflow-trainer/tests/grafana/configmap_test.yaml
@@ -1,0 +1,107 @@
+#
+# Copyright 2026 The Kubeflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: Test Grafana dashboard ConfigMap
+templates:
+  - templates/grafana/configmap.yaml
+release:
+  name: kubeflow-trainer
+  namespace: kubeflow-trainer
+tests:
+  - it: Should not render ConfigMap when grafanaDashboard.enabled is false
+    set:
+      grafanaDashboard:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should render ConfigMap when grafanaDashboard.enabled is true
+    set:
+      grafanaDashboard:
+        enabled: true
+        labels:
+          grafana_dashboard: "1"
+        annotations: {}
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: kubeflow-trainer-grafana-dashboard
+
+  - it: Should have grafana_dashboard label for sidecar auto-discovery
+    set:
+      grafanaDashboard:
+        enabled: true
+        labels:
+          grafana_dashboard: "1"
+        annotations: {}
+    asserts:
+      - equal:
+          path: metadata.labels["grafana_dashboard"]
+          value: "1"
+
+  - it: Should have app.kubernetes.io/component label
+    set:
+      grafanaDashboard:
+        enabled: true
+        labels:
+          grafana_dashboard: "1"
+        annotations: {}
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: grafana-dashboard
+
+  - it: Should contain dashboard JSON data key
+    set:
+      grafanaDashboard:
+        enabled: true
+        labels:
+          grafana_dashboard: "1"
+        annotations: {}
+    asserts:
+      - isNotEmpty:
+          path: data["kubeflow-trainer-dashboard.json"]
+
+  - it: Should support custom annotations
+    set:
+      grafanaDashboard:
+        enabled: true
+        labels:
+          grafana_dashboard: "1"
+        annotations:
+          grafana_folder: "Kubeflow"
+    asserts:
+      - equal:
+          path: metadata.annotations.grafana_folder
+          value: "Kubeflow"
+
+  - it: Should support custom labels
+    set:
+      grafanaDashboard:
+        enabled: true
+        labels:
+          grafana_dashboard: "1"
+          custom-label: "custom-value"
+        annotations: {}
+    asserts:
+      - equal:
+          path: metadata.labels["custom-label"]
+          value: "custom-value"

--- a/charts/kubeflow-trainer/tests/grafana/configmap_test.yaml
+++ b/charts/kubeflow-trainer/tests/grafana/configmap_test.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2026 The Kubeflow authors.
+# Copyright The Kubeflow authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,21 +21,43 @@ release:
   name: kubeflow-trainer
   namespace: kubeflow-trainer
 tests:
-  - it: Should not render ConfigMap when grafanaDashboard.enabled is false
+  - it: Should not render ConfigMap when all dashboards are disabled
     set:
       grafanaDashboard:
-        enabled: false
+        defaultEnabled: false
+        controllerHealth:
+          enabled: false
     asserts:
       - hasDocuments:
           count: 0
 
-  - it: Should render ConfigMap when grafanaDashboard.enabled is true
+  - it: Should render ConfigMap when defaultEnabled is true
     set:
       grafanaDashboard:
-        enabled: true
+        defaultEnabled: true
         labels:
           grafana_dashboard: "1"
         annotations: {}
+        controllerHealth:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: kubeflow-trainer-grafana-dashboard
+
+  - it: Should render ConfigMap when controllerHealth.enabled is true
+    set:
+      grafanaDashboard:
+        defaultEnabled: false
+        labels:
+          grafana_dashboard: "1"
+        annotations: {}
+        controllerHealth:
+          enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -48,10 +70,12 @@ tests:
   - it: Should have grafana_dashboard label for sidecar auto-discovery
     set:
       grafanaDashboard:
-        enabled: true
+        defaultEnabled: true
         labels:
           grafana_dashboard: "1"
         annotations: {}
+        controllerHealth:
+          enabled: false
     asserts:
       - equal:
           path: metadata.labels["grafana_dashboard"]
@@ -60,10 +84,12 @@ tests:
   - it: Should have app.kubernetes.io/component label
     set:
       grafanaDashboard:
-        enabled: true
+        defaultEnabled: true
         labels:
           grafana_dashboard: "1"
         annotations: {}
+        controllerHealth:
+          enabled: false
     asserts:
       - equal:
           path: metadata.labels["app.kubernetes.io/component"]
@@ -72,10 +98,12 @@ tests:
   - it: Should contain dashboard JSON data key
     set:
       grafanaDashboard:
-        enabled: true
+        defaultEnabled: true
         labels:
           grafana_dashboard: "1"
         annotations: {}
+        controllerHealth:
+          enabled: false
     asserts:
       - isNotEmpty:
           path: data["kubeflow-trainer-dashboard.json"]
@@ -83,11 +111,13 @@ tests:
   - it: Should support custom annotations
     set:
       grafanaDashboard:
-        enabled: true
+        defaultEnabled: true
         labels:
           grafana_dashboard: "1"
         annotations:
           grafana_folder: "Kubeflow"
+        controllerHealth:
+          enabled: false
     asserts:
       - equal:
           path: metadata.annotations.grafana_folder
@@ -96,11 +126,13 @@ tests:
   - it: Should support custom labels
     set:
       grafanaDashboard:
-        enabled: true
+        defaultEnabled: true
         labels:
           grafana_dashboard: "1"
           custom-label: "custom-value"
         annotations: {}
+        controllerHealth:
+          enabled: false
     asserts:
       - equal:
           path: metadata.labels["custom-label"]

--- a/charts/kubeflow-trainer/tests/grafana/configmap_test.yaml
+++ b/charts/kubeflow-trainer/tests/grafana/configmap_test.yaml
@@ -1,5 +1,4 @@
-#
-# Copyright The Kubeflow authors.
+# Copyright The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charts/kubeflow-trainer/values.yaml
+++ b/charts/kubeflow-trainer/values.yaml
@@ -161,6 +161,20 @@ webhook:
   # Available options are `Ignore` or `Fail`.
   failurePolicy: Fail
 
+grafanaDashboard:
+  # -- Whether to install the default Grafana dashboard ConfigMap.
+  # Intended for environments running Grafana with sidecar dashboard auto-discovery.
+  enabled: false
+
+  # -- Labels applied to the dashboard ConfigMap.
+  # Match your Grafana sidecar label selector.
+  labels:
+    grafana_dashboard: "1"
+
+  # -- Annotations applied to the dashboard ConfigMap.
+  # Use to set Grafana folder: grafana_folder: "Kubeflow"
+  annotations: {}
+
 dataCache:
   # -- Enable/disable data cache support (LWS dependency, ClusterRole).
   # Set to `true` to install data cache components.

--- a/charts/kubeflow-trainer/values.yaml
+++ b/charts/kubeflow-trainer/values.yaml
@@ -162,18 +162,24 @@ webhook:
   failurePolicy: Fail
 
 grafanaDashboard:
-  # -- Whether to install the default Grafana dashboard ConfigMap.
+  # -- Enable all default Grafana dashboards when set to true.
+  # Individual dashboard settings will be ignored if this is enabled.
   # Intended for environments running Grafana with sidecar dashboard auto-discovery.
-  enabled: false
+  defaultEnabled: false
 
-  # -- Labels applied to the dashboard ConfigMap.
+  # -- Labels applied to the dashboard ConfigMaps.
   # Match your Grafana sidecar label selector.
   labels:
     grafana_dashboard: "1"
 
-  # -- Annotations applied to the dashboard ConfigMap.
+  # -- Annotations applied to the dashboard ConfigMaps.
   # Use to set Grafana folder: grafana_folder: "Kubeflow"
   annotations: {}
+
+  # -- Controller health and TrainJob lifecycle dashboard
+  controllerHealth:
+    # -- Enable deployment of the controller health dashboard
+    enabled: false
 
 dataCache:
   # -- Enable/disable data cache support (LWS dependency, ClusterRole).

--- a/docs/operator-guides/index.md
+++ b/docs/operator-guides/index.md
@@ -83,6 +83,20 @@ Integrate with Volcano, Kueue, Coscheduling, and KAI Scheduler
 
 :::::
 
+## Observability
+
+:::::{grid} 1 1 2 2
+:gutter: 3
+
+::::{grid-item-card} Prometheus Monitoring
+:link: monitoring
+:link-type: doc
+
+Monitor the Trainer controller with Prometheus metrics and Grafana dashboards
+::::
+
+:::::
+
 ----
 
 ```{toctree}
@@ -97,4 +111,5 @@ job-template
 runtime-patches
 extension-framework
 job-scheduling/index
+monitoring
 ```

--- a/docs/operator-guides/index.md
+++ b/docs/operator-guides/index.md
@@ -83,6 +83,20 @@ Integrate with Kueue, Slurm Bridge, KAI Scheduler, Coscheduling, and Volcano
 
 :::::
 
+## Observability
+
+:::::{grid} 1 1 2 2
+:gutter: 3
+
+::::{grid-item-card} Prometheus Monitoring
+:link: monitoring
+:link-type: doc
+
+Monitor the Trainer controller with Prometheus metrics and Grafana dashboards
+::::
+
+:::::
+
 ----
 
 ```{toctree}
@@ -97,4 +111,5 @@ job-template
 runtime-patches
 extension-framework
 job-scheduling/index
+monitoring
 ```

--- a/docs/operator-guides/monitoring.md
+++ b/docs/operator-guides/monitoring.md
@@ -1,0 +1,98 @@
+# Prometheus Monitoring
+
+This guide describes how to monitor the Kubeflow Trainer controller using Prometheus metrics
+and the optional Grafana dashboard shipped with the Helm chart.
+
+## Prerequisites
+
+- Kubeflow Trainer installed via [Helm chart](installation.md#install-with-helm-charts) or kustomize manifests
+- Prometheus configured to scrape the controller's metrics endpoint
+
+:::{note}
+The Trainer controller serves metrics over HTTPS on port 8443 with
+[controller-runtime secure serving](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/metrics/server).
+The Helm chart does not include a ServiceMonitor or PodMonitor, so you must configure
+Prometheus scraping separately. If you use the
+[Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator), create a
+ServiceMonitor that targets port 8443 with TLS settings matching your cluster's CA.
+:::
+
+## Controller Metrics
+
+The Trainer controller exposes standard
+[controller-runtime metrics](https://book.kubebuilder.io/reference/metrics-reference)
+at the `/metrics` endpoint. These include Go process metrics, reconciliation counters, and
+workqueue statistics.
+
+Key metrics used by the Grafana dashboard:
+
+| Metric | Type | Description |
+| --- | --- | --- |
+| `up` | gauge | Whether Prometheus can scrape the controller target |
+| `go_goroutines` | gauge | Number of active goroutines |
+| `process_resident_memory_bytes` | gauge | Resident memory size in bytes |
+| `controller_runtime_reconcile_total` | counter | Total reconciliation attempts (labels: `controller`, `result`) |
+| `controller_runtime_reconcile_time_seconds` | histogram | Reconciliation duration in seconds (labels: `controller`) |
+| `workqueue_depth` | gauge | Current depth of the work queue (label: `name`) |
+| `workqueue_retries_total` | counter | Total number of workqueue retries (label: `name`) |
+
+You can verify that metrics are being scraped by port-forwarding to the controller pod:
+
+```bash
+kubectl port-forward -n kubeflow-system deployment/kubeflow-trainer-controller-manager 8443:8443
+```
+
+Then query `https://localhost:8443/metrics` (the endpoint uses a self-signed certificate, so you
+may need to skip TLS verification for local debugging).
+
+## Enabling the Grafana Dashboard
+
+The Helm chart includes a pre-built Grafana dashboard that provides out-of-the-box visibility into
+controller health and TrainJob lifecycle. It is disabled by default.
+
+To enable it, set `grafanaDashboard.enabled` in your Helm values:
+
+```yaml
+grafanaDashboard:
+  enabled: true
+```
+
+This creates a ConfigMap labeled with `grafana_dashboard: "1"` for
+[Grafana sidecar](https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards)
+auto-discovery. If your Grafana sidecar uses a different label selector, override it with
+`grafanaDashboard.labels`.
+
+To place the dashboard in a specific Grafana folder, use annotations:
+
+```yaml
+grafanaDashboard:
+  enabled: true
+  annotations:
+    grafana_folder: "Kubeflow"
+```
+
+## Dashboard Panels
+
+The dashboard is organized into three rows.
+
+### Controller Health
+
+- **Controller scrape up** - whether Prometheus can reach the controller target
+- **Goroutines** - number of active goroutines over time
+- **Memory (RSS)** - resident memory usage of the controller process
+- **Reconciles / sec** - reconciliation rate broken down by controller and result (success/error)
+- **Reconcile duration p95** - 95th percentile reconciliation latency by controller
+
+### Queue & Backlog
+
+- **Workqueue depth** - current number of items waiting in each work queue
+- **Workqueue retries / sec** - rate of retried items per queue
+
+### TrainJob Lifecycle
+
+- **TrainJob reconciles / sec** - reconciliation rate for the TrainJob controller by result
+- **TrainJob reconcile errors / sec** - error rate for TrainJob reconciliations
+- **TrainJob reconcile duration p95** - 95th percentile latency for TrainJob reconciliations
+
+All panels use template variables for datasource, namespace, and job, so you can filter by
+the Prometheus datasource and the namespace where the Trainer controller is running.

--- a/docs/operator-guides/monitoring.md
+++ b/docs/operator-guides/monitoring.md
@@ -50,11 +50,19 @@ may need to skip TLS verification for local debugging).
 The Helm chart includes a pre-built Grafana dashboard that provides out-of-the-box visibility into
 controller health and TrainJob lifecycle. It is disabled by default.
 
-To enable it, set `grafanaDashboard.enabled` in your Helm values:
+To enable all dashboards, set `grafanaDashboard.defaultEnabled` in your Helm values:
 
 ```yaml
 grafanaDashboard:
-  enabled: true
+  defaultEnabled: true
+```
+
+To enable specific dashboards:
+
+```yaml
+grafanaDashboard:
+  controllerHealth:
+    enabled: true
 ```
 
 This creates a ConfigMap labeled with `grafana_dashboard: "1"` for
@@ -66,7 +74,7 @@ To place the dashboard in a specific Grafana folder, use annotations:
 
 ```yaml
 grafanaDashboard:
-  enabled: true
+  defaultEnabled: true
   annotations:
     grafana_folder: "Kubeflow"
 ```

--- a/docs/operator-guides/monitoring.md
+++ b/docs/operator-guides/monitoring.md
@@ -5,7 +5,7 @@ and the optional Grafana dashboard shipped with the Helm chart.
 
 ## Prerequisites
 
-- Kubeflow Trainer installed via [Helm chart](installation.md#install-with-helm-charts) or kustomize manifests
+- Kubeflow Trainer installed via [Helm chart](installation.md#installing-the-kubeflow-trainer-controller-manager) or kustomize manifests
 - Prometheus configured to scrape the controller's metrics endpoint
 
 :::{note}

--- a/manifests/overlays/grafana-dashboard/configmap.yaml
+++ b/manifests/overlays/grafana-dashboard/configmap.yaml
@@ -1,0 +1,641 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubeflow-trainer-grafana-dashboard
+  labels:
+    grafana_dashboard: "1"
+data:
+  kubeflow-trainer-dashboard.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "panels": [],
+          "title": "Controller Health",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Whether Prometheus can scrape the controller-manager target.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "text": "Down"
+                    },
+                    "1": {
+                      "text": "Up"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 1
+          },
+          "id": 2,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "max(up{namespace=~\"$namespace\", job=~\"$job\"})",
+              "instant": true,
+              "legendFormat": "",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Controller scrape up",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Go goroutines in the controller-manager process.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 6,
+            "y": 1
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "max(go_goroutines{namespace=~\"$namespace\", job=~\"$job\"})",
+              "legendFormat": "goroutines",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Goroutines",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Resident memory usage of the controller-manager process.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 12,
+            "y": 1
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "max(process_resident_memory_bytes{namespace=~\"$namespace\", job=~\"$job\"})",
+              "legendFormat": "rss",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Memory (RSS)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Total reconcile rate per controller and result.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 5
+          },
+          "id": 5,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "sum by(controller, result) (rate(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\", controller=~\"$controller\"}[$__rate_interval]))",
+              "legendFormat": "{{controller}} / {{result}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Reconciles / sec",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "P95 reconcile duration by controller (seconds).",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 5
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum by(le, controller) (rate(controller_runtime_reconcile_time_seconds_bucket{namespace=~\"$namespace\", job=~\"$job\", controller=~\"$controller\"}[$__rate_interval])))",
+              "legendFormat": "{{controller}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Reconcile duration p95",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 13
+          },
+          "id": 7,
+          "panels": [],
+          "title": "Queue & Backlog",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Workqueue depth by queue name (client-go workqueue).",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 14
+          },
+          "id": 8,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "max by(name) (workqueue_depth{namespace=~\"$namespace\", job=~\"$job\"})",
+              "legendFormat": "{{name}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Workqueue depth",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "Rate at which items are re-queued (retries) per workqueue.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 14
+          },
+          "id": 9,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "sum by(name) (rate(workqueue_retries_total{namespace=~\"$namespace\", job=~\"$job\"}[$__rate_interval]))",
+              "legendFormat": "{{name}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Workqueue retries / sec",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 22
+          },
+          "id": 10,
+          "panels": [],
+          "title": "TrainJob Lifecycle",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "TrainJob controller reconcile rate by result.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 23
+          },
+          "id": 11,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "sum by(result) (rate(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\", controller=\"trainjob_controller\"}[$__rate_interval]))",
+              "legendFormat": "{{result}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "TrainJob reconciles / sec",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "TrainJob controller reconcile error rate.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 23
+          },
+          "id": 12,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "sum(rate(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\", controller=\"trainjob_controller\", result=\"error\"}[$__rate_interval]))",
+              "legendFormat": "errors",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "TrainJob reconcile errors / sec",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "description": "P95 TrainJob reconcile duration (seconds).",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 31
+          },
+          "id": 13,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum by(le) (rate(controller_runtime_reconcile_time_seconds_bucket{namespace=~\"$namespace\", job=~\"$job\", controller=\"trainjob_controller\"}[$__rate_interval])))",
+              "legendFormat": "p95",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "TrainJob reconcile duration p95",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 39,
+      "tags": [
+        "kubeflow",
+        "trainer",
+        "observability",
+        "controller-runtime"
+      ],
+      "templating": {
+        "list": [
+          {
+            "hide": 0,
+            "includeAll": false,
+            "label": "Prometheus",
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "type": "datasource"
+          },
+          {
+            "current": {
+              "selected": true,
+              "text": "All",
+              "value": ".*"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "definition": "label_values(up, namespace)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Namespace",
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": {
+              "query": "label_values(up, namespace)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {
+              "selected": true,
+              "text": "All",
+              "value": ".*"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "definition": "label_values(up{namespace=~\"$namespace\"}, job)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Job",
+            "multi": false,
+            "name": "job",
+            "options": [],
+            "query": {
+              "query": "label_values(up{namespace=~\"$namespace\"}, job)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {
+              "selected": true,
+              "text": "All",
+              "value": ".*"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "definition": "label_values(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\"}, controller)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Controller",
+            "multi": true,
+            "name": "controller",
+            "options": [],
+            "query": {
+              "query": "label_values(controller_runtime_reconcile_total{namespace=~\"$namespace\", job=~\"$job\"}, controller)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "sort": 1,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Kubeflow Trainer - Controller Health & TrainJob Lifecycle",
+      "uid": "kubeflow-trainer-controller",
+      "version": 1,
+      "weekStart": ""
+    }

--- a/manifests/overlays/grafana-dashboard/kustomization.yaml
+++ b/manifests/overlays/grafana-dashboard/kustomization.yaml
@@ -1,0 +1,21 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kubeflow-system
+
+resources:
+  - configmap.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a default Grafana dashboard shipped as a ConfigMap in the Kubeflow Trainer Helm chart, providing out-of-the-box visibility into controller health and TrainJob lifecycle.

The dashboard is disabled by default (`grafanaDashboard.enabled: false`) - zero impact on existing deployments. When enabled, the ConfigMap is labeled for Grafana sidecar auto-discovery (`grafana_dashboard: "1"`). It includes 10 panels across 3 rows (Controller Health, Queue & Backlog, TrainJob Lifecycle) using controller-runtime metrics already exposed by the Trainer controller.

Changes:
- `charts/kubeflow-trainer/dashboards/kubeflow-trainer-dashboard.json` - Grafana dashboard JSON model
- `charts/kubeflow-trainer/templates/grafana/configmap.yaml` - Helm template gated by `grafanaDashboard.enabled`
- `charts/kubeflow-trainer/tests/grafana/configmap_test.yaml` - 7 Helm unit tests for the ConfigMap
- `charts/kubeflow-trainer/values.yaml` - new `grafanaDashboard` values section
- `charts/kubeflow-trainer/README.md.gotmpl` - documentation for enabling the dashboard

**Which issue(s) this PR fixes**:
Fixes #3430

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing