### PR TITLE
feat(runtimes): add GRPO post-training runtime and trainer image

### DIFF
--- a/.github/workflows/build-and-push-images.yaml
+++ b/.github/workflows/build-and-push-images.yaml
@@ -62,6 +62,9 @@ jobs:
           - component-name: torchtune-trainer
             dockerfile: cmd/trainers/torchtune/Dockerfile
             platforms: linux/amd64,linux/arm64
+          - component-name: grpo-trainer
+            dockerfile: cmd/trainers/grpo/Dockerfile
+            platforms: linux/amd64,linux/arm64
           - component-name: data-cache
             dockerfile: cmd/data_cache/Dockerfile
             platforms: linux/amd64,linux/arm64

--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,9 @@ test-python: ## Run Python unit test.
 	PYTHONPATH=$(PROJECT_DIR) pytest ./pkg/initializers/model
 	PYTHONPATH=$(PROJECT_DIR) pytest ./pkg/initializers/utils
 
+	pip install -r ./cmd/trainers/grpo/requirements.txt
+	pytest ./cmd/trainers/grpo
+
 .PHONY: test-python-integration
 test-python-integration: ## Run Python integration test.
 	pip install pytest

--- a/cmd/trainers/grpo/Dockerfile
+++ b/cmd/trainers/grpo/Dockerfile
@@ -12,13 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - deepspeed_distributed.yaml
-  - mlx_distributed.yaml
-  - torch_distributed.yaml
-  - jax_distributed.yaml
-  - xgboost_distributed.yaml
-  - torchtune
-  - grpo
+FROM pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime
+
+WORKDIR /workspace
+
+# Install build-essential for compiling any dependencies
+RUN apt update && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the required Python modules
+COPY cmd/trainers/grpo/requirements.txt .
+
+# Install the needed packages
+RUN pip install -r requirements.txt
+
+# Copy the GRPO training entrypoint
+COPY cmd/trainers/grpo/train.py .

--- a/cmd/trainers/grpo/Dockerfile
+++ b/cmd/trainers/grpo/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime
 
-WORKDIR /workspace
+WORKDIR /opt/grpo
 
 # Install build-essential for compiling any dependencies
 RUN apt update && apt-get install -y --no-install-recommends build-essential \
@@ -26,5 +26,5 @@ COPY cmd/trainers/grpo/requirements.txt .
 # Install the needed packages
 RUN pip install -r requirements.txt
 
-# Copy the GRPO training entrypoint
+# Copy the GRPO training entrypoint outside /workspace to avoid PVC mount shadowing
 COPY cmd/trainers/grpo/train.py .

--- a/cmd/trainers/grpo/requirements.txt
+++ b/cmd/trainers/grpo/requirements.txt
@@ -1,0 +1,6 @@
+trl>=0.18.0
+transformers>=4.52.0
+datasets>=3.6.0
+accelerate>=1.7.0
+peft>=0.15.0
+bitsandbytes>=0.49.2

--- a/cmd/trainers/grpo/train.py
+++ b/cmd/trainers/grpo/train.py
@@ -39,7 +39,7 @@ import os
 import sys
 from typing import Union
 
