### PR TITLE
fix(initializer): return actionable dataset STORAGE_URI errors

### DIFF
--- a/pkg/initializers/dataset/__main__.py
+++ b/pkg/initializers/dataset/__main__.py
@@ -25,16 +25,28 @@ logging.basicConfig(
 )
 
 
+def _get_storage_uri() -> str:
+    storage_uri = os.environ.get(utils.STORAGE_URI_ENV)
+    if not storage_uri:
+        logging.error("STORAGE_URI env variable must be set.")
+        raise ValueError("STORAGE_URI environment variable must be set")
+    return storage_uri
+
+
+def _unsupported_scheme_error(scheme: str) -> ValueError:
+    return ValueError(
+        f"Unsupported dataset storage URI scheme {scheme!r}: expected one of "
+        f"{utils.HF_SCHEME!r}, {utils.CACHE_SCHEME!r}, or {utils.S3_SCHEME!r}"
+    )
+
+
 def main():
     logging.info("Starting dataset initialization")
 
-    try:
-        storage_uri = os.environ[utils.STORAGE_URI_ENV]
-    except Exception as e:
-        logging.error("STORAGE_URI env variable must be set.")
-        raise e
+    storage_uri = _get_storage_uri()
+    scheme = urlparse(storage_uri).scheme
 
-    match urlparse(storage_uri).scheme:
+    match scheme:
         # TODO (andreyvelich): Implement more dataset providers.
         case utils.HF_SCHEME:
             from pkg.initializers.dataset.huggingface import HuggingFace
@@ -55,8 +67,14 @@ def main():
             s3.load_config()
             s3.download_dataset()
         case _:
-            logging.error("STORAGE_URI must have the valid dataset provider")
-            raise Exception
+            logging.error(
+                "Unsupported dataset storage URI scheme %r: expected one of %r, %r, or %r",
+                scheme,
+                utils.HF_SCHEME,
+                utils.CACHE_SCHEME,
+                utils.S3_SCHEME,
+            )
+            raise _unsupported_scheme_error(scheme)
 
 
 if __name__ == "__main__":

--- a/pkg/initializers/dataset/main_test.py
+++ b/pkg/initializers/dataset/main_test.py
@@ -28,6 +28,7 @@ from pkg.initializers.dataset.__main__ import main
                 "storage_uri": "hf://dataset/path",
                 "access_token": "test_token",
                 "expected_error": None,
+                "expected_error_match": None,
             },
         ),
         (
@@ -35,6 +36,15 @@ from pkg.initializers.dataset.__main__ import main
             {
                 "storage_uri": "s3://dataset/path",
                 "expected_error": None,
+                "expected_error_match": None,
+            },
+        ),
+        (
+            "Successful download with Data Cache provider",
+            {
+                "storage_uri": "cache://dataset/path",
+                "expected_error": None,
+                "expected_error_match": None,
             },
         ),
         (
@@ -42,7 +52,17 @@ from pkg.initializers.dataset.__main__ import main
             {
                 "storage_uri": None,
                 "access_token": None,
-                "expected_error": Exception,
+                "expected_error": ValueError,
+                "expected_error_match": "STORAGE_URI environment variable must be set",
+            },
+        ),
+        (
+            "Empty storage URI environment variable",
+            {
+                "storage_uri": "",
+                "access_token": None,
+                "expected_error": ValueError,
+                "expected_error_match": "STORAGE_URI environment variable must be set",
             },
         ),
         (
@@ -50,7 +70,11 @@ from pkg.initializers.dataset.__main__ import main
             {
                 "storage_uri": "invalid://dataset/path",
                 "access_token": None,
-                "expected_error": Exception,
+                "expected_error": ValueError,
+                "expected_error_match": (
+                    "Unsupported dataset storage URI scheme 'invalid': expected one of "
+                    "'hf', 'cache', or 's3'"
+                ),
             },
         ),
     ],
@@ -59,16 +83,15 @@ def test_dataset_main(test_name, test_case, mock_env_vars):
     """Test main script with different scenarios"""
     print(f"Running test: {test_name}")
 
-    # Setup mock environment variables
     env_vars = {
         "STORAGE_URI": test_case["storage_uri"],
         "ACCESS_TOKEN": test_case.get("access_token", None),
     }
     mock_env_vars(**env_vars)
 
-    # Setup mock instances
     mock_hf_instance = MagicMock()
     mock_s3_instance = MagicMock()
+    mock_cache_instance = MagicMock()
 
     with patch(
         "pkg.initializers.dataset.huggingface.HuggingFace",
@@ -76,27 +99,43 @@ def test_dataset_main(test_name, test_case, mock_env_vars):
     ) as mock_hf, patch(
         "pkg.initializers.dataset.s3.S3",
         return_value=mock_s3_instance,
-    ) as mock_s3:
+    ) as mock_s3, patch(
+        "pkg.initializers.dataset.cache.CacheInitializer",
+        return_value=mock_cache_instance,
+    ) as mock_cache:
 
-        # Execute test
         if test_case["expected_error"]:
-            with pytest.raises(test_case["expected_error"]):
+            with pytest.raises(
+                test_case["expected_error"],
+                match=test_case["expected_error_match"],
+            ):
                 main()
         else:
             main()
 
-            # Verify appropriate provider instance methods were called
-            if test_case["storage_uri"] and test_case["storage_uri"].startswith(
-                "hf://"
-            ):
+            storage_uri = test_case["storage_uri"]
+            if storage_uri.startswith("hf://"):
+                mock_hf.assert_called_once()
                 mock_hf_instance.load_config.assert_called_once()
                 mock_hf_instance.download_dataset.assert_called_once()
-                mock_hf.assert_called_once()
-            elif test_case["storage_uri"] and test_case["storage_uri"].startswith(
-                "s3://"
-            ):
+                mock_s3.assert_not_called()
+                mock_cache.assert_not_called()
+            elif storage_uri.startswith("s3://"):
+                mock_s3.assert_called_once()
                 mock_s3_instance.load_config.assert_called_once()
                 mock_s3_instance.download_dataset.assert_called_once()
-                mock_s3.assert_called_once()
+                mock_hf.assert_not_called()
+                mock_cache.assert_not_called()
+            elif storage_uri.startswith("cache://"):
+                mock_cache.assert_called_once()
+                mock_cache_instance.load_config.assert_called_once()
+                mock_cache_instance.download_dataset.assert_called_once()
+                mock_hf.assert_not_called()
+                mock_s3.assert_not_called()
+
+        if test_case["expected_error"]:
+            mock_hf.assert_not_called()
+            mock_s3.assert_not_called()
+            mock_cache.assert_not_called()
 
     print("Test execution completed")


### PR DESCRIPTION
## Summary
- Validate `STORAGE_URI` before dispatching to a dataset provider
- Raise `ValueError` with clear messages when the env var is missing/empty or the scheme is unsupported
- Expand dispatcher unit tests for Hugging Face, S3, and Data Cache paths, including error-message checks and ensuring invalid input does not construct providers

Fixes #3825

## Test plan
- [x] `pytest pkg/initializers/dataset -v` (29 tests pass)