### PR TITLE
fix(runtimes): add restricted PSS security contexts

### DIFF
--- a/charts/kubeflow-trainer/files/runtimes/torch-distributed-with-cache.yaml
+++ b/charts/kubeflow-trainer/files/runtimes/torch-distributed-with-cache.yaml
@@ -82,7 +82,6 @@ spec:
                 containers:
                   - name: node
                     image: pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime
-                    workingDir: /tmp
                     securityContext:
                       allowPrivilegeEscalation: false
                       capabilities:

--- a/charts/kubeflow-trainer/files/runtimes/torch-distributed-with-cache.yaml
+++ b/charts/kubeflow-trainer/files/runtimes/torch-distributed-with-cache.yaml
@@ -38,9 +38,23 @@ spec:
             template:
               spec:
                 serviceAccountName: kubeflow-trainer-cache-initializer
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 1000
+                  seccompProfile:
+                    type: RuntimeDefault
                 containers:
                   - name: dataset-initializer
                     image: {{ printf "ghcr.io/kubeflow/trainer/dataset-initializer:%s" (include "trainer.defaultImageTag" .) }}
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      runAsNonRoot: true
+                      runAsUser: 1000
+                      seccompProfile:
+                        type: RuntimeDefault
                     env:
                       - name: CACHE_IMAGE
                         value: {{ include "trainer.runtimeImage" (list .Values.dataCache.cacheImage .) | quote }}
@@ -60,9 +74,24 @@ spec:
           spec:
             template:
               spec:
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 1000
+                  seccompProfile:
+                    type: RuntimeDefault
                 containers:
                   - name: node
                     image: pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime
+                    workingDir: /tmp
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      runAsNonRoot: true
+                      runAsUser: 1000
+                      seccompProfile:
+                        type: RuntimeDefault
                     env:
                       - name: TRAIN_JOB_NAME
                         valueFrom:

--- a/charts/kubeflow-trainer/files/runtimes/torch-distributed-with-cache.yaml
+++ b/charts/kubeflow-trainer/files/runtimes/torch-distributed-with-cache.yaml
@@ -82,7 +82,6 @@ spec:
                 containers:
                   - name: node
                     image: pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime
-                    workingDir: /tmp
                     securityContext:
                       allowPrivilegeEscalation: false
                       capabilities:

--- a/charts/kubeflow-trainer/files/runtimes/torch-distributed-with-cache.yaml
+++ b/charts/kubeflow-trainer/files/runtimes/torch-distributed-with-cache.yaml
@@ -91,9 +91,18 @@ spec:
                       runAsUser: 1000
                       seccompProfile:
                         type: RuntimeDefault
+                    volumeMounts:
+                      - name: workspace
+                        mountPath: /workspace
                     env:
                       - name: TRAIN_JOB_NAME
                         valueFrom:
                           fieldRef:
                             apiVersion: v1
                             fieldPath: metadata.labels['jobset.sigs.k8s.io/jobset-name']
+                # The default image runs as root and owns /workspace, so the non-root
+                # trainer cannot write there. The emptyDir keeps the working directory
+                # writable without changing the image's configured WORKDIR.
+                volumes:
+                  - name: workspace
+                    emptyDir: {}

--- a/charts/kubeflow-trainer/files/runtimes/torch-distributed-with-cache.yaml
+++ b/charts/kubeflow-trainer/files/runtimes/torch-distributed-with-cache.yaml
@@ -38,9 +38,23 @@ spec:
             template:
               spec:
                 serviceAccountName: kubeflow-trainer-cache-initializer
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 1000
+                  seccompProfile:
+                    type: RuntimeDefault
                 containers:
                   - name: dataset-initializer
                     image: {{ printf "ghcr.io/kubeflow/trainer/dataset-initializer:%s" (include "trainer.defaultImageTag" .) }}
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      runAsNonRoot: true
+                      runAsUser: 1000
+                      seccompProfile:
+                        type: RuntimeDefault
                     env:
                       - name: CACHE_IMAGE
                         value: {{ include "trainer.runtimeImage" (list .Values.dataCache.cacheImage .) | quote }}
@@ -60,9 +74,24 @@ spec:
           spec:
             template:
               spec:
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 1000
+                  seccompProfile:
+                    type: RuntimeDefault
                 containers:
                   - name: node
                     image: pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime
+                    workingDir: /tmp
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      runAsNonRoot: true
+                      runAsUser: 1000
+                      seccompProfile:
+                        type: RuntimeDefault
                     env:
                       - name: TRAIN_JOB_NAME
                         valueFrom:

--- a/charts/kubeflow-trainer/files/runtimes/torch-distributed.yaml
+++ b/charts/kubeflow-trainer/files/runtimes/torch-distributed.yaml
@@ -36,6 +36,21 @@ spec:
             spec:
               template:
                 spec:
+                  securityContext:
+                    runAsNonRoot: true
+                    runAsUser: 1000
+                    seccompProfile:
+                      type: RuntimeDefault
                   containers:
                     - name: node
                       image: pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime
+                      workingDir: /tmp
+                      securityContext:
+                        allowPrivilegeEscalation: false
+                        capabilities:
+                          drop:
+                            - ALL
+                        runAsNonRoot: true
+                        runAsUser: 1000
+                        seccompProfile:
+                          type: RuntimeDefault

--- a/charts/kubeflow-trainer/files/runtimes/torch-distributed.yaml
+++ b/charts/kubeflow-trainer/files/runtimes/torch-distributed.yaml
@@ -44,7 +44,6 @@ spec:
                   containers:
                     - name: node
                       image: pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime
-                      workingDir: /tmp
                       securityContext:
                         allowPrivilegeEscalation: false
                         capabilities:

--- a/charts/kubeflow-trainer/files/runtimes/torch-distributed.yaml
+++ b/charts/kubeflow-trainer/files/runtimes/torch-distributed.yaml
@@ -44,7 +44,6 @@ spec:
                   containers:
                     - name: node
                       image: pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime
-                      workingDir: /tmp
                       securityContext:
                         allowPrivilegeEscalation: false
                         capabilities:

--- a/charts/kubeflow-trainer/files/runtimes/torch-distributed.yaml
+++ b/charts/kubeflow-trainer/files/runtimes/torch-distributed.yaml
@@ -36,6 +36,21 @@ spec:
             spec:
               template:
                 spec:
+                  securityContext:
+                    runAsNonRoot: true
+                    runAsUser: 1000
+                    seccompProfile:
+                      type: RuntimeDefault
                   containers:
                     - name: node
                       image: pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime
+                      workingDir: /tmp
+                      securityContext:
+                        allowPrivilegeEscalation: false
+                        capabilities:
+                          drop:
+                            - ALL
+                        runAsNonRoot: true
+                        runAsUser: 1000
+                        seccompProfile:
+                          type: RuntimeDefault

--- a/charts/kubeflow-trainer/files/runtimes/torch-distributed.yaml
+++ b/charts/kubeflow-trainer/files/runtimes/torch-distributed.yaml
@@ -53,3 +53,12 @@ spec:
                         runAsUser: 1000
                         seccompProfile:
                           type: RuntimeDefault
+                      volumeMounts:
+                        - name: workspace
+                          mountPath: /workspace
+                  # The default image runs as root and owns /workspace, so the non-root
+                  # trainer cannot write there. The emptyDir keeps the working directory
+                  # writable without changing the image's configured WORKDIR.
+                  volumes:
+                    - name: workspace
+                      emptyDir: {}

--- a/charts/kubeflow-trainer/tests/runtimes/torch_distributed_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torch_distributed_test.yaml
@@ -51,3 +51,14 @@ tests:
       - matchRegex:
           path: data["runtimes.yaml"]
           pattern: "name: torch-distributed"
+
+  - it: Should set restricted PSS compatible security contexts
+    set:
+      runtimes:
+        torchDistributed:
+          enabled: true
+    asserts:
+      - matchRegex:
+          path: data["runtimes.yaml"]
+          pattern: |-
+            (?s)- name: node.*securityContext:\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault\s+containers:\s+- name: node\s+image: pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime\s+workingDir: /tmp\s+securityContext:\s+allowPrivilegeEscalation: false\s+capabilities:\s+drop:\s+- ALL\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault

--- a/charts/kubeflow-trainer/tests/runtimes/torch_distributed_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torch_distributed_test.yaml
@@ -61,4 +61,4 @@ tests:
       - matchRegex:
           path: data["runtimes.yaml"]
           pattern: |-
-            (?s)- name: node.*securityContext:\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault\s+containers:\s+- name: node\s+image: pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime\s+workingDir: /tmp\s+securityContext:\s+allowPrivilegeEscalation: false\s+capabilities:\s+drop:\s+- ALL\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault
+            (?s)- name: node.*securityContext:\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault\s+containers:\s+- name: node\s+image: pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime\s+securityContext:\s+allowPrivilegeEscalation: false\s+capabilities:\s+drop:\s+- ALL\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault

