### PR TITLE
feat(docs): add TTLSecondsAfterFinished and RunPolicy to KEP-2899

### DIFF
--- a/proposals/2899-resource-timeouts/README.md
+++ b/proposals/2899-resource-timeouts/README.md
@@ -2,9 +2,11 @@
 
 ## Summary
 
-Add lifecycle management fields to the Trainer APIs. For the Trainer v2.2 release, we will implement:
+Add lifecycle management fields to the Trainer APIs:
 
-- **`ActiveDeadlineSeconds`** on `TrainJobSpec`: Allows data scientists to set maximum runtime for individual TrainJobs via the Kubeflow SDK.
+- **`ActiveDeadlineSeconds`** on `TrainJobSpec` (shipped in v2.2): lets data scientists set the maximum runtime for individual TrainJobs via the Kubeflow SDK.
+- **`TTLSecondsAfterFinished`** on `TrainJobSpec`: lets data scientists set how long a finished TrainJob and its child resources are retained before automatic cleanup.
+- **`RunPolicy`** on `TrainingRuntimeSpec` (`ClusterTrainingRuntime` and `TrainingRuntime`): lets platform admins set runtime-level defaults for `ActiveDeadlineSeconds` and `TTLSecondsAfterFinished` that TrainJobs using the runtime inherit and can override.
 
 This brings TrainJob lifecycle management in line with Kubernetes Jobs and JobSets.
 
@@ -19,7 +21,9 @@ Currently, `TrainJob` resources persist in the cluster indefinitely after comple
 ### Goals
 
 - Add `ActiveDeadlineSeconds` to `TrainJobSpec` for data scientists to control individual job timeouts
-- Expose `ActiveDeadlineSeconds` in the Kubeflow Python SDK for data scientists
+- Add `TTLSecondsAfterFinished` to `TrainJobSpec` for data scientists to control post-finish cleanup of individual jobs
+- Add a `RunPolicy` struct to `TrainingRuntimeSpec` so platform admins can set default `ActiveDeadlineSeconds` and `TTLSecondsAfterFinished` for all TrainJobs using a runtime, with per-TrainJob overrides
+- Expose `ActiveDeadlineSeconds` and `TTLSecondsAfterFinished` in the Kubeflow Python SDK for data scientists
 - Follow Kubernetes Job/JobSet patterns and existing Trainer API conventions
 
 ### Non-Goals
@@ -54,6 +58,14 @@ TrainerClient().train(
 )
 ```
 
+#### Story 3
+
+As a **Platform Admin**, I want to set default `ActiveDeadlineSeconds` and `TTLSecondsAfterFinished` on a `ClusterTrainingRuntime` so that every TrainJob using that runtime is bounded and cleaned up automatically, without each data scientist setting these fields. Data scientists can still override either value on an individual TrainJob.
+
+#### Story 4
+
+As a **Data Scientist**, I want finished TrainJobs and their pods, services, and endpoints to be removed automatically after a bounded time, so that stale resources from completed runs do not accumulate or interfere with later jobs (for example, Pod IP reuse resolving to a previous job's headless Service).
+
 ## Design Details
 
 ### API Design
@@ -75,8 +87,51 @@ type TrainJobSpec struct {
     // +kubebuilder:validation:Minimum=1
     // +kubebuilder:validation:XValidation:rule="self == oldSelf",message="field is immutable"
     ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty"`