-from datasets import load_dataset, load_from_disk
+from datasets import load_dataset
 from trl import GRPOConfig, GRPOTrainer
 
 logging.basicConfig(
@@ -100,7 +100,7 @@ def load_reward_function():
         logger.error("Reward function module not found: %s", module_path)
         sys.exit(1)
 
-    if not hasattr(module, "reward_function"):
+    if not hasattr(module, "reward_function") or not callable(module.reward_function):
         logger.error("Module %s must define a 'reward_function' callable", module_path)
         sys.exit(1)
 
@@ -119,12 +119,8 @@ def main():
     logger.info("Dataset path: %s", dataset_path)
     logger.info("Output directory: %s", output_dir)
 
-    if os.path.isdir(dataset_path):
-        logger.info("Loading dataset from disk: %s", dataset_path)
-        dataset = load_from_disk(dataset_path)
-    else:
-        logger.info("Loading dataset from URI: %s", dataset_path)
-        dataset = load_dataset(dataset_path, split="train")
+    logger.info("Loading dataset: %s", dataset_path)
+    dataset = load_dataset(dataset_path, split="train")
 
     reward_fn = load_reward_function()
 

--- a/cmd/trainers/grpo/train.py
+++ b/cmd/trainers/grpo/train.py
@@ -1,0 +1,163 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GRPO training entrypoint for Kubeflow Trainer.
+
+This script launches TRL GRPOTrainer for reinforcement learning post-training
+using Group Relative Policy Optimization. It reads configuration from environment
+variables and command-line arguments, following the Kubeflow Trainer convention.
+
+Environment Variables:
+    STORAGE_URI:        URI for the pre-trained model (set by model initializer).
+    DATASET_STORAGE_URI: URI for the training dataset (set by dataset initializer).
+    MODEL_PATH:         Local path to the pre-trained model (default: /workspace/model).
+    DATASET_PATH:       Local path to the training dataset (default: /workspace/dataset).
+    OUTPUT_DIR:         Output directory for checkpoints (default: /workspace/output).
+    NUM_GENERATIONS:    Number of completions per prompt (default: 4).
+    MAX_PROMPT_LENGTH:  Maximum prompt token length (default: 512).
+    MAX_COMPLETION_LENGTH: Maximum completion token length (default: 256).
+    PER_DEVICE_TRAIN_BATCH_SIZE: Per-device batch size (default: 4).
+    GRADIENT_ACCUMULATION_STEPS: Gradient accumulation steps (default: 4).
+    NUM_TRAIN_EPOCHS:   Number of training epochs (default: 1).
+    LEARNING_RATE:      Learning rate (default: 5e-7).
+    LOGGING_STEPS:      Log every N steps (default: 1).
+"""
+
+import logging
+import os
+import sys
+from typing import Union
+
+from datasets import load_dataset, load_from_disk
+from trl import GRPOConfig, GRPOTrainer
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s [%(name)s] %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+)
+logger = logging.getLogger(__name__)
+
+WORKSPACE_MODEL = "/workspace/model"
+WORKSPACE_DATASET = "/workspace/dataset"
+WORKSPACE_OUTPUT = "/workspace/output"
+
+
+def get_env(name: str, default: Union[str, None] = None) -> str:
+    value = os.environ.get(name, default)
+    if value is None:
+        logger.error("Required environment variable %s is not set", name)
+        sys.exit(1)
+    return value
+
+
+def get_env_int(name: str, default: int) -> int:
+    return int(os.environ.get(name, str(default)))
+
+
+def get_env_float(name: str, default: float) -> float:
+    return float(os.environ.get(name, str(default)))
+
+
+def length_reward(completions: list[str], **kwargs) -> list[float]:
+    """Default reward function that rewards longer completions.
+
+    Users should override REWARD_FUNCTION_MODULE or supply a custom
+    training script for production reward functions.
+    """
+    return [float(len(c)) for c in completions]
+
+
+def load_reward_function():
+    """Load a custom reward function module if REWARD_FUNCTION_MODULE is set."""
+    module_path = os.environ.get("REWARD_FUNCTION_MODULE")
+    if module_path is None:
+        logger.info("Using default length-based reward function")
+        return length_reward
+
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("reward_module", module_path)
+    if spec is None or spec.loader is None:
+        logger.error("Cannot load reward function module: %s", module_path)
+        sys.exit(1)
+
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except FileNotFoundError:
+        logger.error("Reward function module not found: %s", module_path)
+        sys.exit(1)
+
+    if not hasattr(module, "reward_function"):
+        logger.error("Module %s must define a 'reward_function' callable", module_path)
+        sys.exit(1)
+
+    logger.info("Loaded custom reward function from %s", module_path)
+    return module.reward_function
+
+
+def main():
+    logger.info("Starting GRPO training")
+
+    model_path = get_env("MODEL_PATH", WORKSPACE_MODEL)
+    dataset_path = get_env("DATASET_PATH", WORKSPACE_DATASET)
+    output_dir = get_env("OUTPUT_DIR", WORKSPACE_OUTPUT)
+
+    logger.info("Model path: %s", model_path)
+    logger.info("Dataset path: %s", dataset_path)
+    logger.info("Output directory: %s", output_dir)
+
+    if os.path.isdir(dataset_path):
+        logger.info("Loading dataset from disk: %s", dataset_path)
+        dataset = load_from_disk(dataset_path)
+    else:
+        logger.info("Loading dataset from URI: %s", dataset_path)
+        dataset = load_dataset(dataset_path, split="train")
+
+    reward_fn = load_reward_function()
+
+    training_args = GRPOConfig(
+        output_dir=output_dir,
+        num_generations=get_env_int("NUM_GENERATIONS", 4),
+        max_prompt_length=get_env_int("MAX_PROMPT_LENGTH", 512),
+        max_completion_length=get_env_int("MAX_COMPLETION_LENGTH", 256),
+        per_device_train_batch_size=get_env_int("PER_DEVICE_TRAIN_BATCH_SIZE", 4),
+        gradient_accumulation_steps=get_env_int("GRADIENT_ACCUMULATION_STEPS", 4),
+        num_train_epochs=get_env_int("NUM_TRAIN_EPOCHS", 1),
+        learning_rate=get_env_float("LEARNING_RATE", 5e-7),
+        logging_steps=get_env_int("LOGGING_STEPS", 1),
+        save_strategy="epoch",
+        report_to="none",
+    )
+
+    logger.info("Initializing GRPOTrainer")
+    trainer = GRPOTrainer(
+        model=model_path,
+        reward_funcs=reward_fn,
+        args=training_args,
+        train_dataset=dataset,
+    )
+
+    logger.info("Starting training")
+    trainer.train()
+
+    logger.info("Saving final model to %s", output_dir)
+    trainer.save_model(output_dir)
+
+    logger.info("GRPO training completed successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/cmd/trainers/grpo/train_test.py
+++ b/cmd/trainers/grpo/train_test.py
@@ -1,0 +1,222 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import os
+import sys
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+train = importlib.import_module("train")  # noqa: E402
+
+get_env = train.get_env
+get_env_int = train.get_env_int
+get_env_float = train.get_env_float
+length_reward = train.length_reward
+load_reward_function = train.load_reward_function
+
+
+@dataclass
+class GRPOTestCase:
+    name: str
+    env_vars: dict
+    expected: object = None
+    expected_error: type = None
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        GRPOTestCase(
+            name="returns value when env var is set",
+            env_vars={"MODEL_PATH": "/custom/model"},
+            expected="/custom/model",
+        ),
+        GRPOTestCase(
+            name="returns default when env var is not set",
+            env_vars={},
+            expected="/default/path",
+        ),
+    ],
+)
+def test_get_env(test_case, monkeypatch):
+    for key, value in test_case.env_vars.items():
+        monkeypatch.setenv(key, value)
+    if "MODEL_PATH" not in test_case.env_vars:
+        monkeypatch.delenv("MODEL_PATH", raising=False)
+
+    result = get_env("MODEL_PATH", "/default/path")
+    assert result == test_case.expected
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        GRPOTestCase(
+            name="exits when required env var is missing and no default",
+            env_vars={},
+            expected_error=SystemExit,
+        ),
+    ],
+)
+def test_get_env_missing_required(test_case, monkeypatch):
+    monkeypatch.delenv("REQUIRED_VAR", raising=False)
+    with pytest.raises(test_case.expected_error):
+        get_env("REQUIRED_VAR")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        GRPOTestCase(
+            name="parses integer from env",
+            env_vars={"NUM_GENERATIONS": "8"},
+            expected=8,
+        ),
+        GRPOTestCase(
+            name="returns default when env var is not set",
+            env_vars={},
+            expected=4,
+        ),
+    ],
+)
+def test_get_env_int(test_case, monkeypatch):
+    for key, value in test_case.env_vars.items():
+        monkeypatch.setenv(key, value)
+    if "NUM_GENERATIONS" not in test_case.env_vars:
+        monkeypatch.delenv("NUM_GENERATIONS", raising=False)
+
+    result = get_env_int("NUM_GENERATIONS", 4)
+    assert result == test_case.expected
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        GRPOTestCase(
+            name="parses float from env",
+            env_vars={"LEARNING_RATE": "1e-5"},
+            expected=1e-5,
+        ),
+        GRPOTestCase(
+            name="returns default when env var is not set",
+            env_vars={},
+            expected=5e-7,
+        ),
+    ],
+)
+def test_get_env_float(test_case, monkeypatch):
+    for key, value in test_case.env_vars.items():
+        monkeypatch.setenv(key, value)
+    if "LEARNING_RATE" not in test_case.env_vars:
+        monkeypatch.delenv("LEARNING_RATE", raising=False)
+
+    result = get_env_float("LEARNING_RATE", 5e-7)
+    assert result == test_case.expected
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        GRPOTestCase(
+            name="rewards based on completion length",
+            env_vars={},
+            expected=[5.0, 11.0, 0.0],
+        ),
+    ],
+)
+def test_length_reward(test_case):
+    completions = ["hello", "hello world", ""]
+    result = length_reward(completions)
+    assert result == test_case.expected
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        GRPOTestCase(
+            name="returns default reward when no module specified",
+            env_vars={},
+        ),
+        GRPOTestCase(
+            name="exits when module file cannot be loaded",
+            env_vars={"REWARD_FUNCTION_MODULE": "/nonexistent/module.py"},
+            expected_error=SystemExit,
+        ),
+    ],
+)
+def test_load_reward_function(test_case, monkeypatch):
+    for key, value in test_case.env_vars.items():
+        monkeypatch.setenv(key, value)
+    if "REWARD_FUNCTION_MODULE" not in test_case.env_vars:
+        monkeypatch.delenv("REWARD_FUNCTION_MODULE", raising=False)
+
+    if test_case.expected_error:
+        with pytest.raises(test_case.expected_error):
+            load_reward_function()
+    else:
+        fn = load_reward_function()
+        assert callable(fn)
+        assert fn == length_reward
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        GRPOTestCase(
+            name="main initializes GRPOTrainer with correct config",
+            env_vars={
+                "MODEL_PATH": "/workspace/model",
+                "DATASET_PATH": "/workspace/dataset",
+                "OUTPUT_DIR": "/workspace/output",
+                "NUM_GENERATIONS": "4",
+                "MAX_PROMPT_LENGTH": "512",
+                "MAX_COMPLETION_LENGTH": "256",
+                "PER_DEVICE_TRAIN_BATCH_SIZE": "2",
+                "GRADIENT_ACCUMULATION_STEPS": "4",
+                "NUM_TRAIN_EPOCHS": "1",
+                "LEARNING_RATE": "5e-7",
+                "LOGGING_STEPS": "1",
+            },
+        ),
+    ],
+)
+def test_main(test_case, monkeypatch, tmp_path):
+    for key, value in test_case.env_vars.items():
+        monkeypatch.setenv(key, value)
+
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    monkeypatch.setenv("DATASET_PATH", str(dataset_dir))
+
+    mock_dataset = MagicMock()
+    mock_trainer_instance = MagicMock()
+
+    with (
+        patch.object(train, "load_from_disk", return_value=mock_dataset) as mock_load,
+        patch.object(train, "GRPOConfig") as mock_config_cls,
+        patch.object(
+            train, "GRPOTrainer", return_value=mock_trainer_instance
+        ) as mock_trainer_cls,
+    ):
+        train.main()
+
+        mock_load.assert_called_once_with(str(dataset_dir))
+        mock_config_cls.assert_called_once()
+        mock_trainer_cls.assert_called_once()
+        mock_trainer_instance.train.assert_called_once()
+        mock_trainer_instance.save_model.assert_called_once_with("/workspace/output")

--- a/cmd/trainers/grpo/train_test.py
+++ b/cmd/trainers/grpo/train_test.py
@@ -199,15 +199,11 @@ def test_main(test_case, monkeypatch, tmp_path):
     for key, value in test_case.env_vars.items():
         monkeypatch.setenv(key, value)
 
-    dataset_dir = tmp_path / "dataset"
-    dataset_dir.mkdir()
-    monkeypatch.setenv("DATASET_PATH", str(dataset_dir))
-
     mock_dataset = MagicMock()
     mock_trainer_instance = MagicMock()
 
     with (
-        patch.object(train, "load_from_disk", return_value=mock_dataset) as mock_load,
+        patch.object(train, "load_dataset", return_value=mock_dataset) as mock_load,
         patch.object(train, "GRPOConfig") as mock_config_cls,
         patch.object(
             train, "GRPOTrainer", return_value=mock_trainer_instance
@@ -215,7 +211,7 @@ def test_main(test_case, monkeypatch, tmp_path):
     ):
         train.main()
 
-        mock_load.assert_called_once_with(str(dataset_dir))
+        mock_load.assert_called_once_with("/workspace/dataset", split="train")
         mock_config_cls.assert_called_once()
         mock_trainer_cls.assert_called_once()
         mock_trainer_instance.train.assert_called_once()

--- a/examples/grpo/grpo-trainjob.yaml
+++ b/examples/grpo/grpo-trainjob.yaml
@@ -1,0 +1,66 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Example: GRPO Post-Training with TRL
+#
+# This TrainJob runs GRPO (Group Relative Policy Optimization) post-training
+# using the TRL library on the grpo-distributed ClusterTrainingRuntime.
+# It fine-tunes Qwen2.5-0.5B-Instruct with the TLDR summarization dataset
+# using a length-based reward function.
+#
+# The GRPO trainer runs with torchrun for distributed training. PET_* env vars
+# (PET_NNODES, PET_NPROC_PER_NODE, PET_NODE_RANK, PET_MASTER_ADDR,
+# PET_MASTER_PORT) are injected by the Trainer torch plugin.
+#
+# Apply: kubectl apply -f grpo-trainjob.yaml
+# Check: kubectl get trainjob grpo-example
+# Logs:  kubectl logs -l jobset.sigs.k8s.io/jobset-name=grpo-example
+# Clean: kubectl delete trainjob grpo-example
+
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  name: grpo-example
+spec:
+  runtimeRef:
+    apiGroup: trainer.kubeflow.org
+    kind: ClusterTrainingRuntime
+    name: grpo-distributed
+
+  initializer:
+    dataset:
+      storageUri: hf://trl-lib/tldr
+    model:
+      storageUri: hf://Qwen/Qwen2.5-0.5B-Instruct
+
+  trainer:
+    numNodes: 1
+    resourcesPerNode:
+      requests:
+        nvidia.com/gpu: 2
+    env:
+      - name: NUM_GENERATIONS
+        value: "4"
+      - name: MAX_PROMPT_LENGTH
+        value: "512"
+      - name: MAX_COMPLETION_LENGTH
+        value: "256"
+      - name: PER_DEVICE_TRAIN_BATCH_SIZE
+        value: "2"
+      - name: GRADIENT_ACCUMULATION_STEPS
+        value: "4"
+      - name: NUM_TRAIN_EPOCHS
+        value: "1"
+      - name: LEARNING_RATE
+        value: "5e-7"

--- a/manifests/base/runtimes/grpo/grpo_distributed.yaml
+++ b/manifests/base/runtimes/grpo/grpo_distributed.yaml
@@ -1,0 +1,102 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: ClusterTrainingRuntime
+metadata:
+  name: grpo-distributed
+  labels:
+    trainer.kubeflow.org/framework: torch
+spec:
+  mlPolicy:
+    numNodes: 1
+    torch: {}
+  template:
+    spec:
+      volumeClaimPolicies:
+        - templates:
+            - metadata:
+                name: initializer
+              spec:
+                accessModes: ["ReadWriteOnce"]
+                resources:
+                  requests:
+                    storage: 50Gi
+      replicatedJobs:
+        - name: dataset-initializer
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: dataset-initializer
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: dataset-initializer
+                      image: ghcr.io/kubeflow/trainer/dataset-initializer
+                      env:
+                        - name: STORAGE_URI
+                          value: hf://trl-lib/tldr
+                      volumeMounts:
+                        - mountPath: /workspace
+                          name: initializer
+        - name: model-initializer
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: model-initializer
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: model-initializer
+                      image: ghcr.io/kubeflow/trainer/model-initializer
+                      env:
+                        - name: STORAGE_URI
+                          value: hf://Qwen/Qwen2.5-0.5B-Instruct
+                      volumeMounts:
+                        - name: initializer
+                          mountPath: /workspace
+        - name: node
+          dependsOn:
+            - name: dataset-initializer
+              status: Complete
+            - name: model-initializer
+              status: Complete
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: trainer
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: node
+                      image: ghcr.io/kubeflow/trainer/grpo-trainer
+                      command:
+                        - torchrun
+                        - train.py
+                      env:
+                        - name: MODEL_PATH
+                          value: /workspace/model
+                        - name: DATASET_PATH
+                          value: /workspace/dataset
+                        - name: OUTPUT_DIR
+                          value: /workspace/output
+                      resources:
+                        limits:
+                          nvidia.com/gpu: 2
+                      volumeMounts:
+                        - mountPath: /workspace
+                          name: initializer

--- a/manifests/base/runtimes/grpo/grpo_distributed.yaml
+++ b/manifests/base/runtimes/grpo/grpo_distributed.yaml
@@ -86,7 +86,7 @@ spec:
                       image: ghcr.io/kubeflow/trainer/grpo-trainer
                       command:
                         - torchrun
-                        - train.py
+                        - /opt/grpo/train.py
                       env:
                         - name: MODEL_PATH
                           value: /workspace/model

--- a/manifests/base/runtimes/grpo/kustomization.yaml
+++ b/manifests/base/runtimes/grpo/kustomization.yaml
@@ -15,10 +15,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - deepspeed_distributed.yaml
-  - mlx_distributed.yaml
-  - torch_distributed.yaml
-  - jax_distributed.yaml
-  - xgboost_distributed.yaml
-  - torchtune
-  - grpo
+  - grpo_distributed.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds initial support for GRPO (Group Relative Policy Optimization) post-training in Kubeflow Trainer, following the approach agreed upon in #3508.

This implements the minimal viable GRPO path using TRL's `GRPOTrainer` with the existing `torch-distributed` CustomTrainer pattern. No CRD/API changes or torch plugin modifications are needed — the existing PET env injection handles distributed GRPO via `torchrun`.

**Changes:**

- **GRPO trainer image** (`cmd/trainers/grpo/`):
  - `Dockerfile` based on `pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime`
  - `requirements.txt` with TRL, transformers, datasets, accelerate, peft, bitsandbytes
  - `train.py` entrypoint wrapping TRL's `GRPOTrainer`, configurable via env vars (`MODEL_PATH`, `DATASET_PATH`, `NUM_GENERATIONS`, `LEARNING_RATE`, etc.)
  - Pluggable reward functions via `REWARD_FUNCTION_MODULE` env var
  - `train_test.py` with 11 unit tests

- **ClusterTrainingRuntime** (`manifests/base/runtimes/grpo/`):
  - `grpo_distributed.yaml` runtime with dataset/model initializers and `torchrun`-based trainer node
  - Wired into parent `kustomization.yaml`

- **Example** (`examples/grpo/`):
  - `grpo-trainjob.yaml` showing GRPO post-training of Qwen2.5-0.5B-Instruct with the TLDR dataset

- **Makefile**: Added GRPO trainer to `test-python` target

**Which issue(s) this PR fixes**: #3508

**Checklist:**

- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing