### PR TITLE
fix(operator): preserve terminal Failed condition after JobSet TTL cleanup

### DIFF
--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -95,8 +95,9 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Keep track of the origin TrainJob status
 	prevTrainJob := trainJob.DeepCopy()
 
-	// Let's clear the failed condition that could have been set previously.
-	// An external change to the TrainJob spec may transition it out of the Failed state.
+	// Clear a recoverable Failed condition when the referenced runtime becomes available.
+	// Terminal failures must be preserved so finished TrainJobs are not reconciled again
+	// after their JobSet is TTL-deleted.
 	removeFailedCondition(&trainJob)
 
 	runtimeRefGK := jobruntimes.RuntimeRefToRuntimeRegistryKey(trainJob.Spec.RuntimeRef)
@@ -245,10 +246,9 @@ func setFailedCondition(trainJob *trainer.TrainJob, message, reason string) {
 
 func removeFailedCondition(trainJob *trainer.TrainJob) {
 	cond := meta.FindStatusCondition(trainJob.Status.Conditions, trainer.TrainJobFailed)
-	if cond != nil && cond.Reason == trainer.TrainJobDeadlineExceededReason {
-		return
+	if cond != nil && cond.Reason == trainer.TrainJobRuntimeNotSupportedReason {
+		meta.RemoveStatusCondition(&trainJob.Status.Conditions, trainer.TrainJobFailed)
 	}
-	meta.RemoveStatusCondition(&trainJob.Status.Conditions, trainer.TrainJobFailed)
 }
 
 func setTrainJobStatus(ctx context.Context, runtime jobruntimes.Runtime, trainJob *trainer.TrainJob) error {

--- a/pkg/controller/trainjob_controller_test.go
+++ b/pkg/controller/trainjob_controller_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+)
+
+func TestRemoveFailedCondition(t *testing.T) {
+	cases := map[string]struct {
+		conditions     []metav1.Condition
+		wantConditions []metav1.Condition
+	}{
+		"no failed condition": {
+			conditions: []metav1.Condition{
+				{
+					Type:   trainer.TrainJobSuspended,
+					Status: metav1.ConditionFalse,
+				},
+			},
+			wantConditions: []metav1.Condition{
+				{
+					Type:   trainer.TrainJobSuspended,
+					Status: metav1.ConditionFalse,
+				},
+			},
+		},
+		"unsupported runtime is recoverable": {
+			conditions: []metav1.Condition{
+				{
+					Type:   trainer.TrainJobFailed,
+					Status: metav1.ConditionTrue,
+					Reason: trainer.TrainJobRuntimeNotSupportedReason,
+				},
+			},
+			wantConditions: nil,
+		},
+		"jobset failure is terminal": {
+			conditions: []metav1.Condition{
+				{
+					Type:   trainer.TrainJobFailed,
+					Status: metav1.ConditionTrue,
+					Reason: "FailedJobs",
+				},
+			},
+			wantConditions: []metav1.Condition{
+				{
+					Type:   trainer.TrainJobFailed,
+					Status: metav1.ConditionTrue,
+					Reason: "FailedJobs",
+				},
+			},
+		},
+		"deadline exceeded is terminal": {
+			conditions: []metav1.Condition{
+				{
+					Type:   trainer.TrainJobFailed,
+					Status: metav1.ConditionTrue,
+					Reason: trainer.TrainJobDeadlineExceededReason,
+				},
+			},
+			wantConditions: []metav1.Condition{
+				{
+					Type:   trainer.TrainJobFailed,
+					Status: metav1.ConditionTrue,
+					Reason: trainer.TrainJobDeadlineExceededReason,
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			trainJob := &trainer.TrainJob{
+				Status: trainer.TrainJobStatus{
+					Conditions: tc.conditions,
+				},
+			}
+			removeFailedCondition(trainJob)
+			if diff := cmp.Diff(tc.wantConditions, trainJob.Status.Conditions, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("unexpected conditions (-want +got):\n%s", diff)
+			}
+			if tc.wantConditions != nil && !meta.IsStatusConditionTrue(trainJob.Status.Conditions, trainer.TrainJobFailed) &&
+				meta.FindStatusCondition(tc.wantConditions, trainer.TrainJobFailed) != nil {
+				t.Errorf("expected Failed condition to remain set")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Stop clearing every `Failed` condition at the start of TrainJob reconciliation
- Only remove the recoverable `TrainingRuntimeNotSupported` failure so a TrainJob can proceed once its runtime becomes available
- Preserve terminal failures (JobSet max restarts, deadline exceeded) so finished TrainJobs are not reconciled again after their JobSet is deleted by `ttlSecondsAfterFinished`

Fixes #3779

## Context
When a JobSet reached `ReachedMaxRestarts` and was later TTL-deleted, the controller cleared the TrainJob `Failed` condition before checking `IsTrainJobFinished`, causing a new JobSet to be created and the restart budget to reset.

This follows the approach discussed in the issue thread by @andreyvelich.

## Test plan
- [x] `go test ./pkg/controller/... -run TestRemoveFailedCondition -v`
- [x] `go test ./pkg/controller/...`