--- a/charts/kubeflow-trainer/tests/runtimes/torch_distributed_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torch_distributed_test.yaml
@@ -62,3 +62,14 @@ tests:
           path: data["runtimes.yaml"]
           pattern: |-
             (?s)- name: node.*securityContext:\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault\s+containers:\s+- name: node\s+image: pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime\s+securityContext:\s+allowPrivilegeEscalation: false\s+capabilities:\s+drop:\s+- ALL\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault
+
+  - it: Should mount a writable working directory for the trainer node
+    set:
+      runtimes:
+        torchDistributed:
+          enabled: true
+    asserts:
+      - matchRegex:
+          path: data["runtimes.yaml"]
+          pattern: |-
+            (?s)- name: node.*volumeMounts:\s+- name: workspace\s+mountPath: /workspace.*volumes:\s+- name: workspace\s+emptyDir: \{\}

--- a/charts/kubeflow-trainer/tests/runtimes/torch_distributed_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torch_distributed_test.yaml
@@ -61,4 +61,4 @@ tests:
       - matchRegex:
           path: data["runtimes.yaml"]
           pattern: |-
-            (?s)- name: node.*securityContext:\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault\s+containers:\s+- name: node\s+image: pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime\s+securityContext:\s+allowPrivilegeEscalation: false\s+capabilities:\s+drop:\s+- ALL\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault
+            (?s)- name: node.*securityContext:\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault\s+containers:\s+- name: node\s+image: pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime\s+securityContext:\s+allowPrivilegeEscalation: false\s+capabilities:\s+drop:\s+- ALL\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault

--- a/charts/kubeflow-trainer/tests/runtimes/torch_distributed_with_cache_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torch_distributed_with_cache_test.yaml
@@ -62,3 +62,41 @@ tests:
       - matchRegex:
           path: data["runtimes.yaml"]
           pattern: "ghcr.io/kubeflow/trainer/data-cache:v1.0.0"
+
+  - it: Should have node job depend on dataset-initializer
+    set:
+      dataCache:
+        enabled: true
+        cacheImage:
+          registry: ghcr.io
+          repository: kubeflow/trainer/data-cache
+          tag: "v1.0.0"
+        runtimes:
+          torchDistributedWithCache:
+            enabled: true
+    asserts:
+      - matchRegex:
+          path: data["runtimes.yaml"]
+          pattern: |-
+            (?s)- name: node\s+dependsOn:\s+- name: dataset-initializer\s+status: Complete
+
+  - it: Should set restricted PSS compatible security contexts
+    set:
+      dataCache:
+        enabled: true
+        cacheImage:
+          registry: ghcr.io
+          repository: kubeflow/trainer/data-cache
+          tag: "v1.0.0"
+        runtimes:
+          torchDistributedWithCache:
+            enabled: true
+    asserts:
+      - matchRegex:
+          path: data["runtimes.yaml"]
+          pattern: |-
+            (?s)- name: dataset-initializer.*securityContext:\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault\s+containers:\s+- name: dataset-initializer\s+image: ghcr.io/kubeflow/trainer/dataset-initializer:.*\s+securityContext:\s+allowPrivilegeEscalation: false\s+capabilities:\s+drop:\s+- ALL\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault
+      - matchRegex:
+          path: data["runtimes.yaml"]
+          pattern: |-
+            (?s)- name: node.*securityContext:\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault\s+containers:\s+- name: node\s+image: pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime\s+workingDir: /tmp\s+securityContext:\s+allowPrivilegeEscalation: false\s+capabilities:\s+drop:\s+- ALL\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault

--- a/charts/kubeflow-trainer/tests/runtimes/torch_distributed_with_cache_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torch_distributed_with_cache_test.yaml
@@ -99,4 +99,4 @@ tests:
       - matchRegex:
           path: data["runtimes.yaml"]
           pattern: |-
-            (?s)- name: node.*securityContext:\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault\s+containers:\s+- name: node\s+image: pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime\s+workingDir: /tmp\s+securityContext:\s+allowPrivilegeEscalation: false\s+capabilities:\s+drop:\s+- ALL\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault
+            (?s)- name: node.*securityContext:\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault\s+containers:\s+- name: node\s+image: pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime\s+securityContext:\s+allowPrivilegeEscalation: false\s+capabilities:\s+drop:\s+- ALL\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault

--- a/charts/kubeflow-trainer/tests/runtimes/torch_distributed_with_cache_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torch_distributed_with_cache_test.yaml
@@ -100,3 +100,20 @@ tests:
           path: data["runtimes.yaml"]
           pattern: |-
             (?s)- name: node.*securityContext:\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault\s+containers:\s+- name: node\s+image: pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime\s+securityContext:\s+allowPrivilegeEscalation: false\s+capabilities:\s+drop:\s+- ALL\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault
+
+  - it: Should mount a writable working directory for the trainer node
+    set:
+      dataCache:
+        enabled: true
+        cacheImage:
+          registry: ghcr.io
+          repository: kubeflow/trainer/data-cache
+          tag: "v1.0.0"
+        runtimes:
+          torchDistributedWithCache:
+            enabled: true
+    asserts:
+      - matchRegex:
+          path: data["runtimes.yaml"]
+          pattern: |-
+            (?s)- name: node.*volumeMounts:\s+- name: workspace\s+mountPath: /workspace.*volumes:\s+- name: workspace\s+emptyDir: \{\}

--- a/charts/kubeflow-trainer/tests/runtimes/torch_distributed_with_cache_test.yaml
+++ b/charts/kubeflow-trainer/tests/runtimes/torch_distributed_with_cache_test.yaml
@@ -99,4 +99,4 @@ tests:
       - matchRegex:
           path: data["runtimes.yaml"]
           pattern: |-
-            (?s)- name: node.*securityContext:\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault\s+containers:\s+- name: node\s+image: pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime\s+securityContext:\s+allowPrivilegeEscalation: false\s+capabilities:\s+drop:\s+- ALL\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault
+            (?s)- name: node.*securityContext:\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault\s+containers:\s+- name: node\s+image: pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime\s+securityContext:\s+allowPrivilegeEscalation: false\s+capabilities:\s+drop:\s+- ALL\s+runAsNonRoot: true\s+runAsUser: 1000\s+seccompProfile:\s+type: RuntimeDefault

--- a/cmd/data_cache/Dockerfile
+++ b/cmd/data_cache/Dockerfile
@@ -53,8 +53,8 @@ RUN apt-get update && \
 COPY --from=builder /workspace/target/release/head /usr/local/bin/head
 COPY --from=builder /workspace/target/release/worker /usr/local/bin/worker
 
-# Create non-root user
-RUN groupadd -r cache_user && useradd -r -g cache_user cache_user
+# Create a non-root user that matches the runtime security context.
+RUN groupadd --gid 1000 cache_user && useradd --uid 1000 --gid cache_user cache_user
 
 # Change ownership and switch to non-root user
 RUN chown -R cache_user:cache_user /usr/local/bin/

--- a/cmd/data_cache/Dockerfile
+++ b/cmd/data_cache/Dockerfile
@@ -56,6 +56,7 @@ COPY --from=builder /workspace/target/release/worker /usr/local/bin/worker
 # Create a non-root user that matches the runtime security context.
 RUN groupadd --gid 1000 cache_user && useradd --uid 1000 --gid cache_user cache_user
 
-# Change ownership and switch to non-root user
+# Change ownership and switch to the non-root user by number, so the
+# kubelet can verify runAsNonRoot from the image alone.
 RUN chown -R cache_user:cache_user /usr/local/bin/
-USER cache_user
+USER 1000:1000

--- a/manifests/base/runtimes/data-cache/torch_distributed_with_cache.yaml
+++ b/manifests/base/runtimes/data-cache/torch_distributed_with_cache.yaml
@@ -36,9 +36,23 @@ spec:
             template:
               spec:
                 serviceAccountName: kubeflow-trainer-cache-initializer
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 1000
+                  seccompProfile:
+                    type: RuntimeDefault
                 containers:
                   - name: dataset-initializer
                     image: ghcr.io/kubeflow/trainer/dataset-initializer
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      runAsNonRoot: true
+                      runAsUser: 1000
+                      seccompProfile:
+                        type: RuntimeDefault
                     env:
                       - name: CACHE_IMAGE
                         value: "ghcr.io/kubeflow/trainer/data-cache:latest"
@@ -58,9 +72,24 @@ spec:
           spec:
             template:
               spec:
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 1000
+                  seccompProfile:
+                    type: RuntimeDefault
                 containers:
                   - name: node
                     image: pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime
+                    workingDir: /tmp
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      runAsNonRoot: true
+                      runAsUser: 1000
+                      seccompProfile:
+                        type: RuntimeDefault
                     env:
                       - name: TRAIN_JOB_NAME
                         valueFrom:

--- a/manifests/base/runtimes/data-cache/torch_distributed_with_cache.yaml
+++ b/manifests/base/runtimes/data-cache/torch_distributed_with_cache.yaml
@@ -80,7 +80,6 @@ spec:
                 containers:
                   - name: node
                     image: pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime
-                    workingDir: /tmp
                     securityContext:
                       allowPrivilegeEscalation: false
                       capabilities:

--- a/manifests/base/runtimes/data-cache/torch_distributed_with_cache.yaml
+++ b/manifests/base/runtimes/data-cache/torch_distributed_with_cache.yaml
@@ -36,9 +36,23 @@ spec:
             template:
               spec:
                 serviceAccountName: kubeflow-trainer-cache-initializer
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 1000
+                  seccompProfile:
+                    type: RuntimeDefault
                 containers:
                   - name: dataset-initializer
                     image: ghcr.io/kubeflow/trainer/dataset-initializer
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      runAsNonRoot: true
+                      runAsUser: 1000
+                      seccompProfile:
+                        type: RuntimeDefault
                     env:
                       - name: CACHE_IMAGE
                         value: "ghcr.io/kubeflow/trainer/data-cache:latest"
@@ -58,9 +72,24 @@ spec:
           spec:
             template:
               spec:
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 1000
+                  seccompProfile:
+                    type: RuntimeDefault
                 containers:
                   - name: node
                     image: pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime
+                    workingDir: /tmp
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      runAsNonRoot: true
+                      runAsUser: 1000
+                      seccompProfile:
+                        type: RuntimeDefault
                     env:
                       - name: TRAIN_JOB_NAME
                         valueFrom:

--- a/manifests/base/runtimes/data-cache/torch_distributed_with_cache.yaml
+++ b/manifests/base/runtimes/data-cache/torch_distributed_with_cache.yaml
@@ -80,7 +80,6 @@ spec:
                 containers:
                   - name: node
                     image: pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime
-                    workingDir: /tmp
                     securityContext:
                       allowPrivilegeEscalation: false
                       capabilities:

--- a/manifests/base/runtimes/data-cache/torch_distributed_with_cache.yaml
+++ b/manifests/base/runtimes/data-cache/torch_distributed_with_cache.yaml
@@ -89,9 +89,18 @@ spec:
                       runAsUser: 1000
                       seccompProfile:
                         type: RuntimeDefault
+                    volumeMounts:
+                      - name: workspace
+                        mountPath: /workspace
                     env:
                       - name: TRAIN_JOB_NAME
                         valueFrom:
                           fieldRef:
                             apiVersion: v1
                             fieldPath: metadata.labels['jobset.sigs.k8s.io/jobset-name']
+                # The default image runs as root and owns /workspace, so the non-root
+                # trainer cannot write there. The emptyDir keeps the working directory
+                # writable without changing the image's configured WORKDIR.
+                volumes:
+                  - name: workspace
+                    emptyDir: {}

--- a/manifests/base/runtimes/torch_distributed.yaml
+++ b/manifests/base/runtimes/torch_distributed.yaml
@@ -33,6 +33,21 @@ spec:
             spec:
               template:
                 spec:
+                  securityContext:
+                    runAsNonRoot: true
+                    runAsUser: 1000
+                    seccompProfile:
+                      type: RuntimeDefault
                   containers:
                     - name: node
                       image: pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime
+                      workingDir: /tmp
+                      securityContext:
+                        allowPrivilegeEscalation: false
+                        capabilities:
+                          drop:
+                            - ALL
+                        runAsNonRoot: true
+                        runAsUser: 1000
+                        seccompProfile:
+                          type: RuntimeDefault

--- a/manifests/base/runtimes/torch_distributed.yaml
+++ b/manifests/base/runtimes/torch_distributed.yaml
@@ -41,7 +41,6 @@ spec:
                   containers:
                     - name: node
                       image: pytorch/pytorch:2.10.0-cuda12.8-cudnn9-runtime
-                      workingDir: /tmp
                       securityContext:
                         allowPrivilegeEscalation: false
                         capabilities:

--- a/manifests/base/runtimes/torch_distributed.yaml
+++ b/manifests/base/runtimes/torch_distributed.yaml
@@ -33,6 +33,21 @@ spec:
             spec:
               template:
                 spec:
+                  securityContext:
+                    runAsNonRoot: true
+                    runAsUser: 1000
+                    seccompProfile:
+                      type: RuntimeDefault
                   containers:
                     - name: node
                       image: pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime
+                      workingDir: /tmp
+                      securityContext:
+                        allowPrivilegeEscalation: false
+                        capabilities:
+                          drop:
+                            - ALL
+                        runAsNonRoot: true
+                        runAsUser: 1000
+                        seccompProfile:
+                          type: RuntimeDefault

--- a/manifests/base/runtimes/torch_distributed.yaml
+++ b/manifests/base/runtimes/torch_distributed.yaml
@@ -41,7 +41,6 @@ spec:
                   containers:
                     - name: node
                       image: pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime
-                      workingDir: /tmp
                       securityContext:
                         allowPrivilegeEscalation: false
                         capabilities:

--- a/manifests/base/runtimes/torch_distributed.yaml
+++ b/manifests/base/runtimes/torch_distributed.yaml
@@ -50,3 +50,12 @@ spec:
                         runAsUser: 1000
                         seccompProfile:
                           type: RuntimeDefault
+                      volumeMounts:
+                        - name: workspace
+                          mountPath: /workspace
+                  # The default image runs as root and owns /workspace, so the non-root
+                  # trainer cannot write there. The emptyDir keeps the working directory
+                  # writable without changing the image's configured WORKDIR.
+                  volumes:
+                    - name: workspace
+                      emptyDir: {}

--- a/pkg/initializers/dataset/cache.py
+++ b/pkg/initializers/dataset/cache.py
@@ -21,6 +21,20 @@ from kubernetes.client.rest import ApiException
 import pkg.initializers.types.types as types
 import pkg.initializers.utils.utils as utils
 
+RESTRICTED_POD_SECURITY_CONTEXT = {
+    "runAsNonRoot": True,
+    "runAsUser": 1000,
+    "seccompProfile": {"type": "RuntimeDefault"},
+}
+
+RESTRICTED_CONTAINER_SECURITY_CONTEXT = {
+    "allowPrivilegeEscalation": False,
+    "capabilities": {"drop": ["ALL"]},
+    "runAsNonRoot": True,
+    "runAsUser": 1000,
+    "seccompProfile": {"type": "RuntimeDefault"},
+}
+
 logging.basicConfig(
     format="%(asctime)s %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s",
     datefmt="%Y-%m-%dT%H:%M:%SZ",
@@ -174,12 +188,14 @@ class CacheInitializer(utils.DatasetProvider):
                             },
                             "spec": {
                                 "serviceAccountName": service_account.metadata.name,
+                                "securityContext": RESTRICTED_POD_SECURITY_CONTEXT,
                                 "containers": [
                                     {
                                         "name": "head",
                                         "image": cache_image,
                                         "command": ["head"],
                                         "args": ["0.0.0.0", "50051"],
+                                        "securityContext": RESTRICTED_CONTAINER_SECURITY_CONTEXT,
                                         "resources": {
                                             "limits": {
                                                 "cpu": head_cpu,
@@ -212,12 +228,14 @@ class CacheInitializer(utils.DatasetProvider):
                         "workerTemplate": {
                             "spec": {
                                 "serviceAccountName": f"{train_job_name}-cache",
+                                "securityContext": RESTRICTED_POD_SECURITY_CONTEXT,
                                 "containers": [
                                     {
                                         "name": "worker",
                                         "image": cache_image,
                                         "command": ["worker"],
                                         "args": ["0.0.0.0", "50051"],
+                                        "securityContext": RESTRICTED_CONTAINER_SECURITY_CONTEXT,
                                         "resources": {
                                             "limits": {
                                                 "cpu": worker_cpu,

--- a/pkg/initializers/dataset/cache.py
+++ b/pkg/initializers/dataset/cache.py
@@ -22,6 +22,20 @@ from kubernetes.client.rest import ApiException
 import pkg.initializers.types.types as types
 import pkg.initializers.utils.utils as utils
 
+RESTRICTED_POD_SECURITY_CONTEXT = {
+    "runAsNonRoot": True,
+    "runAsUser": 1000,
+    "seccompProfile": {"type": "RuntimeDefault"},
+}
+
+RESTRICTED_CONTAINER_SECURITY_CONTEXT = {
+    "allowPrivilegeEscalation": False,
+    "capabilities": {"drop": ["ALL"]},
+    "runAsNonRoot": True,
+    "runAsUser": 1000,
+    "seccompProfile": {"type": "RuntimeDefault"},
+}
+
 logging.basicConfig(
     format="%(asctime)s %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s",
     datefmt="%Y-%m-%dT%H:%M:%SZ",
@@ -190,12 +204,14 @@ class CacheInitializer(utils.DatasetProvider):
                             },
                             "spec": {
                                 "serviceAccountName": service_account.metadata.name,
+                                "securityContext": RESTRICTED_POD_SECURITY_CONTEXT,
                                 "containers": [
                                     {
                                         "name": "head",
                                         "image": cache_image,
                                         "command": ["head"],
                                         "args": ["0.0.0.0", "50051"],
+                                        "securityContext": RESTRICTED_CONTAINER_SECURITY_CONTEXT,
                                         "resources": {
                                             "limits": {
                                                 "cpu": head_cpu,
@@ -228,12 +244,14 @@ class CacheInitializer(utils.DatasetProvider):
                         "workerTemplate": {
                             "spec": {
                                 "serviceAccountName": f"{train_job_name}-cache",
+                                "securityContext": RESTRICTED_POD_SECURITY_CONTEXT,
                                 "containers": [
                                     {
                                         "name": "worker",
                                         "image": cache_image,
                                         "command": ["worker"],
                                         "args": ["0.0.0.0", "50051"],
+                                        "securityContext": RESTRICTED_CONTAINER_SECURITY_CONTEXT,
                                         "resources": {
                                             "limits": {
                                                 "cpu": worker_cpu,

--- a/pkg/initializers/dataset/cache_test.py
+++ b/pkg/initializers/dataset/cache_test.py
@@ -248,6 +248,84 @@ def test_download_dataset(test_name, test_case):
     print("Test execution completed")
 
 
+def test_download_dataset_creates_restricted_pss_compatible_leader_worker_set():
+    cache_initializer_instance = CacheInitializer()
+
+    config = {
+        "storage_uri": "cache://test_schema/test_table",
+        "train_job_name": "restricted-job",
+        "cache_image": "test-image:latest",
+        "iam_role": "arn:aws:iam::123456789012:role/test-role",
+        "metadata_loc": "s3://test-bucket/metadata",
+    }
+
+    with patch.object(utils, "get_config_from_env", return_value=config):
+        cache_initializer_instance.load_config()
+
+    with patch(
+        "pkg.initializers.dataset.cache.get_namespace", return_value="test-namespace"
+    ), patch("pkg.initializers.dataset.cache.config"), patch(
+        "pkg.initializers.dataset.cache.client"
+    ) as mock_client:
+
+        mock_api_client = MagicMock()
+        mock_core_v1 = MagicMock()
+        mock_custom_api = MagicMock()
+
+        mock_client.ApiClient.return_value = mock_api_client
+        mock_client.CoreV1Api.return_value = mock_core_v1
+        mock_client.CustomObjectsApi.return_value = mock_custom_api
+
+        mock_training_job = {
+            "apiVersion": "trainer.kubeflow.org/v1alpha1",
+            "kind": "TrainJob",
+            "metadata": {"name": "restricted-job", "uid": "test-uid"},
+        }
+        mock_lws_ready = {
+            "status": {"conditions": [{"type": "Available", "status": "True"}]}
+        }
+        mock_custom_api.get_namespaced_custom_object.side_effect = [
+            mock_training_job,
+            mock_lws_ready,
+        ]
+
+        cache_initializer_instance.download_dataset()
+
+        create_call = mock_custom_api.create_namespaced_custom_object.call_args
+        assert create_call.kwargs["plural"] == "leaderworkersets"
+
+        leader_worker_set = create_call.kwargs["body"]
+        leader_spec = leader_worker_set["spec"]["leaderWorkerTemplate"][
+            "leaderTemplate"
+        ]["spec"]
+        worker_spec = leader_worker_set["spec"]["leaderWorkerTemplate"][
+            "workerTemplate"
+        ]["spec"]
+        expected_pod_security_context = {
+            "runAsNonRoot": True,
+            "runAsUser": 1000,
+            "seccompProfile": {"type": "RuntimeDefault"},
+        }
+        expected_container_security_context = {
+            "allowPrivilegeEscalation": False,
+            "capabilities": {"drop": ["ALL"]},
+            "runAsNonRoot": True,
+            "runAsUser": 1000,
+            "seccompProfile": {"type": "RuntimeDefault"},
+        }
+
+        assert leader_spec["securityContext"] == expected_pod_security_context
+        assert worker_spec["securityContext"] == expected_pod_security_context
+        assert (
+            leader_spec["containers"][0]["securityContext"]
+            == expected_container_security_context
+        )
+        assert (
+            worker_spec["containers"][0]["securityContext"]
+            == expected_container_security_context
+        )
+
+
 def test_download_dataset_service_already_exists():
     """Service creation should be idempotent — a 409 AlreadyExists response
     must be treated as a no-op, not as a creation failure that triggers

--- a/pkg/initializers/dataset/cache_test.py
+++ b/pkg/initializers/dataset/cache_test.py
@@ -271,6 +271,84 @@ def test_download_dataset(test_name, test_case):
     print("Test execution completed")
 
 
+def test_download_dataset_creates_restricted_pss_compatible_leader_worker_set():
+    cache_initializer_instance = CacheInitializer()
+
+    config = {
+        "storage_uri": "cache://test_schema/test_table",
+        "train_job_name": "restricted-job",
+        "cache_image": "test-image:latest",
+        "iam_role": "arn:aws:iam::123456789012:role/test-role",
+        "metadata_loc": "s3://test-bucket/metadata",
+    }
+
+    with patch.object(utils, "get_config_from_env", return_value=config):
+        cache_initializer_instance.load_config()
+
+    with patch(
+        "pkg.initializers.dataset.cache.get_namespace", return_value="test-namespace"
+    ), patch("pkg.initializers.dataset.cache.config"), patch(
+        "pkg.initializers.dataset.cache.client"
+    ) as mock_client:
+
+        mock_api_client = MagicMock()
+        mock_core_v1 = MagicMock()
+        mock_custom_api = MagicMock()
+
+        mock_client.ApiClient.return_value = mock_api_client
+        mock_client.CoreV1Api.return_value = mock_core_v1
+        mock_client.CustomObjectsApi.return_value = mock_custom_api
+
+        mock_training_job = {
+            "apiVersion": "trainer.kubeflow.org/v1alpha1",
+            "kind": "TrainJob",
+            "metadata": {"name": "restricted-job", "uid": "test-uid"},
+        }
+        mock_lws_ready = {
+            "status": {"conditions": [{"type": "Available", "status": "True"}]}
+        }
+        mock_custom_api.get_namespaced_custom_object.side_effect = [
+            mock_training_job,
+            mock_lws_ready,
+        ]
+
+        cache_initializer_instance.download_dataset()
+
+        create_call = mock_custom_api.create_namespaced_custom_object.call_args
+        assert create_call.kwargs["plural"] == "leaderworkersets"
+
+        leader_worker_set = create_call.kwargs["body"]
+        leader_spec = leader_worker_set["spec"]["leaderWorkerTemplate"][
+            "leaderTemplate"
+        ]["spec"]
+        worker_spec = leader_worker_set["spec"]["leaderWorkerTemplate"][
+            "workerTemplate"
+        ]["spec"]
+        expected_pod_security_context = {
+            "runAsNonRoot": True,
+            "runAsUser": 1000,
+            "seccompProfile": {"type": "RuntimeDefault"},
+        }
+        expected_container_security_context = {
+            "allowPrivilegeEscalation": False,
+            "capabilities": {"drop": ["ALL"]},
+            "runAsNonRoot": True,
+            "runAsUser": 1000,
+            "seccompProfile": {"type": "RuntimeDefault"},
+        }
+
+        assert leader_spec["securityContext"] == expected_pod_security_context
+        assert worker_spec["securityContext"] == expected_pod_security_context
+        assert (
+            leader_spec["containers"][0]["securityContext"]
+            == expected_container_security_context
+        )
+        assert (
+            worker_spec["containers"][0]["securityContext"]
+            == expected_container_security_context
+        )
+
+
 def test_download_dataset_service_already_exists():
     """Service creation should be idempotent — a 409 AlreadyExists response
     must be treated as a no-op, not as a creation failure that triggers


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the Torch distributed Trainer runtime manifests and matching Helm templates restricted-PSS compatible.

It adds pod and container security contexts for the Torch distributed runtime and the data-cache variant, and updates Helm unit tests to cover those fields.

The runtime containers preserve each image's configured working directory so custom images retain their existing command and relative-path behavior.

The CPU end-to-end tests also require kubeflow/sdk#604, which writes SDK-generated files to a writable location without overriding the image working directory.

Validation:

- `make helm-unittest` passed: 18 suites / 109 tests
- `kustomize build manifests/base/runtimes`
- `kustomize build manifests/base/runtimes/data-cache`
- `helm template` from a temporary chart copy after dependency build
- `git diff --check`

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Related to kubeflow/manifests#3487

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/components/trainer/) included if any changes are user facing
