### PR TITLE
fix(api): reject zero and negative numNodes and numProcPerNode

### DIFF
--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_clustertrainingruntimes.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_clustertrainingruntimes.yaml
@@ -91,6 +91,9 @@ spec:
                           This value is equal to the number of slots for each node in the hostfile.
                         format: int32
                         type: integer
+                        x-kubernetes-validations:
+                        - message: NumProcPerNode in mpiPolicy must be >= 1
+                          rule: self >= 1
                       runLauncherAsNode:
                         default: false
                         description: |-

--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_optimizationjobs.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_optimizationjobs.yaml
@@ -6157,12 +6157,17 @@ spec:
                           numNodes:
                             description: numNodes is the number of training nodes.
                             format: int32
+                            minimum: 0
                             type: integer
                           numProcPerNode:
                             description: numProcPerNode is the number of processes/workers/slots
                               on every training node.
                             format: int32
                             type: integer
+                            x-kubernetes-validations:
+                            - message: numProcPerNode must be greater than or equal
+                                to 1
+                              rule: self >= 1
                           resourcesPerNode:
                             description: resourcesPerNode defines the compute resources
                               for each training node.

--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainingruntimes.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainingruntimes.yaml
@@ -91,6 +91,9 @@ spec:
                           This value is equal to the number of slots for each node in the hostfile.
                         format: int32
                         type: integer
+                        x-kubernetes-validations:
+                        - message: NumProcPerNode in mpiPolicy must be >= 1
+                          rule: self >= 1
                       runLauncherAsNode:
                         default: false
                         description: |-

--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
@@ -5220,12 +5220,16 @@ spec:
                   numNodes:
                     description: numNodes is the number of training nodes.
                     format: int32
+                    minimum: 0
                     type: integer
                   numProcPerNode:
                     description: numProcPerNode is the number of processes/workers/slots
                       on every training node.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: numProcPerNode must be greater than or equal to 1
+                      rule: self >= 1
                   resourcesPerNode:
                     description: resourcesPerNode defines the compute resources for
                       each training node.

--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
@@ -5794,6 +5794,7 @@ spec:
                   numNodes:
                     description: numNodes is the number of training nodes.
                     format: int32
+                    minimum: 0
                     type: integer
                   numProcPerNode:
                     description: |-
@@ -5802,6 +5803,9 @@ spec:
                       For the Torch runtime the value defaults to `auto` and can be overridden with an int.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: numProcPerNode must be greater than or equal to 1
+                      rule: self >= 1
                   resourcesPerNode:
                     description: resourcesPerNode defines the compute resources for
                       each training node.

--- a/manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
@@ -88,6 +88,9 @@ spec:
                           This value is equal to the number of slots for each node in the hostfile.
                         format: int32
                         type: integer
+                        x-kubernetes-validations:
+                        - message: NumProcPerNode in mpiPolicy must be >= 1
+                          rule: self >= 1
                       runLauncherAsNode:
                         default: false
                         description: |-

--- a/manifests/base/crds/trainer.kubeflow.org_optimizationjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_optimizationjobs.yaml
@@ -6154,12 +6154,17 @@ spec:
                           numNodes:
                             description: numNodes is the number of training nodes.
                             format: int32
+                            minimum: 0
                             type: integer
                           numProcPerNode:
                             description: numProcPerNode is the number of processes/workers/slots
                               on every training node.
                             format: int32
                             type: integer
+                            x-kubernetes-validations:
+                            - message: numProcPerNode must be greater than or equal
+                                to 1
+                              rule: self >= 1
                           resourcesPerNode:
                             description: resourcesPerNode defines the compute resources
                               for each training node.

--- a/manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
@@ -88,6 +88,9 @@ spec:
                           This value is equal to the number of slots for each node in the hostfile.
                         format: int32
                         type: integer
+                        x-kubernetes-validations:
+                        - message: NumProcPerNode in mpiPolicy must be >= 1
+                          rule: self >= 1
                       runLauncherAsNode:
                         default: false
                         description: |-

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -5791,6 +5791,7 @@ spec:
                   numNodes:
                     description: numNodes is the number of training nodes.
                     format: int32
+                    minimum: 0
                     type: integer
                   numProcPerNode:
                     description: |-
@@ -5799,6 +5800,9 @@ spec:
                       For the Torch runtime the value defaults to `auto` and can be overridden with an int.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: numProcPerNode must be greater than or equal to 1