+
+    // TTLSecondsAfterFinished specifies the duration in seconds the TrainJob is retained after it
+    // reaches a terminal state (Complete or Failed), after which the TrainJob and its child
+    // resources become eligible for automatic deletion. Value must be a non-negative integer;
+    // 0 means delete immediately after finishing. Overrides the runtime default in
+    // spec.runPolicy.ttlSecondsAfterFinished. Following Kubernetes Job semantics, this field is
+    // mutable after creation.
+    // +optional
+    // +kubebuilder:validation:Minimum=0
+    TTLSecondsAfterFinished *int64 `json:"ttlSecondsAfterFinished,omitempty"`
 }
 ```
+
+#### TrainingRuntimeSpec Changes
+
+Add a `RunPolicy` struct to `TrainingRuntimeSpec` (used by both `ClusterTrainingRuntime` and `TrainingRuntime`) in `pkg/apis/trainer/v1alpha1/trainingruntime_types.go`:
+
+```go
+type TrainingRuntimeSpec struct {
+    // ... existing fields ...
+
+    // RunPolicy defines lifecycle defaults applied to TrainJobs that reference this runtime.
+    // Each field is a default that a TrainJob can override on its own spec.
+    // +optional
+    RunPolicy *RunPolicy `json:"runPolicy,omitempty"`
+}
+
+// RunPolicy holds runtime-level lifecycle defaults for TrainJobs using this runtime.
+type RunPolicy struct {
+    // ActiveDeadlineSeconds is the default maximum active duration in seconds for TrainJobs that
+    // reference this runtime. A TrainJob's own spec.activeDeadlineSeconds takes precedence.
+    // +optional
+    // +kubebuilder:validation:Minimum=1
+    ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty"`
+
+    // TTLSecondsAfterFinished is the default retention duration in seconds after a TrainJob using
+    // this runtime reaches a terminal state, after which it is eligible for automatic deletion.
+    // A TrainJob's own spec.ttlSecondsAfterFinished takes precedence.
+    // +optional
+    // +kubebuilder:validation:Minimum=0
+    TTLSecondsAfterFinished *int64 `json:"ttlSecondsAfterFinished,omitempty"`
+}
+```
+
+The name `runPolicy` is used on the runtime (rather than a flat field) so it reads as policy applied to the resulting runs, not to the runtime object's own lifecycle. On `TrainJobSpec` the fields stay flat, matching the already-shipped `activeDeadlineSeconds`.
 
 #### New Condition Reason
 
@@ -94,7 +149,15 @@ When a TrainJob exceeds its `ActiveDeadlineSeconds`, the controller sets a `Fail
 
 ### Value Resolution
 
-`ActiveDeadlineSeconds` is set directly on `TrainJobSpec` by the data scientist.
+Both `ActiveDeadlineSeconds` and `TTLSecondsAfterFinished` follow the same precedence: the value on `TrainJobSpec` wins if set; otherwise the controller falls back to the runtime default in `TrainingRuntimeSpec.RunPolicy`; if neither is set, the feature is disabled for that TrainJob.
+
+```
+effectiveValue = trainJob.spec.<field>  (if set)
+              else runtime.spec.runPolicy.<field>  (if set)
+              else unset (no enforcement / no auto-cleanup)
+```
+
+Resolution happens per reconcile, so a runtime default cannot silently override a value the user explicitly set on the TrainJob.
 
 ### User Examples
 
@@ -132,14 +195,44 @@ TrainerClient().train(
 )
 ```
 
-The `active_deadline_seconds` parameter in the SDK maps to `ActiveDeadlineSeconds` on the created `TrainJob`.
+The `active_deadline_seconds` parameter in the SDK maps to `ActiveDeadlineSeconds` on the created `TrainJob`. `ttl_seconds_after_finished` maps to `TTLSecondsAfterFinished` the same way.
+
+**Runtime defaults (Platform Admin):**
+
+```yaml
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: ClusterTrainingRuntime
+metadata:
+  name: torch-distributed-gpu
+spec:
+  runPolicy:
+    activeDeadlineSeconds: 28800       # Default max runtime: 8 hours
+    ttlSecondsAfterFinished: 3600      # Default cleanup: 1 hour after finish
+  template:
+    # ... JobSet template ...
+```
+
+**TrainJob overriding the runtime TTL default (Data Scientist):**
+
+```yaml
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  name: keep-longer-for-debugging
+spec:
+  ttlSecondsAfterFinished: 86400       # Keep this failed run for 24h, overrides the 1h default
+  runtimeRef:
+    name: torch-distributed-gpu
+  trainer:
+    numNodes: 2
+```
 
 ### Implementation Overview
 
 **Controller Changes** (`pkg/controller/trainjob_controller.go`):
 
 1. **Value Resolution:**
-    - Read `ActiveDeadlineSeconds` directly from `TrainJobSpec`
+    - Resolve `ActiveDeadlineSeconds` and `TTLSecondsAfterFinished` using the precedence above: `TrainJobSpec` value if set, else `TrainingRuntimeSpec.RunPolicy` default, else unset
 
 2. **Deadline Enforcement:**
     - Check if job is running and effective deadline is set
@@ -147,7 +240,14 @@ The `active_deadline_seconds` parameter in the SDK maps to `ActiveDeadlineSecond
     - If exceeded, mark TrainJob as Failed (`Reason: DeadlineExceeded`); the runtime framework handles cleanup of the underlying JobSet
     - Otherwise, requeue at `deadline`
 
-3. **Clock Skew Handling:**
+3. **TTL Enforcement:**
+    - Only applies once the TrainJob is finished (`Complete` or `Failed` condition is true)
+    - Calculate `expiry = finishTime + effectiveTTLSecondsAfterFinished`, where `finishTime` is the transition time of the terminal condition
+    - If `expiry` has passed, delete the TrainJob; owner references cascade the delete to the child JobSet, Jobs, Pods, and Services, matching Kubernetes Job `ttlSecondsAfterFinished` semantics
+    - Otherwise, requeue at `expiry`
+    - TTL deletes the TrainJob itself rather than only the child JobSet. This avoids the JobSet-recreation loop from [#3779](https://github.com/kubeflow/trainer/issues/3779): once the parent TrainJob is gone there is nothing left to reconcile, so no new JobSet is created with a reset restart count
+
+4. **Clock Skew Handling:**
     - If calculated requeue time is in the past (due to clock skew), requeue with a small delay (e.g., 1 second)
 
 ### Clock Skew Handling
@@ -184,12 +284,15 @@ This design ensures no TrainJobs are "forgotten" after a controller restart.
 
 **Field-level CEL markers** on the API types:
 
-- `Minimum=1` on `ActiveDeadlineSeconds` (`TrainJobSpec`)
+- `Minimum=1` on `ActiveDeadlineSeconds` (`TrainJobSpec` and `RunPolicy`)
+- `Minimum=0` on `TTLSecondsAfterFinished` (`TrainJobSpec` and `RunPolicy`)
 - `XValidation: self == oldSelf` on `ActiveDeadlineSeconds` (`TrainJobSpec`) - immutable after creation
+- `TTLSecondsAfterFinished` is mutable after creation, matching Kubernetes Job behavior (users may extend or shorten retention on a finished job)
 
 **Cross-field CEL markers** on `TrainingRuntimeSpec` to prevent conflicting lifecycle fields in the JobSet/Job template:
 
 - `self.template.spec.replicatedJobs.all(rj, !has(rj.template.spec.activeDeadlineSeconds))` - Job-level deadline would terminate pods independently from TrainJob deadline tracking
+- `!has(self.template.spec.ttlSecondsAfterFinished)` - JobSet-level TTL would delete the JobSet out from under the TrainJob and trigger the recreation loop in [#3779](https://github.com/kubeflow/trainer/issues/3779); TTL must be expressed via `runPolicy` or the TrainJob so the controller owns cleanup
 
 ### Interaction with Suspend
 
@@ -214,6 +317,12 @@ to implement this enhancement.
 - Deadline exceeded → job failed with DeadlineExceeded reason
 - Deadline not reached → requeue at deadline
 - Clock skew → requeue with delay instead of negative duration
+- Value resolution: TrainJob value set → runtime default ignored
+- Value resolution: TrainJob value unset, runtime default set → runtime default used
+- Value resolution: neither set → feature disabled
+- TTL on unfinished job → no deletion
+- TTL expired on finished job → TrainJob deleted (children cascade)
+- TTL not reached on finished job → requeue at expiry
 
 #### Integration Tests
 
@@ -227,19 +336,22 @@ to implement this enhancement.
 - `test/e2e/trainjob_deadline_test.go`:
     - Real training workload with deadline: Verify job fails at timeout with DeadlineExceeded reason
     - Verify no orphaned resources remain
+- `test/e2e/trainjob_ttl_test.go`:
+    - Real training workload with TTL: verify the TrainJob and its child JobSet, Pods, and Services are deleted after the TTL elapses
+    - Verify a failed TrainJob with maxRestarts stays terminally Failed and is not recreated after TTL cleanup (regression for [#3779](https://github.com/kubeflow/trainer/issues/3779))
 
 ## Future Plan
 
-### TTLSecondsAfterFinished
-
-We postpone the implementation of `TTLSecondsAfterFinished` on the `TrainingRuntimeSpec` to avoid user confusion in the v2.2 release. In a future iteration, we plan to implement it to allow platform admins to configure automatic cleanup policies as defaults for all TrainJobs using a runtime.
+The initial `RunPolicy` struct holds `ActiveDeadlineSeconds` and `TTLSecondsAfterFinished`. If future lifecycle knobs (for example `BackoffLimit` or a cleanup policy) are needed, they can be added under `RunPolicy` without breaking changes.
 
 ## Implementation History
 
 - **2025-10-20**: Issue opened [#2899](https://github.com/kubeflow/trainer/issues/2899)
 - **2026-01-04**: Initial KEP drafted
 - **2026-01-22**: KEP updated with layered API design (TrainJob + TrainingRuntime)
-- **TBD**: Alpha implementation
+- **2026-02-28**: `ActiveDeadlineSeconds` on `TrainJobSpec` shipped in v2.2
+- **2026-07-28**: KEP extended with `TTLSecondsAfterFinished` and the `RunPolicy` runtime defaults, prompted by [#3779](https://github.com/kubeflow/trainer/issues/3779)
+- **TBD**: TTL alpha implementation
 
 
 ## Alternatives
@@ -269,16 +381,26 @@ Put both fields only on `TrainingRuntimeSpec`.
 - Data scientists cannot customize deadlines for specific jobs
 - Less flexible for varying job requirements
 
-### Alternative 3: Add `ActiveDeadlineSeconds` to TrainingRuntimeSpec as Default
+### Alternative 3: Runtime defaults that TrainJobs can override
 
-Add `ActiveDeadlineSeconds` to `TrainingRuntimeSpec` as a default that individual TrainJobs can override.
+Add lifecycle fields to `TrainingRuntimeSpec` as defaults that individual TrainJobs can override.
 
 **Pros:**
-- Platform admins can enforce default deadlines for all jobs
+- Platform admins can enforce default deadlines and cleanup for all jobs
 - Data scientists can still override per job
 
 **Cons:**
 - Adds complexity to value resolution logic
-- Potential user confusion (users may not realize a default deadline exists)
+- Potential user confusion (users may not realize a default exists)
 
-**Decision:** Deferred to a future iteration. If user feedback shows demand for runtime-level default deadlines, this extension can be added without breaking changes.
+**Decision:** Adopted for `ActiveDeadlineSeconds` and `TTLSecondsAfterFinished`, grouped under a `RunPolicy` struct on `TrainingRuntimeSpec` (see API Design). The runtime defaults are additive, so this does not break the already-shipped flat `TrainJobSpec.ActiveDeadlineSeconds`.
+
+### Alternative 4: Flat `ttlSecondsAfterFinished` on the runtime
+
+Put `ttlSecondsAfterFinished` directly on `TrainingRuntimeSpec` instead of under `RunPolicy`.
+
+**Cons:**
+- On a runtime (a template that never runs), a bare `ttlSecondsAfterFinished` reads as "TTL of the runtime object," which is misleading
+- No grouping for future lifecycle knobs
+
+**Decision:** Rejected in favor of `RunPolicy` on the runtime. `TrainJobSpec` keeps flat fields, since a TrainJob is the thing that runs and finishes, so no disambiguation is needed there.

--- a/proposals/2899-resource-timeouts/README.md
+++ b/proposals/2899-resource-timeouts/README.md
@@ -168,7 +168,7 @@ effectiveValue = trainJob.spec.<field>  (if set)
 
 The runtime value comes from the snapshot ConfigMap written by `pkg/runtime/core/snapshot.go` on the first reconcile, not from the live runtime. Editing `runPolicy` therefore only affects TrainJobs created afterwards.
 
-An unset TrainJob field means "inherit", so a TrainJob can change a runtime default but not switch it off. `activeDeadlineSeconds` has no wire value meaning "no deadline" at all, since the non-pointer `int64` with `Minimum=1` makes `0` indistinguishable from unset. Whether to add an explicit opt-out is unresolved.
+An unset TrainJob field means "inherit", so a TrainJob can change a runtime default but not switch it off. `activeDeadlineSeconds` has no wire value meaning "no deadline" at all, since the non-pointer `int64` with `Minimum=1` makes `0` indistinguishable from unset. Phase 1 ships without an opt-out, matching other Runtime defaults such as `env`, which a TrainJob also cannot remove.
 
 ### User Examples
 

--- a/proposals/2899-resource-timeouts/README.md
+++ b/proposals/2899-resource-timeouts/README.md
@@ -23,7 +23,9 @@ Currently, `TrainJob` resources persist in the cluster indefinitely after comple
 - Add `ActiveDeadlineSeconds` to `TrainJobSpec` for data scientists to control individual job timeouts
 - Add `TTLSecondsAfterFinished` to `TrainJobSpec` for data scientists to control post-finish cleanup of individual jobs
 - Add a `RunPolicy` struct to `TrainingRuntimeSpec` so platform admins can set default `ActiveDeadlineSeconds` and `TTLSecondsAfterFinished` for all TrainJobs using a runtime, with per-TrainJob overrides
+- Add `StartTime` and `CompletionTime` to `TrainJobStatus` and use them as the reference points for deadline and TTL calculation
 - Expose `ActiveDeadlineSeconds` and `TTLSecondsAfterFinished` in the Kubeflow Python SDK for data scientists
+- Keep MultiKueue working when `TTLSecondsAfterFinished` is set: a worker-cluster TTL must never delete a TrainJob before its terminal status has been synchronized back to the manager cluster
 - Follow Kubernetes Job/JobSet patterns and existing Trainer API conventions
 
 ### Non-Goals
@@ -72,33 +74,40 @@ As a **Data Scientist**, I want finished TrainJobs and their pods, services, and
 
 #### TrainJobSpec Changes
 
-Add `ActiveDeadlineSeconds` to `TrainJobSpec` in `pkg/apis/trainer/v1alpha1/trainjob_types.go`:
+`ActiveDeadlineSeconds` already ships. Add `TTLSecondsAfterFinished` alongside it in `pkg/apis/trainer/v1alpha1/trainjob_types.go`:
 
 ```go
 type TrainJobSpec struct {
     // ... existing fields ...
 
-    // ActiveDeadlineSeconds specifies the duration in seconds relative to the TrainJob
+    // activeDeadlineSeconds specifies the duration in seconds relative to the TrainJob
     // start time (which resets on resume from suspension) that the TrainJob may be active
     // before the system tries to terminate it. Value must be a positive integer.
     // Once reached, all running Pods are terminated and the TrainJob status becomes
     // Failed with reason: DeadlineExceeded.
+    // TODO(beta): replace with *int64 to match batch/v1.JobSpec.
     // +optional
     // +kubebuilder:validation:Minimum=1
     // +kubebuilder:validation:XValidation:rule="self == oldSelf",message="field is immutable"
-    ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty"`
+    ActiveDeadlineSeconds int64 `json:"activeDeadlineSeconds,omitempty"`
 
-    // TTLSecondsAfterFinished specifies the duration in seconds the TrainJob is retained after it
+    // ttlSecondsAfterFinished specifies the duration in seconds the TrainJob is retained after it
     // reaches a terminal state (Complete or Failed), after which the TrainJob and its child
     // resources become eligible for automatic deletion. Value must be a non-negative integer;
-    // 0 means delete immediately after finishing. Overrides the runtime default in
-    // spec.runPolicy.ttlSecondsAfterFinished. Following Kubernetes Job semantics, this field is
-    // mutable after creation.
+    // 0 means delete immediately after finishing. Overrides the referenced runtime's
+    // spec.runPolicy.ttlSecondsAfterFinished default. Following Kubernetes Job semantics, this
+    // field is mutable after creation.
     // +optional
     // +kubebuilder:validation:Minimum=0
-    TTLSecondsAfterFinished *int64 `json:"ttlSecondsAfterFinished,omitempty"`
+    TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 }
 ```
+
+New fields use pointers, matching `batch/v1.JobSpec`. The shipped `ActiveDeadlineSeconds` stays a non-pointer `int64` because changing it is a breaking change to a released field; it flips at beta promotion.
+
+#### TrainJobStatus Changes
+
+Add `StartTime` and `CompletionTime` (`*metav1.Time`) to `TrainJobStatus`, with the same semantics as [Kubernetes Job](https://github.com/kubernetes/api/blob/master/batch/v1/types.go) and [JobSet](https://github.com/kubernetes-sigs/jobset/pull/1306): `startTime` resets on each resume from suspension, `completionTime` is set once the TrainJob is terminal. They become the reference points for deadline and TTL, which the controller infers from conditions today.
 
 #### TrainingRuntimeSpec Changes
 
@@ -108,7 +117,7 @@ Add a `RunPolicy` struct to `TrainingRuntimeSpec` (used by both `ClusterTraining
 type TrainingRuntimeSpec struct {
     // ... existing fields ...
 
-    // RunPolicy defines lifecycle defaults applied to TrainJobs that reference this runtime.
+    // runPolicy defines lifecycle defaults applied to TrainJobs that reference this runtime.
     // Each field is a default that a TrainJob can override on its own spec.
     // +optional
     RunPolicy *RunPolicy `json:"runPolicy,omitempty"`
@@ -116,18 +125,18 @@ type TrainingRuntimeSpec struct {
 
 // RunPolicy holds runtime-level lifecycle defaults for TrainJobs using this runtime.
 type RunPolicy struct {
-    // ActiveDeadlineSeconds is the default maximum active duration in seconds for TrainJobs that
+    // activeDeadlineSeconds is the default maximum active duration in seconds for TrainJobs that
     // reference this runtime. A TrainJob's own spec.activeDeadlineSeconds takes precedence.
     // +optional
     // +kubebuilder:validation:Minimum=1
     ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty"`
 
-    // TTLSecondsAfterFinished is the default retention duration in seconds after a TrainJob using
+    // ttlSecondsAfterFinished is the default retention duration in seconds after a TrainJob using
     // this runtime reaches a terminal state, after which it is eligible for automatic deletion.
     // A TrainJob's own spec.ttlSecondsAfterFinished takes precedence.
     // +optional
     // +kubebuilder:validation:Minimum=0
-    TTLSecondsAfterFinished *int64 `json:"ttlSecondsAfterFinished,omitempty"`
+    TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 }
 ```
 
@@ -157,7 +166,9 @@ effectiveValue = trainJob.spec.<field>  (if set)
               else unset (no enforcement / no auto-cleanup)
 ```
 
-Resolution happens per reconcile, so a runtime default cannot silently override a value the user explicitly set on the TrainJob.
+The runtime value comes from the snapshot ConfigMap written by `pkg/runtime/core/snapshot.go` on the first reconcile, not from the live runtime. Editing `runPolicy` therefore only affects TrainJobs created afterwards.
+
+An unset TrainJob field means "inherit", so a TrainJob can change a runtime default but not switch it off. `activeDeadlineSeconds` has no wire value meaning "no deadline" at all, since the non-pointer `int64` with `Minimum=1` makes `0` indistinguishable from unset. Whether to add an explicit opt-out is unresolved.
 
 ### User Examples
 
@@ -236,14 +247,14 @@ spec:
 
 2. **Deadline Enforcement:**
     - Check if job is running and effective deadline is set
-    - Calculate `deadline = startTime + effectiveActiveDeadlineSeconds` (where `startTime` is reset on each resume from suspension)
-    - If exceeded, mark TrainJob as Failed (`Reason: DeadlineExceeded`); the runtime framework handles cleanup of the underlying JobSet
+    - Calculate `deadline = status.startTime + effectiveActiveDeadlineSeconds` (where `status.startTime` is reset on each resume from suspension)
+    - If exceeded, mark TrainJob as Failed (`Reason: DeadlineExceeded`) and delete the child JobSet directly, as `reconcileDeadline` does today
     - Otherwise, requeue at `deadline`
 
 3. **TTL Enforcement:**
     - Only applies once the TrainJob is finished (`Complete` or `Failed` condition is true)
-    - Calculate `expiry = finishTime + effectiveTTLSecondsAfterFinished`, where `finishTime` is the transition time of the terminal condition
-    - If `expiry` has passed, delete the TrainJob; owner references cascade the delete to the child JobSet, Jobs, Pods, and Services, matching Kubernetes Job `ttlSecondsAfterFinished` semantics
+    - Calculate `expiry = status.completionTime + effectiveTTLSecondsAfterFinished`
+    - If `expiry` has passed, delete the TrainJob; owner references cascade the delete to the child JobSet, Jobs, Pods, and Services, matching Kubernetes Job `ttlSecondsAfterFinished` semantics. This requires adding `delete` to the controller's TrainJob RBAC marker in `pkg/controller/trainjob_controller.go` (today `get;list;watch;update;patch`) and re-running `make generate`
     - Otherwise, requeue at `expiry`
     - TTL deletes the TrainJob itself rather than only the child JobSet. This avoids the JobSet-recreation loop from [#3779](https://github.com/kubeflow/trainer/issues/3779): once the parent TrainJob is gone there is nothing left to reconcile, so no new JobSet is created with a reset restart count
 
@@ -273,9 +284,8 @@ return ctrl.Result{RequeueAfter: requeueAfter}, nil
 The controller is stateless and stores no timers in memory. On restart:
 
 1. Controller-runtime triggers initial sync, reconciling all TrainJobs
-2. For each TrainJob, deadlines are recalculated from:
-   - The last resume time (or `metadata.creationTimestamp` if never suspended) for deadline calculation
-3. If deadline already expired during downtime, action is taken immediately
+2. For each TrainJob, deadlines and expiries are recalculated from `status.startTime` and `status.completionTime`
+3. If a deadline or a TTL already expired during downtime, action is taken immediately
 4. Otherwise, appropriate requeue times are set
 
 This design ensures no TrainJobs are "forgotten" after a controller restart.
@@ -287,12 +297,20 @@ This design ensures no TrainJobs are "forgotten" after a controller restart.
 - `Minimum=1` on `ActiveDeadlineSeconds` (`TrainJobSpec` and `RunPolicy`)
 - `Minimum=0` on `TTLSecondsAfterFinished` (`TrainJobSpec` and `RunPolicy`)
 - `XValidation: self == oldSelf` on `ActiveDeadlineSeconds` (`TrainJobSpec`) - immutable after creation
-- `TTLSecondsAfterFinished` is mutable after creation, matching Kubernetes Job behavior (users may extend or shorten retention on a finished job)
+- `TTLSecondsAfterFinished` is mutable on `TrainJobSpec`, matching Kubernetes Job: a user may extend or shorten retention on a finished TrainJob
+- Both `RunPolicy` fields are mutable. Because the runtime value is read from the snapshot, editing a runtime does not change the effective value for existing TrainJobs
 
-**Cross-field CEL markers** on `TrainingRuntimeSpec` to prevent conflicting lifecycle fields in the JobSet/Job template:
+**Cross-field CEL markers** on `TrainingRuntimeSpec` to prevent conflicting lifecycle fields in the JobSet/Job template. These paths must be unset:
 
-- `self.template.spec.replicatedJobs.all(rj, !has(rj.template.spec.activeDeadlineSeconds))` - Job-level deadline would terminate pods independently from TrainJob deadline tracking
-- `!has(self.template.spec.ttlSecondsAfterFinished)` - JobSet-level TTL would delete the JobSet out from under the TrainJob and trigger the recreation loop in [#3779](https://github.com/kubeflow/trainer/issues/3779); TTL must be expressed via `runPolicy` or the TrainJob so the controller owns cleanup
+- `template.spec.ttlSecondsAfterFinished` - JobSet-level TTL would delete the JobSet out from under the TrainJob and trigger the recreation loop in [#3779](https://github.com/kubeflow/trainer/issues/3779); TTL must be expressed via `runPolicy` or the TrainJob so the controller owns cleanup
+- `template.spec.replicatedJobs[].template.spec.ttlSecondsAfterFinished` - Job-level TTL would delete child Jobs the TrainJob still tracks
+- `template.spec.replicatedJobs[].template.spec.activeDeadlineSeconds` and `template.spec.replicatedJobs[].template.spec.template.spec.activeDeadlineSeconds` - Job- and Pod-level deadlines would terminate pods independently from TrainJob deadline tracking
+
+`spec.template`, `spec.template.spec`, and every level below `replicatedJobs[].template` are optional in the generated CRD, which carries `minProperties: 1` and no `required` lists, so each rule needs `!has()` guards at every level. An unguarded traversal raises `no such key` and rejects the runtime:
+
+```
+!has(self.template) || !has(self.template.spec) || !has(self.template.spec.ttlSecondsAfterFinished)
+```
 
 ### Interaction with Suspend
 
@@ -300,6 +318,16 @@ Matching Kubernetes Job behavior (K8s 1.35+ with `MutableSchedulingDirectivesFor
 
 - If a TrainJob is created in a suspended state, the timer does not start until the TrainJob is first unsuspended
 - When a running TrainJob is suspended, the controller clears the internal start time reference. On resume, the start time is reset to the current time, and the full `ActiveDeadlineSeconds` window applies from that point
+
+### Interaction with MultiKueue
+
+A worker-cluster TTL that deletes the remote TrainJob before its terminal status syncs back makes MultiKueue treat the remote as missing and dispatch the job again. Kueue fixed this for batch Job by clearing `spec.ttlSecondsAfterFinished` on the remote copy ([kueue#14734](https://github.com/kubernetes-sigs/kueue/pull/14734)); other integrations are tracked in [kueue#14779](https://github.com/kubernetes-sigs/kueue/issues/14779).
+
+Two items for TrainJob:
+
+1. The MultiKueue adapter deep-copies `TrainJobSpec`, so a TrainJob-level TTL propagates. Kueue needs the same fix, which is only possible once this API is released and vendored into Kueue.
+
+2. MultiKueue does not copy runtimes, so Kueue cannot strip `runPolicy.ttlSecondsAfterFinished` from a worker-cluster runtime. Admins must leave it unset there, documented alongside the existing requirement to pre-create the runtimes.
 
 ### Test Plan
 
@@ -323,6 +351,9 @@ to implement this enhancement.
 - TTL on unfinished job → no deletion
 - TTL expired on finished job → TrainJob deleted (children cascade)
 - TTL not reached on finished job → requeue at expiry
+- `ttlSecondsAfterFinished: 0` on a finished job → deleted immediately
+- Runtime template setting JobSet-level TTL → rejected by validation
+- Runtime setting only `runPolicy`, with no `template` → accepted, CEL guards do not error
 
 #### Integration Tests
 
@@ -330,6 +361,10 @@ to implement this enhancement.
     - End-to-end deadline enforcement from TrainJob
     - Suspended TrainJob → deadline timer does not start until first unsuspend
     - Running TrainJob suspended and resumed → deadline timer resets (full duration available again)
+    - TTL from the TrainJob → TrainJob and its child JobSet deleted after expiry
+    - TTL from `runPolicy` with no TrainJob value → runtime default applied
+    - TrainJob TTL set alongside a `runPolicy` default → TrainJob value wins
+    - `runPolicy` edited after the TrainJob was admitted → the snapshot value is still applied
 
 #### E2E Tests
 
@@ -349,7 +384,7 @@ The initial `RunPolicy` struct holds `ActiveDeadlineSeconds` and `TTLSecondsAfte
 - **2025-10-20**: Issue opened [#2899](https://github.com/kubeflow/trainer/issues/2899)
 - **2026-01-04**: Initial KEP drafted
 - **2026-01-22**: KEP updated with layered API design (TrainJob + TrainingRuntime)
-- **2026-02-28**: `ActiveDeadlineSeconds` on `TrainJobSpec` shipped in v2.2
+- **2026-03-19**: `ActiveDeadlineSeconds` on `TrainJobSpec` shipped in v2.2.0 ([#3258](https://github.com/kubeflow/trainer/pull/3258))
 - **2026-07-28**: KEP extended with `TTLSecondsAfterFinished` and the `RunPolicy` runtime defaults, prompted by [#3779](https://github.com/kubeflow/trainer/issues/3779)
 - **TBD**: TTL alpha implementation
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Extends KEP-2899 (resource-timeouts) with post-finish cleanup APIs, per the discussion in #3779:

- `TrainJobSpec.ttlSecondsAfterFinished` (flat, matching the already-shipped `activeDeadlineSeconds`)
- `TrainingRuntimeSpec.runPolicy` holding `activeDeadlineSeconds` and `ttlSecondsAfterFinished` as runtime-level defaults
- Value resolution: a TrainJob value overrides the runtime default; if neither is set the feature is off
- TTL deletes the TrainJob itself (children cascade via owner refs), which also avoids the JobSet-recreation loop reported in #3779, since once the parent is gone there is nothing left to reconcile
- A cross-field CEL marker forbids `ttlSecondsAfterFinished` in the JobSet template so cleanup is always controller-owned

The `runPolicy` grouping is used on the runtime (not a flat field) so it reads as policy applied to the resulting runs rather than the runtime object's own lifecycle; `TrainJobSpec` keeps flat fields.

The reset-loop bug in #3779 still needs a separate controller fix (`removeFailedCondition`); this PR is the API proposal only.

**Which issue(s) this PR fixes**:

Part of #2899, related to #3779

**Checklist:**

- [x] Docs included if any changes are user facing

cc @andreyvelich @kramaranya @kuantian-zhang