### PR TITLE
fix(initializer): return actionable model STORAGE_URI errors

### DIFF
--- a/pkg/initializers/model/__main__.py
+++ b/pkg/initializers/model/__main__.py
@@ -27,16 +27,28 @@ logging.basicConfig(
 )
 
 
+def _get_storage_uri() -> str:
+    storage_uri = os.environ.get(utils.STORAGE_URI_ENV)
+    if not storage_uri:
+        logging.error("STORAGE_URI env variable must be set.")
+        raise ValueError("STORAGE_URI environment variable must be set")
+    return storage_uri
+
+
+def _unsupported_scheme_error(scheme: str) -> ValueError:
+    return ValueError(
+        f"Unsupported model storage URI scheme {scheme!r}: expected one of "
+        f"{utils.HF_SCHEME!r} or {utils.S3_SCHEME!r}"
+    )
+
+
 def main():
     logging.info("Starting pre-trained model initialization")
 
-    try:
-        storage_uri = os.environ[utils.STORAGE_URI_ENV]
-    except Exception as e:
-        logging.error("STORAGE_URI env variable must be set.")
-        raise e
+    storage_uri = _get_storage_uri()
+    scheme = urlparse(storage_uri).scheme
 
-    match urlparse(storage_uri).scheme:
+    match scheme:
         # TODO (andreyvelich): Implement more model providers.
         case utils.HF_SCHEME:
             hf = HuggingFace()
@@ -48,9 +60,12 @@ def main():
             s3.download_model()
         case _:
             logging.error(
-                f"STORAGE_URI must have the valid model provider. STORAGE_URI: {storage_uri}"
+                "Unsupported model storage URI scheme %r: expected one of %r or %r",
+                scheme,
+                utils.HF_SCHEME,
+                utils.S3_SCHEME,
             )
-            raise Exception
+            raise _unsupported_scheme_error(scheme)
 
 
 if __name__ == "__main__":

--- a/pkg/initializers/model/main_test.py
+++ b/pkg/initializers/model/main_test.py
@@ -28,6 +28,7 @@ from pkg.initializers.model.__main__ import main
                 "storage_uri": "hf://model/path",
                 "access_token": "test_token",
                 "expected_error": None,
+                "expected_error_match": None,
             },
         ),
         (
@@ -35,6 +36,7 @@ from pkg.initializers.model.__main__ import main
             {
                 "storage_uri": "s3://model/path",
                 "expected_error": None,
+                "expected_error_match": None,
             },
         ),
         (
@@ -42,7 +44,17 @@ from pkg.initializers.model.__main__ import main
             {
                 "storage_uri": None,
                 "access_token": None,
-                "expected_error": Exception,
+                "expected_error": ValueError,
+                "expected_error_match": "STORAGE_URI environment variable must be set",
+            },
+        ),
+        (
+            "Empty storage URI environment variable",
+            {
+                "storage_uri": "",
+                "access_token": None,
+                "expected_error": ValueError,
+                "expected_error_match": "STORAGE_URI environment variable must be set",
             },
         ),
         (
@@ -50,7 +62,11 @@ from pkg.initializers.model.__main__ import main
             {
                 "storage_uri": "invalid://model/path",
                 "access_token": None,
-                "expected_error": Exception,
+                "expected_error": ValueError,
+                "expected_error_match": (
+                    "Unsupported model storage URI scheme 'invalid': expected one of "
+                    "'hf' or 's3'"
+                ),
             },
         ),
     ],
@@ -59,14 +75,12 @@ def test_model_main(test_name, test_case, mock_env_vars):
     """Test main script with different scenarios"""
     print(f"Running test: {test_name}")
 
-    # Setup mock environment variables
     env_vars = {
         "STORAGE_URI": test_case["storage_uri"],
         "ACCESS_TOKEN": test_case.get("access_token"),
     }
     mock_env_vars(**env_vars)
 
-    # Setup mock instances
     mock_hf_instance = MagicMock()
     mock_s3_instance = MagicMock()
 
@@ -78,25 +92,29 @@ def test_model_main(test_name, test_case, mock_env_vars):
         return_value=mock_s3_instance,
     ) as mock_s3:
 
-        # Execute test
         if test_case["expected_error"]:
-            with pytest.raises(test_case["expected_error"]):
+            with pytest.raises(
+                test_case["expected_error"],
+                match=test_case["expected_error_match"],
+            ):
                 main()
         else:
             main()
 
-            # Verify appropriate provider instance methods were called
-            if test_case["storage_uri"] and test_case["storage_uri"].startswith(
-                "hf://"
-            ):
+            storage_uri = test_case["storage_uri"]
+            if storage_uri.startswith("hf://"):
+                mock_hf.assert_called_once()
                 mock_hf_instance.load_config.assert_called_once()
                 mock_hf_instance.download_model.assert_called_once()
-                mock_hf.assert_called_once()
-            elif test_case["storage_uri"] and test_case["storage_uri"].startswith(
-                "s3://"
-            ):
+                mock_s3.assert_not_called()
+            elif storage_uri.startswith("s3://"):
+                mock_s3.assert_called_once()
                 mock_s3_instance.load_config.assert_called_once()
                 mock_s3_instance.download_model.assert_called_once()
-                mock_s3.assert_called_once()
+                mock_hf.assert_not_called()
+
+        if test_case["expected_error"]:
+            mock_hf.assert_not_called()
+            mock_s3.assert_not_called()
 
     print("Test execution completed")


### PR DESCRIPTION
## Summary
- Validate missing and empty `STORAGE_URI` with a descriptive `ValueError` instead of a raw `KeyError`
- Raise a stable `ValueError` for unsupported schemes, listing supported model providers (`hf`, `s3`)
- Add parameterized tests for missing, empty, Hugging Face, S3, and unsupported URI cases

Fixes #3834

## Test plan
- [x] `pytest pkg/initializers/model/ -v` (13 tests pass)
- [x] Missing `STORAGE_URI` → `ValueError("STORAGE_URI environment variable must be set")`
- [x] Empty `STORAGE_URI` → same `ValueError`
- [x] `invalid://model/path` → `ValueError` with supported schemes
- [x] `hf://` and `s3://` success paths unchanged