### PR TITLE
feat: promote TrainJobStatus feature gate to Beta

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -15191,7 +15191,7 @@
             "x-kubernetes-list-type": "map"
           },
           "trainerStatus": {
-            "description": "trainerStatus contains the latest observed runtime status of the Trainer step of the TrainJob. It reflects progress, remaining time, metrics, and the last update timestamp.\n\nThis field is nil if the TrainJob does not report trainer-level status, or if no status has been observed yet (for example, immediately after the TrainJob is created).\n\nThis is an alpha feature and requires enabling the TrainJobStatus feature gate.",
+            "description": "trainerStatus contains the latest observed runtime status of the Trainer step of the TrainJob. It reflects progress, remaining time, metrics, and the last update timestamp.\n\nThis field is nil if the TrainJob does not report trainer-level status, or if no status has been observed yet (for example, immediately after the TrainJob is created).\n\nThis is a beta feature enabled by default and can be disabled through the TrainJobStatus feature gate.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/trainer.v1alpha1.TrainerStatus"
@@ -15468,7 +15468,7 @@
         "type": "object",
         "properties": {
           "trainerStatus": {
-            "description": "trainerStatus contains the latest observed runtime status of the Trainer step of the TrainJob. It reflects progress, remaining time, metrics, and the last update timestamp.\n\nThis field is nil if the TrainJob does not report trainer-level status, or if no status has been observed yet (for example, immediately after the TrainJob is created).\n\nThis is an alpha feature and requires enabling the TrainJobStatus feature gate.",
+            "description": "trainerStatus contains the latest observed runtime status of the Trainer step of the TrainJob. It reflects progress, remaining time, metrics, and the last update timestamp.\n\nThis field is nil if the TrainJob does not report trainer-level status, or if no status has been observed yet (for example, immediately after the TrainJob is created).\n\nThis is a beta feature enabled by default and can be disabled through the TrainJobStatus feature gate.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/trainer.v1alpha1.TrainerStatus"

--- a/docs/user-guides/trainjob-progress.md
+++ b/docs/user-guides/trainjob-progress.md
@@ -8,8 +8,8 @@ pairs) directly into `TrainJob.status.trainerStatus` in real time. This eliminat
 to manually parse or scrape container logs to monitor training health and performance.
 
 :::{important}
-The TrainJob progress feature was introduced in Kubeflow Trainer v2.2.0 and requires the `TrainJobStatus` alpha
-feature gate to be enabled on the controller.
+The TrainJob progress feature was introduced in Kubeflow Trainer v2.2.0. The `TrainJobStatus`
+feature is a Beta feature and enabled by default, so no configuration is required for normal use.
 :::
 
 :::{note}
@@ -20,18 +20,20 @@ to understand the basics of Kubeflow Trainer.
 ## Prerequisites
 
 - Kubeflow Trainer v2.2.0 or later installed on your cluster.
-- The `TrainJobStatus` alpha feature gate enabled on the Trainer controller. To enable
-  it, pass the flag to the controller at startup:
-
-  ```bash
-  --feature-gates=TrainJobStatus=true
-  ```
-
-  Or, if deploying via Helm, set `manager.config.featureGates.TrainJobStatus=true`.
-
-  The command-line flag takes precedence over any value set in the controller config file.
-
 - For SDK-based progress reporting: Kubeflow SDK `>= 0.5.0`.
+
+`TrainJobStatus` is a Beta feature and is enabled by default, so no configuration is required for normal use.
+Administrators can opt out with:
+
+```bash
+--feature-gates=TrainJobStatus=false
+```
+
+For Helm:
+
+```bash
+manager.config.featureGates.TrainJobStatus=false
+```
 
 ## View TrainJob progress and metrics
 
@@ -124,9 +126,9 @@ trainer = Trainer(
     compute_metrics=compute_metrics,
 )
 
-# When running inside a Kubeflow TrainJob with TrainJobStatus enabled,
-# KubeflowTrainerCallback is auto-registered and reports the following
-# at each logging step: loss, learning_rate, epoch, completion percentage.
+# When running inside a Kubeflow TrainJob, KubeflowTrainerCallback is
+# auto-registered and reports the following at each logging step:
+# loss, learning_rate, epoch, completion percentage.
 # Any custom metrics returned by compute_metrics (like 'accuracy') are also automatically reported.
 trainer.train()
 ```
@@ -184,6 +186,7 @@ to the controller endpoint.
 #### Implementation Guidance
 
 When building a raw HTTP client:
+
 - **Client-side rate limiting**: Ensure your client throttles requests (e.g. at most once every 5 seconds) to avoid overloading the Kubernetes API server and controller.
 - **Token rotation**: The bearer token injected into the container is a JWT that periodically rotates. You should check the expiry of the JWT or ensure you re-read the token from the filesystem file (`KUBEFLOW_TRAINER_SERVER_TOKEN`) rather than caching it indefinitely.
 - **Error handling**: Ensure there's sufficient error handling (e.g., catching timeouts and transient network errors) to avoid breaking or impacting your main training loops.

--- a/docs/user-guides/trainjob-progress.md
+++ b/docs/user-guides/trainjob-progress.md
@@ -8,8 +8,9 @@ pairs) directly into `TrainJob.status.trainerStatus` in real time. This eliminat
 to manually parse or scrape container logs to monitor training health and performance.
 
 :::{important}
-The TrainJob progress feature was introduced in Kubeflow Trainer v2.2.0 and requires the `TrainJobStatus` alpha
-feature gate to be enabled on the controller.
+The TrainJob progress feature was introduced in Kubeflow Trainer v2.2.0. The `TrainJobStatus`
+feature is now generally available and enabled by default, so no feature-gate configuration
+is required.
 :::
 
 :::{note}
@@ -20,18 +21,13 @@ to understand the basics of Kubeflow Trainer.
 ## Prerequisites
 
 - Kubeflow Trainer v2.2.0 or later installed on your cluster.
-- The `TrainJobStatus` alpha feature gate enabled on the Trainer controller. To enable
-  it, pass the flag to the controller at startup:
-
-  ```bash
-  --feature-gates=TrainJobStatus=true
-  ```
-
-  Or, if deploying via Helm, set `manager.config.featureGates.TrainJobStatus=true`.
-
-  The command-line flag takes precedence over any value set in the controller config file.
-
 - For SDK-based progress reporting: Kubeflow SDK `>= 0.5.0`.
+
+:::{note}
+`TrainJobStatus` was originally introduced as an alpha feature in Kubeflow Trainer v2.2.0.
+If you are using an older Trainer release where the feature is still alpha, refer to the
+documentation for that release for the required feature-gate configuration.
+:::
 
 ## View TrainJob progress and metrics
 
@@ -124,9 +120,9 @@ trainer = Trainer(
     compute_metrics=compute_metrics,
 )
 
-# When running inside a Kubeflow TrainJob with TrainJobStatus enabled,
-# KubeflowTrainerCallback is auto-registered and reports the following
-# at each logging step: loss, learning_rate, epoch, completion percentage.
+# When running inside a Kubeflow TrainJob, KubeflowTrainerCallback is
+# auto-registered and reports the following at each logging step:
+# loss, learning_rate, epoch, completion percentage.
 # Any custom metrics returned by compute_metrics (like 'accuracy') are also automatically reported.
 trainer.train()
 ```
@@ -184,6 +180,7 @@ to the controller endpoint.
 #### Implementation Guidance
 
 When building a raw HTTP client:
+
 - **Client-side rate limiting**: Ensure your client throttles requests (e.g. at most once every 5 seconds) to avoid overloading the Kubernetes API server and controller.
 - **Token rotation**: The bearer token injected into the container is a JWT that periodically rotates. You should check the expiry of the JWT or ensure you re-read the token from the filesystem file (`KUBEFLOW_TRAINER_SERVER_TOKEN`) rather than caching it indefinitely.
 - **Error handling**: Ensure there's sufficient error handling (e.g., catching timeouts and transient network errors) to avoid breaking or impacting your main training loops.

--- a/hack/e2e-setup-cluster.sh
+++ b/hack/e2e-setup-cluster.sh
@@ -181,15 +181,6 @@ if [ "${INSTALL_METHOD}" = "kustomize" ]; then
   images:
   - name: "${CONTROLLER_MANAGER_CI_IMAGE_NAME}"
     newTag: "${CI_IMAGE_TAG}"
-  patches:
-  - patch: |-
-      # enable feature flags
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: --feature-gates=TrainJobStatus=true
-    target:
-      kind: Deployment
-      name: kubeflow-trainer-controller-manager
 EOF
 
   kubectl apply --server-side -k "${E2E_MANIFESTS_DIR}"
@@ -250,7 +241,6 @@ elif [ "${INSTALL_METHOD}" = "helm" ]; then
     --set runtimes.mlxDistributed.image.tag=${CI_IMAGE_TAG} \
     --set runtimes.deepspeedDistributed.image.tag=${CI_IMAGE_TAG} \
     --set image.tag=${CI_IMAGE_TAG} \
-    --set manager.config.featureGates.TrainJobStatus=true \
     --wait
 fi
 

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -520,7 +520,7 @@ type TrainJobStatus struct {
 	// status, or if no status has been observed yet (for example,
 	// immediately after the TrainJob is created).
 	//
-	// This is an alpha feature and requires enabling the TrainJobStatus feature gate.
+	// This is a beta feature enabled by default and can be disabled through the TrainJobStatus feature gate.
 	// +optional
 	TrainerStatus *TrainerStatus `json:"trainerStatus,omitempty"`
 }
@@ -617,7 +617,7 @@ type UpdateTrainJobStatusRequest struct {
 	// status, or if no status has been observed yet (for example,
 	// immediately after the TrainJob is created).
 	//
-	// This is an alpha feature and requires enabling the TrainJobStatus feature gate.
+	// This is a beta feature enabled by default and can be disabled through the TrainJobStatus feature gate.
 	// +optional
 	TrainerStatus *TrainerStatus `json:"trainerStatus,omitempty"`
 }

--- a/pkg/apis/trainer/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/trainer/v1alpha1/zz_generated.openapi.go
@@ -2388,7 +2388,7 @@ func schema_pkg_apis_trainer_v1alpha1_TrainJobStatus(ref common.ReferenceCallbac
 					},
 					"trainerStatus": {
 						SchemaProps: spec.SchemaProps{
-							Description: "trainerStatus contains the latest observed runtime status of the Trainer step of the TrainJob. It reflects progress, remaining time, metrics, and the last update timestamp.\n\nThis field is nil if the TrainJob does not report trainer-level status, or if no status has been observed yet (for example, immediately after the TrainJob is created).\n\nThis is an alpha feature and requires enabling the TrainJobStatus feature gate.",
+							Description: "trainerStatus contains the latest observed runtime status of the Trainer step of the TrainJob. It reflects progress, remaining time, metrics, and the last update timestamp.\n\nThis field is nil if the TrainJob does not report trainer-level status, or if no status has been observed yet (for example, immediately after the TrainJob is created).\n\nThis is a beta feature enabled by default and can be disabled through the TrainJobStatus feature gate.",
 							Ref:         ref("github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1.TrainerStatus"),
 						},
 					},
@@ -2781,7 +2781,7 @@ func schema_pkg_apis_trainer_v1alpha1_UpdateTrainJobStatusRequest(ref common.Ref
 				Properties: map[string]spec.Schema{
 					"trainerStatus": {
 						SchemaProps: spec.SchemaProps{
-							Description: "trainerStatus contains the latest observed runtime status of the Trainer step of the TrainJob. It reflects progress, remaining time, metrics, and the last update timestamp.\n\nThis field is nil if the TrainJob does not report trainer-level status, or if no status has been observed yet (for example, immediately after the TrainJob is created).\n\nThis is an alpha feature and requires enabling the TrainJobStatus feature gate.",
+							Description: "trainerStatus contains the latest observed runtime status of the Trainer step of the TrainJob. It reflects progress, remaining time, metrics, and the last update timestamp.\n\nThis field is nil if the TrainJob does not report trainer-level status, or if no status has been observed yet (for example, immediately after the TrainJob is created).\n\nThis is a beta feature enabled by default and can be disabled through the TrainJobStatus feature gate.",
 							Ref:         ref("github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1.TrainerStatus"),
 						},
 					},

--- a/pkg/client/applyconfiguration/trainer/v1alpha1/trainjobstatus.go
+++ b/pkg/client/applyconfiguration/trainer/v1alpha1/trainjobstatus.go
@@ -39,7 +39,7 @@ type TrainJobStatusApplyConfiguration struct {
 	// status, or if no status has been observed yet (for example,
 	// immediately after the TrainJob is created).
 	//
-	// This is an alpha feature and requires enabling the TrainJobStatus feature gate.
+	// This is a beta feature enabled by default and can be disabled through the TrainJobStatus feature gate.
 	TrainerStatus *TrainerStatusApplyConfiguration `json:"trainerStatus,omitempty"`
 }
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -41,7 +41,7 @@ const (
 // Entries are separated from each other with blank lines to avoid sweeping gofmt changes
 // when adding or removing one entry.
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	TrainJobStatus: {Default: false, PreRelease: featuregate.Alpha},
+	TrainJobStatus: {Default: true, PreRelease: featuregate.Beta},
 }
 
 // Enabled is helper for `utilfeature.DefaultFeatureGate.Enabled()`

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -45,7 +45,7 @@ const (
 // Entries are separated from each other with blank lines to avoid sweeping gofmt changes
 // when adding or removing one entry.
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	TrainJobStatus: {Default: false, PreRelease: featuregate.Alpha},
+	TrainJobStatus: {Default: true, PreRelease: featuregate.GA},
 }
 
 func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) {

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"testing"
+
+	"k8s.io/component-base/featuregate"
+)
+
+func TestTrainJobStatusFeatureGate(t *testing.T) {
+	spec, ok := defaultFeatureGates[TrainJobStatus]
+	if !ok {
+		t.Fatal("TrainJobStatus feature gate is not registered")
+	}
+
+	if !spec.Default {
+		t.Error("TrainJobStatus feature gate should be enabled by default")
+	}
+
+	if spec.PreRelease != featuregate.Beta {
+		t.Errorf("TrainJobStatus feature gate stage = %q, want %q", spec.PreRelease, featuregate.Beta)
+	}
+
+	if spec.LockToDefault {
+		t.Error("TrainJobStatus feature gate should not be locked to default in Beta")
+	}
+}

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package features
+
+import (
+	"testing"
+
+	"k8s.io/component-base/featuregate"
+)
+
+func TestTrainJobStatusFeatureGate(t *testing.T) {
+	spec, ok := defaultFeatureGates[TrainJobStatus]
+	if !ok {
+		t.Fatal("TrainJobStatus feature gate is not registered")
+	}
+
+	if !spec.Default {
+		t.Error("TrainJobStatus feature gate should be enabled by default")
+	}
+
+	if spec.PreRelease != featuregate.GA {
+		t.Errorf("TrainJobStatus feature gate stage = %q, want %q", spec.PreRelease, featuregate.GA)
+	}
+}

--- a/pkg/runtime/core/clustertrainingruntime_test.go
+++ b/pkg/runtime/core/clustertrainingruntime_test.go
@@ -26,15 +26,19 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 	schedulerpluginsv1alpha1 "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
+	"github.com/kubeflow/trainer/v2/pkg/features"
 	testingutil "github.com/kubeflow/trainer/v2/pkg/util/testing"
 )
 
 func TestClusterTrainingRuntimeNewObjects(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TrainJobStatus, false)
 
 	resRequests := corev1.ResourceList{
 		corev1.ResourceCPU: resource.MustParse("1"),

--- a/pkg/runtime/core/clustertrainingruntime_test.go
+++ b/pkg/runtime/core/clustertrainingruntime_test.go
@@ -31,10 +31,12 @@ import (
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
+	"github.com/kubeflow/trainer/v2/pkg/features"
 	testingutil "github.com/kubeflow/trainer/v2/pkg/util/testing"
 )
 
 func TestClusterTrainingRuntimeNewObjects(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TrainJobStatus, false)
 
 	resRequests := corev1.ResourceList{
 		corev1.ResourceCPU: resource.MustParse("1"),

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -28,6 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
@@ -35,6 +37,7 @@ import (
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
+	"github.com/kubeflow/trainer/v2/pkg/features"
 	jobsetplgconsts "github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/jobset/constants"
 	testingutil "github.com/kubeflow/trainer/v2/pkg/util/testing"
 )
@@ -75,6 +78,8 @@ func wantJobSetWithMergedGPU(ns, name, uid string, requests corev1.ResourceList,
 }
 
 func TestTrainingRuntimeNewObjects(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TrainJobStatus, false)
+
 	resRequests := corev1.ResourceList{
 		corev1.ResourceCPU: resource.MustParse("1"),
 	}

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -35,6 +35,7 @@ import (
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
+	"github.com/kubeflow/trainer/v2/pkg/features"
 	jobsetplgconsts "github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/jobset/constants"
 	testingutil "github.com/kubeflow/trainer/v2/pkg/util/testing"
 )
@@ -75,6 +76,8 @@ func wantJobSetWithMergedGPU(ns, name, uid string, requests corev1.ResourceList,
 }
 
 func TestTrainingRuntimeNewObjects(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TrainJobStatus, false)
+
 	resRequests := corev1.ResourceList{
 		corev1.ResourceCPU: resource.MustParse("1"),
 	}

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -30,8 +30,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	batchv1ac "k8s.io/client-go/applyconfigurations/batch/v1"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -46,6 +48,7 @@ import (
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/apply"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
+	"github.com/kubeflow/trainer/v2/pkg/features"
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework"
 	fwkplugins "github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins"
@@ -68,6 +71,8 @@ import (
 // we can delegate the actual plugin testing to each plugin directories, and implement detailed unit testing.
 
 func TestNew(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TrainJobStatus, false)
+
 	cases := map[string]struct {
 		registry                                                               fwkplugins.Registry
 		emptyCoSchedulingIndexerTrainingRuntimeContainerRuntimeClassKey        bool
@@ -189,6 +194,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestRunEnforceMLPolicyPlugins(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TrainJobStatus, false)
+
 	cases := map[string]struct {
 		registry        fwkplugins.Registry
 		runtimeInfo     *runtime.Info
@@ -353,6 +360,8 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 }
 
 func TestRunEnforcePodGroupPolicyPlugins(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TrainJobStatus, false)
+
 	cases := map[string]struct {
 		registry        fwkplugins.Registry
 		runtimeInfo     *runtime.Info
@@ -448,6 +457,8 @@ func TestRunEnforcePodGroupPolicyPlugins(t *testing.T) {
 }
 
 func TestRunCustomValidationPlugins(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TrainJobStatus, false)
+
 	cases := map[string]struct {
 		registry     fwkplugins.Registry
 		oldObj       *trainer.TrainJob
@@ -505,6 +516,8 @@ func nodeContainerRequests(cpu, memory string) *corev1ac.ResourceRequirementsApp
 }
 
 func TestRunComponentBuilderPlugins(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TrainJobStatus, false)
+
 	cases := map[string]struct {
 		registry        fwkplugins.Registry
 		runtimeInfo     *runtime.Info
@@ -2283,6 +2296,8 @@ test-job-node-0-1.test-job slots=1
 }
 
 func TestWatchExtensionPlugins(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TrainJobStatus, false)
+
 	cases := map[string]struct {
 		registry    fwkplugins.Registry
 		wantPlugins []framework.WatchExtensionPlugin
@@ -2351,6 +2366,8 @@ func (f fakeTrainJobStatusPlugin) Status(context.Context, *trainer.TrainJob) (*t
 }
 
 func TestTrainJobStatusPlugins(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TrainJobStatus, false)
+
 	lastTransitionTime := metav1.Time{Time: time.Now()}.Rfc3339Copy()
 	cases := map[string]struct {
 		registry   fwkplugins.Registry
@@ -2567,6 +2584,7 @@ func TestTrainJobStatusPlugins(t *testing.T) {
 }
 
 func TestRunPreComponentBuilderPlugins(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TrainJobStatus, false)
 	cases := map[string]struct {
 		registry        fwkplugins.Registry
 		runtimeInfo     *runtime.Info

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -46,6 +46,7 @@ import (
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/apply"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
+	"github.com/kubeflow/trainer/v2/pkg/features"
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework"
 	fwkplugins "github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins"
@@ -68,6 +69,8 @@ import (
 // we can delegate the actual plugin testing to each plugin directories, and implement detailed unit testing.
 
 func TestNew(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TrainJobStatus, false)
+
 	cases := map[string]struct {
 		registry                                                               fwkplugins.Registry
 		emptyCoSchedulingIndexerTrainingRuntimeContainerRuntimeClassKey        bool
@@ -189,6 +192,8 @@ func TestNew(t *testing.T) {
 }
 
 func TestRunEnforceMLPolicyPlugins(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TrainJobStatus, false)
+
 	cases := map[string]struct {
 		registry        fwkplugins.Registry
 		runtimeInfo     *runtime.Info
@@ -353,6 +358,8 @@ func TestRunEnforceMLPolicyPlugins(t *testing.T) {
 }
 
 func TestRunEnforcePodGroupPolicyPlugins(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TrainJobStatus, false)
+
 	cases := map[string]struct {
 		registry        fwkplugins.Registry
 		runtimeInfo     *runtime.Info
@@ -448,6 +455,8 @@ func TestRunEnforcePodGroupPolicyPlugins(t *testing.T) {
 }
 
 func TestRunCustomValidationPlugins(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TrainJobStatus, false)
+
 	cases := map[string]struct {
 		registry     fwkplugins.Registry
 		oldObj       *trainer.TrainJob
@@ -505,6 +514,8 @@ func nodeContainerRequests(cpu, memory string) *corev1ac.ResourceRequirementsApp
 }
 
 func TestRunComponentBuilderPlugins(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TrainJobStatus, false)
+
 	cases := map[string]struct {
 		registry        fwkplugins.Registry
 		runtimeInfo     *runtime.Info
@@ -2283,6 +2294,8 @@ test-job-node-0-1.test-job slots=1
 }
 
 func TestWatchExtensionPlugins(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TrainJobStatus, false)
+
 	cases := map[string]struct {
 		registry    fwkplugins.Registry
 		wantPlugins []framework.WatchExtensionPlugin
@@ -2351,6 +2364,8 @@ func (f fakeTrainJobStatusPlugin) Status(context.Context, *trainer.TrainJob) (*t
 }
 
 func TestTrainJobStatusPlugins(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TrainJobStatus, false)
+
 	lastTransitionTime := metav1.Time{Time: time.Now()}.Rfc3339Copy()
 	cases := map[string]struct {
 		registry   fwkplugins.Registry
@@ -2567,6 +2582,8 @@ func TestTrainJobStatusPlugins(t *testing.T) {
 }
 
 func TestPodNetworkPlugins(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TrainJobStatus, false)
+
 	cases := map[string]struct {
 		registry        fwkplugins.Registry
 		runtimeInfo     *runtime.Info

--- a/pkg/runtime/framework/plugins/registry_test.go
+++ b/pkg/runtime/framework/plugins/registry_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"testing"
+
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/utils/ptr"
+
+	"github.com/kubeflow/trainer/v2/pkg/features"
+	"github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins/trainjobstatus"
+)
+
+func TestNewRegistry_TrainJobStatus(t *testing.T) {
+	cases := map[string]struct {
+		gateVal    *bool
+		wantPlugin bool
+	}{
+		"TrainJobStatus registered by default": {
+			gateVal:    nil,
+			wantPlugin: true,
+		},
+		"TrainJobStatus registered when explicitly enabled": {
+			gateVal:    ptr.To(true),
+			wantPlugin: true,
+		},
+		"TrainJobStatus not registered when explicitly disabled": {
+			gateVal:    ptr.To(false),
+			wantPlugin: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if tc.gateVal != nil {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TrainJobStatus, *tc.gateVal)
+			}
+			registry := NewRegistry()
+			_, isRegistered := registry[trainjobstatus.Name]
+			if isRegistered != tc.wantPlugin {
+				t.Errorf("NewRegistry() plugin %q registered = %v, want %v", trainjobstatus.Name, isRegistered, tc.wantPlugin)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Promotes the `TrainJobStatus` feature gate from Alpha/default-disabled to Beta/default-enabled while preserving the ability for users and administrators to opt out (`TrainJobStatus=false`).

`OptimizationJob` relies on consistent TrainJob status reporting to monitor trials and consume reported metrics. Enabling `TrainJobStatus` by default makes that behavior available out of the box without requiring explicit feature-gate configuration.

Following maintainer discussion on promotion stages and opt-out support:
* Promotes `TrainJobStatus` to Beta (`Default: true`, `PreRelease: featuregate.Beta`, without `LockToDefault` so opt-out remains supported);
* Prerequisite status-server integration testing and health probes from #3337 are completed;
* Adds unit coverage for the default-enabled, explicitly enabled, and explicitly disabled plugin registry paths (`NewRegistry`);
* Isolates unrelated framework/runtime unit tests by explicitly setting `TrainJobStatus=false` using standard `featuregatetesting.SetFeatureGateDuringTest`;
* Removes redundant `TrainJobStatus=true` enablement from Kustomize and Helm E2E setups so E2E tests exercise the default-enabled configuration;
* Updates TrainJob progress documentation and API types/OpenAPI/Swagger definitions to reflect Beta status and document opt-out flags.

Validation performed locally:

* `go test ./pkg/features/...`
* `go test ./pkg/runtime/framework/plugins/...`
* `go test ./pkg/runtime/framework/core/...`
* `go test ./pkg/runtime/core/...`
* `go vet ./...`
* `python hack/boilerplate/boilerplate.py --base-ref upstream/master`
* `git diff --check`

**Which issue(s) this PR fixes** *(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)*:

Fixes #3857

**Checklist:**

* [x] [[Docs](https://trainer.kubeflow.org/en/latest/)](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing
