### PR TITLE
fix(operator): surface runtime resource reconciliation errors in TrainJob status

### DIFF
--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -77,6 +77,10 @@ const (
 	// when the referenced TrainingRuntime is not supported.
 	TrainJobRuntimeNotSupportedReason string = "TrainingRuntimeNotSupported"
 
+	// TrainJobResourcesCreationFailedReason is the "Failed" condition reason
+	// when the creation of runtime resources fails.
+	TrainJobResourcesCreationFailedReason string = "ResourcesCreationFailed"
+
 	// TrainJobDeadlineExceededReason is the "Failed" condition reason
 	// when the TrainJob exceeds its ActiveDeadlineSeconds.
 	// Matches the Kubernetes Job behavior.

--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -122,14 +122,12 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	} else if !trainjob.IsTrainJobFinished(&trainJob) {
 		err = r.reconcileObjects(ctx, runtime, &trainJob)
 		if err != nil {
-			// TODO (astefanutti): the error should be surfaced in the TrainJob status to indicate
-			//  the creation of the runtime resources failed and the TrainJob is backed off until
-			//  the next retry attempt.
 			// The event message is truncated to stay within the maximum length limit (1024 chars).
 			message := fmt.Sprintf("TrainJob resources reconciliation failed: %.950v", err.Error())
 			if len(err.Error()) > 950 {
 				message = fmt.Sprintf("%s ...", message)
 			}
+			setFailedCondition(&trainJob, message, trainer.TrainJobResourcesCreationFailedReason)
 			r.recorder.Eventf(&trainJob, nil, corev1.EventTypeWarning, "TrainJobResourcesCreationFailed", "Reconciling", message)
 		}
 	}