+                      rule: self >= 1
                   resourcesPerNode:
                     description: resourcesPerNode defines the compute resources for
                       each training node.

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -5217,12 +5217,16 @@ spec:
                   numNodes:
                     description: numNodes is the number of training nodes.
                     format: int32
+                    minimum: 0
                     type: integer
                   numProcPerNode:
                     description: numProcPerNode is the number of processes/workers/slots
                       on every training node.
                     format: int32
                     type: integer
+                    x-kubernetes-validations:
+                    - message: numProcPerNode must be greater than or equal to 1
+                      rule: self >= 1
                   resourcesPerNode:
                     description: resourcesPerNode defines the compute resources for
                       each training node.

--- a/pkg/apis/trainer/v1alpha1/trainingruntime_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainingruntime_types.go
@@ -274,6 +274,7 @@ type MPIMLPolicySource struct {
 	// This value is equal to the number of slots for each node in the hostfile.
 	// Defaults to 1.
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:XValidation:rule="self >= 1",message="NumProcPerNode in mpiPolicy must be >= 1"
 	// +optional
 	NumProcPerNode *int32 `json:"numProcPerNode,omitempty"`
 

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -274,6 +274,7 @@ type Trainer struct {
 
 	// numNodes is the number of training nodes.
 	// TODO (andreyvelich): Do we want to support dynamic num of nodes in TrainJob for PyTorch elastic: `--nnodes=1:4` ?
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	NumNodes *int32 `json:"numNodes,omitempty"`
 
@@ -284,6 +285,7 @@ type Trainer struct {
 	// numProcPerNode is the number of processes/workers/slots on every training node.
 	// For the MPI runtime only int value can be set to represent number of slots per node.
 	// For the Torch runtime the value defaults to `auto` and can be overridden with an int.
+	// +kubebuilder:validation:XValidation:rule="self >= 1",message="numProcPerNode must be greater than or equal to 1"
 	// +optional
 	NumProcPerNode *int32 `json:"numProcPerNode,omitempty"`
 }

--- a/pkg/runtime/framework/plugins/flux/flux.go
+++ b/pkg/runtime/framework/plugins/flux/flux.go
@@ -100,22 +100,10 @@ func (f *Flux) Name() string {
 	return Name
 }
 
-func (f *Flux) Validate(_ context.Context, runtimeInfo *runtime.Info, _, newJobObj *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
+func (f *Flux) Validate(_ context.Context, runtimeInfo *runtime.Info, _, _ *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
 	var allErrs field.ErrorList
 	if runtimeInfo == nil || runtimeInfo.RuntimePolicy.MLPolicySource == nil || runtimeInfo.RuntimePolicy.MLPolicySource.Flux == nil {
 		return nil, allErrs
-	}
-
-	fluxPolicy := runtimeInfo.RuntimePolicy.MLPolicySource.Flux
-
-	// We require at least 1 proc per node. Zero or fewer does not make sense.
-	numProcPerNode := fluxPolicy.NumProcPerNode
-	if newJobObj.Spec.Trainer != nil && newJobObj.Spec.Trainer.NumProcPerNode != nil {
-		numProcPerNode = newJobObj.Spec.Trainer.NumProcPerNode
-	}
-	if numProcPerNode != nil && *numProcPerNode < 1 {
-		numProcPerNodePath := field.NewPath("spec").Child("trainer").Child("numProcPerNode")
-		allErrs = append(allErrs, field.Invalid(numProcPerNodePath, *numProcPerNode, "must be greater than or equal to 1 for Flux TrainJob"))
 	}
 
 	// Iterate through Trainer's internal PodSet abstraction

--- a/pkg/runtime/framework/plugins/flux/flux_test.go
+++ b/pkg/runtime/framework/plugins/flux/flux_test.go
@@ -245,49 +245,6 @@ func TestValidate(t *testing.T) {
 			},
 			newObj: &trainer.TrainJob{},
 		},
-		"invalid when runtime policy numProcPerNode is less than one": {
-			info: &runtime.Info{
-				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicySource: &trainer.MLPolicySource{
-						Flux: &trainer.FluxMLPolicySource{
-							NumProcPerNode: ptr.To[int32](0),
-						},
-					},
-				},
-			},
-			newObj: &trainer.TrainJob{},
-			wantError: field.ErrorList{
-				field.Invalid(
-					field.NewPath("spec").Child("trainer").Child("numProcPerNode"),
-					int32(0),
-					"must be greater than or equal to 1 for Flux TrainJob",
-				),
-			},
-		},
-		"invalid when trainJob numProcPerNode is less than one": {
-			info: &runtime.Info{
-				RuntimePolicy: runtime.RuntimePolicy{
-					MLPolicySource: &trainer.MLPolicySource{
-						Flux: &trainer.FluxMLPolicySource{
-							NumProcPerNode: ptr.To[int32](1),
-						},
-					},
-				},
-			},
-			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
-				Trainer(utiltesting.MakeTrainJobTrainerWrapper().
-					NumProcPerNode(0).
-					Obj(),
-				).
-				Obj(),
-			wantError: field.ErrorList{
-				field.Invalid(
-					field.NewPath("spec").Child("trainer").Child("numProcPerNode"),
-					int32(0),
-					"must be greater than or equal to 1 for Flux TrainJob",
-				),
-			},
-		},
 		"invalid when node podSet includes reserved flux installer init container": {
 			info: &runtime.Info{
 				RuntimePolicy: runtime.RuntimePolicy{

--- a/test/integration/webhooks/trainingruntime_webhook_test.go
+++ b/test/integration/webhooks/trainingruntime_webhook_test.go
@@ -222,6 +222,24 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 				},
 				testingutil.BeInvalidError(),
 			),
+			ginkgo.Entry("Should fail to create trainingRuntime with mpi.numProcPerNode < 1",
+				func() *trainer.TrainingRuntime {
+					return testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(
+							testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime").Obj().Spec).
+							WithMLPolicy(
+								testingutil.MakeMLPolicyWrapper().
+									WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().
+										MPIPolicy(ptr.To[int32](0), trainer.MPIImplementationOpenMPI, nil, nil).
+										Obj(),
+									).
+									Obj(),
+							).
+							Obj()).
+						Obj()
+				},
+				testingutil.BeInvalidError(),
+			),
 		)
 		ginkgo.DescribeTable("Defaulting TrainingRuntime on creation", func(trainingRuntime func() *trainer.TrainingRuntime, wantTrainingRuntime func() *trainer.TrainingRuntime) {
 			created := trainingRuntime()

--- a/test/integration/webhooks/trainjob_test.go
+++ b/test/integration/webhooks/trainjob_test.go
@@ -104,6 +104,57 @@ var _ = ginkgo.Describe("TrainJob Webhook", ginkgo.Ordered, func() {
 						Obj()
 				},
 				testingutil.BeForbiddenError()),
+			ginkgo.Entry("Should fail in creating trainJob with negative numNodes",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
+						Trainer(testingutil.MakeTrainJobTrainerWrapper().
+							NumNodes(-1).
+							Obj()).
+						Obj()
+				},
+				testingutil.BeInvalidError()),
+			ginkgo.Entry("Should succeed in creating trainJob with zero numNodes",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
+						Trainer(testingutil.MakeTrainJobTrainerWrapper().
+							NumNodes(0).
+							Obj()).
+						Obj()
+				},
+				gomega.Succeed()),
+			ginkgo.Entry("Should fail in creating trainJob with negative numProcPerNode",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
+						Trainer(testingutil.MakeTrainJobTrainerWrapper().
+							NumProcPerNode(-5).
+							Obj()).
+						Obj()
+				},
+				testingutil.BeInvalidError()),
+			ginkgo.Entry("Should fail in creating trainJob with zero numProcPerNode",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
+						Trainer(testingutil.MakeTrainJobTrainerWrapper().
+							NumProcPerNode(0).
+							Obj()).
+						Obj()
+				},
+				testingutil.BeInvalidError()),
+			ginkgo.Entry("Should succeed in creating trainJob with positive numNodes and numProcPerNode",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
+						Trainer(testingutil.MakeTrainJobTrainerWrapper().
+							NumNodes(1).
+							NumProcPerNode(1).
+							Obj()).
+						Obj()
+				},
+				gomega.Succeed()),
 			ginkgo.Entry("Should succeed in creating trainJob with namespace scoped trainingRuntime",
 				func() *trainer.TrainJob {
 					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
@@ -218,7 +269,9 @@ var _ = ginkgo.Describe("TrainJob Webhook", ginkgo.Ordered, func() {
 						}).
 						Obj()
 				},
-				testingutil.BeForbiddenError(),
+				// numProcPerNode: 0 is rejected by the CRD schema before the Flux
+				// plugin webhook runs, so the error is Invalid, not Forbidden.
+				testingutil.BeInvalidError(),
 			),
 			ginkgo.Entry("Should fail in creating TrainJob with reserved flux-installer init container",
 				func() *trainer.TrainJob {

--- a/test/integration/webhooks/trainjob_test.go
+++ b/test/integration/webhooks/trainjob_test.go
@@ -104,6 +104,57 @@ var _ = ginkgo.Describe("TrainJob Webhook", ginkgo.Ordered, func() {
 						Obj()
 				},
 				testingutil.BeForbiddenError()),
+			ginkgo.Entry("Should fail in creating trainJob with negative numNodes",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
+						Trainer(testingutil.MakeTrainJobTrainerWrapper().
+							NumNodes(-1).
+							Obj()).
+						Obj()
+				},
+				testingutil.BeInvalidError()),
+			ginkgo.Entry("Should succeed in creating trainJob with zero numNodes",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
+						Trainer(testingutil.MakeTrainJobTrainerWrapper().
+							NumNodes(0).
+							Obj()).
+						Obj()
+				},
+				gomega.Succeed()),
+			ginkgo.Entry("Should fail in creating trainJob with negative numProcPerNode",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
+						Trainer(testingutil.MakeTrainJobTrainerWrapper().
+							NumProcPerNode(-5).
+							Obj()).
+						Obj()
+				},
+				testingutil.BeInvalidError()),
+			ginkgo.Entry("Should fail in creating trainJob with zero numProcPerNode",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
+						Trainer(testingutil.MakeTrainJobTrainerWrapper().
+							NumProcPerNode(0).
+							Obj()).
+						Obj()
+				},
+				testingutil.BeInvalidError()),
+			ginkgo.Entry("Should succeed in creating trainJob with positive numNodes and numProcPerNode",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), runtimeName).
+						Trainer(testingutil.MakeTrainJobTrainerWrapper().
+							NumNodes(1).
+							NumProcPerNode(1).
+							Obj()).
+						Obj()
+				},
+				gomega.Succeed()),
 			ginkgo.Entry("Should succeed in creating trainJob with namespace scoped trainingRuntime",
 				func() *trainer.TrainJob {
 					return testingutil.MakeTrainJobWrapper(ns.Name, jobName).
@@ -218,7 +269,9 @@ var _ = ginkgo.Describe("TrainJob Webhook", ginkgo.Ordered, func() {
 						}).
 						Obj()
 				},
-				testingutil.BeForbiddenError(),
+				// numProcPerNode: 0 is now rejected by the CRD schema (Minimum=1)
+				// before the Flux plugin webhook runs, so the error is Invalid, not Forbidden.
+				testingutil.BeInvalidError(),
 			),
 			ginkgo.Entry("Should fail in creating TrainJob with reserved flux-installer init container",
 				func() *trainer.TrainJob {


### PR DESCRIPTION
## What this PR does / why we need it

`TrainJob.Spec.Trainer.NumNodes` and `NumProcPerNode` had no lower-bound
validation. A TrainJob with `numNodes: 0` or `numProcPerNode: -5` was accepted at
admission and the invalid values propagated into the pod spec (the Torch plugin
rendered `PET_NPROC_PER_NODE=-5` and set the trainer PodSet count to 0), failing
at pod runtime instead of at admission.

This adds `+kubebuilder:validation:Minimum=1` to both fields and regenerates the
CRDs, so the API server rejects non-positive values at admission. It mirrors the
existing `FluxMLPolicySource.NumProcPerNode` contract (`self >= 1`) and fixes all
runtimes at once (Torch, PlainML, JAX, XGBoost, MPI), since they all read these
two TrainJob fields.

Similar to the JobSet replica validation in kubernetes-sigs/jobset#1279.

## Which issue(s) this PR fixes

Closes #3805

## Special notes for your reviewer

A pre-existing integration case (`Should fail in creating TrainJob with Flux
numProcPerNode < 1`) expected a `Forbidden` error from the Flux plugin webhook.
With the new CRD-schema bound the value is now rejected earlier, so that case's
matcher is updated from `BeForbiddenError()` to `BeInvalidError()`. The Flux
plugin validation remains as defense in depth.

Added integration webhook cases: negative and zero `numNodes`, negative and zero
`numProcPerNode` (all rejected), plus a positive control that succeeds.

## Does this PR introduce a user-facing change?

```release-note
Reject TrainJobs with zero or negative `numNodes` or `numProcPerNode` at admission.

## Two things to double-check before pushing

1. **Fork remote** — if `git remote -v` doesn't show your fork, add it:
   ```bash
   git remote add fork https://github.com/sanskar-singh-2403/trainer.git