@@ -277,10 +275,10 @@ func removeFailedCondition(trainJob *trainer.TrainJob) {
 }
 
 func setTrainJobStatus(ctx context.Context, runtime jobruntimes.Runtime, trainJob *trainer.TrainJob) error {
-	deadlineCond := meta.FindStatusCondition(trainJob.Status.Conditions, trainer.TrainJobFailed)
-	if deadlineCond != nil && deadlineCond.Reason != trainer.TrainJobDeadlineExceededReason {
-		deadlineCond = nil
-	}
+	// Preserve any pre-existing Failed condition from being overwritten
+	// by the runtime TrainJobStatus. This covers both terminal failures
+	// (DeadlineExceeded) and creation failures (ResourcesCreationFailed).
+	failedCond := meta.FindStatusCondition(trainJob.Status.Conditions, trainer.TrainJobFailed)
 
 	status, err := runtime.TrainJobStatus(ctx, trainJob)
 	if err != nil {
@@ -289,8 +287,8 @@ func setTrainJobStatus(ctx context.Context, runtime jobruntimes.Runtime, trainJo
 	if status != nil {
 		trainJob.Status = *status
 	}
-	if deadlineCond != nil {
-		meta.SetStatusCondition(&trainJob.Status.Conditions, *deadlineCond)
+	if failedCond != nil {
+		meta.SetStatusCondition(&trainJob.Status.Conditions, *failedCond)
 	}
 	return nil
 }

--- a/pkg/controller/trainjob_controller_test.go
+++ b/pkg/controller/trainjob_controller_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2025 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	jobruntimes "github.com/kubeflow/trainer/v2/pkg/runtime"
+)
+
+type mockRuntime struct {
+	status *trainer.TrainJobStatus
+	err    error
+}
+
+func (m *mockRuntime) NewObjects(ctx context.Context, trainJob *trainer.TrainJob) ([]runtime.ApplyConfiguration, error) {
+	return nil, nil
+}
+
+func (m *mockRuntime) RuntimeInfo(trainJob *trainer.TrainJob, runtimeTemplateSpec any, mlPolicy *trainer.MLPolicy, podGroupPolicy *trainer.PodGroupPolicy) (*jobruntimes.Info, error) {
+	return nil, nil
+}
+
+func (m *mockRuntime) TrainJobStatus(ctx context.Context, trainJob *trainer.TrainJob) (*trainer.TrainJobStatus, error) {
+	return m.status, m.err
+}
+
+func (m *mockRuntime) EventHandlerRegistrars() []jobruntimes.ReconcilerBuilder {
+	return nil
+}
+
+func (m *mockRuntime) ValidateObjects(ctx context.Context, old, new *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
+	return nil, nil
+}
+
+func TestSetTrainJobStatusPreservesFailedCondition(t *testing.T) {
+	testCases := map[string]struct {
+		reason        string
+		runtimeStatus *trainer.TrainJobStatus
+	}{
+		"preserves ResourcesCreationFailed condition with nil runtime status": {
+			reason:        trainer.TrainJobResourcesCreationFailedReason,
+			runtimeStatus: nil,
+		},
+		"preserves ResourcesCreationFailed condition with non-nil runtime status": {
+			reason:        trainer.TrainJobResourcesCreationFailedReason,
+			runtimeStatus: &trainer.TrainJobStatus{},
+		},
+		"preserves DeadlineExceeded condition": {
+			reason:        trainer.TrainJobDeadlineExceededReason,
+			runtimeStatus: &trainer.TrainJobStatus{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			trainJob := &trainer.TrainJob{}
+			setFailedCondition(trainJob, "test failure", tc.reason)
+
+			runtime := &mockRuntime{status: tc.runtimeStatus}
+
+			if err := setTrainJobStatus(context.Background(), runtime, trainJob); err != nil {
+				t.Fatalf("setTrainJobStatus returned error: %v", err)
+			}
+
+			cond := meta.FindStatusCondition(trainJob.Status.Conditions, trainer.TrainJobFailed)
+			if cond == nil {
+				t.Fatal("Expected Failed condition to be preserved, but it was overwritten or removed")
+			}
+			if cond.Reason != tc.reason {
+				t.Fatalf("Expected condition reason %s, got %s", tc.reason, cond.Reason)
+			}
+			if cond.Message != "test failure" {
+				t.Fatalf("Expected message 'test failure', got %q", cond.Message)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

When `reconcileObjects()` fails during TrainJob reconciliation (either during `runtime.NewObjects()` or the SSA `client.Apply()`), the error was previously only emitted as a Kubernetes Event via `r.recorder.Eventf()`. The TrainJob status was not updated to reflect the failure, leaving users unable to diagnose the issue via `kubectl get trainjob` — the job would appear stuck in a non-terminal state (e.g., "Pending") with no indication of what went wrong.

**Changes made:**

1. **New condition reason constant** (`pkg/apis/trainer/v1alpha1/trainjob_types.go`): Added `TrainJobResourcesCreationFailedReason = "ResourcesCreationFailed"` following the existing convention for condition reason constants.

2. **Surface error in TrainJob status** (`pkg/controller/trainjob_controller.go`): Call the existing `setFailedCondition()` helper when `reconcileObjects()` fails, mirroring the established pattern used for unsupported runtimes (`TrainingRuntimeNotSupported`) and deadline exceeded (`DeadlineExceeded`). The Kubernetes Event is preserved for real-time notification.

3. **Fix latent overwrite bug in setTrainJobStatus** (`pkg/controller/trainjob_controller.go`): Updated `setTrainJobStatus()` to generically preserve any pre-existing Failed condition instead of using a fragile reason-specific whitelist (which only preserved `DeadlineExceeded`). In a partial SSA apply failure, the runtime could return a non-nil status that would silently overwrite and erase the Failed condition. This fix ensures the condition survives regardless of the reason.

4. **Unit test** (`pkg/controller/trainjob_controller_test.go`): Added test coverage for `setTrainJobStatus()` verifying that Failed conditions with `ResourcesCreationFailed` and `DeadlineExceeded` reasons are preserved with both nil and non-nil runtime status returns.

Resolves the TODO left by astefanutti at trainjob_controller.go:125.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #3671

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing