### PR TITLE
fix(controller): retry deadline JobSet cleanup

### DIFF
--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -126,7 +126,8 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		err = errors.Join(err, statusErr)
 	}
 
-	deadlineResult := r.reconcileDeadline(ctx, &trainJob)
+	deadlineResult, deadlineErr := r.reconcileDeadline(ctx, &trainJob)
+	err = errors.Join(err, deadlineErr)
 
 	if !equality.Semantic.DeepEqual(trainJob.Status, prevTrainJob.Status) {
 		// TODO(astefanutti): Consider using SSA once controller-runtime client has SSA support
@@ -153,9 +154,19 @@ func (r *TrainJobReconciler) reconcileObjects(ctx context.Context, runtime jobru
 	return nil
 }
 
-func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *trainer.TrainJob) ctrl.Result {
-	if trainJob.Spec.ActiveDeadlineSeconds == 0 || trainjob.IsTrainJobFinished(trainJob) || ptr.Deref(trainJob.Spec.Suspend, false) {
-		return ctrl.Result{}
+func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *trainer.TrainJob) (ctrl.Result, error) {
+	deadlineCond := meta.FindStatusCondition(trainJob.Status.Conditions, trainer.TrainJobFailed)
+	deadlineExceeded := deadlineCond != nil &&
+		deadlineCond.Status == metav1.ConditionTrue &&
+		deadlineCond.Reason == trainer.TrainJobDeadlineExceededReason
+	if !deadlineExceeded && (trainJob.Spec.ActiveDeadlineSeconds == 0 || trainjob.IsTrainJobFinished(trainJob) || ptr.Deref(trainJob.Spec.Suspend, false)) {
+		return ctrl.Result{}, nil
+	}
+	if deadlineExceeded {
+		jobSet := &jobsetv1alpha2.JobSet{
+			ObjectMeta: metav1.ObjectMeta{Name: trainJob.Name, Namespace: trainJob.Namespace},
+		}
+		return ctrl.Result{}, client.IgnoreNotFound(r.client.Delete(ctx, jobSet))
 	}
 	startTime := trainJob.CreationTimestamp.Time
 	suspendedCond := meta.FindStatusCondition(trainJob.Status.Conditions, trainer.TrainJobSuspended)
@@ -163,7 +174,7 @@ func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *tr
 		startTime = suspendedCond.LastTransitionTime.Time
 	}
 	if startTime.IsZero() {
-		return ctrl.Result{}
+		return ctrl.Result{}, nil
 	}
 	deadline := startTime.Add(time.Duration(trainJob.Spec.ActiveDeadlineSeconds) * time.Second)
 	now := r.clock.Now()
@@ -176,10 +187,7 @@ func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *tr
 		jobSet := &jobsetv1alpha2.JobSet{
 			ObjectMeta: metav1.ObjectMeta{Name: trainJob.Name, Namespace: trainJob.Namespace},
 		}
-		if err := client.IgnoreNotFound(r.client.Delete(ctx, jobSet)); err != nil {
-			ctrl.LoggerFrom(ctx).V(2).Info("Failed to delete JobSet after deadline exceeded", "error", err)
-		}
-		return ctrl.Result{}
+		return ctrl.Result{}, client.IgnoreNotFound(r.client.Delete(ctx, jobSet))
 	}
 	requeueAfter := deadline.Sub(now)
 	if requeueAfter <= 0 {
@@ -188,7 +196,7 @@ func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *tr
 	ctrl.LoggerFrom(ctx).V(2).Info("Scheduling deadline check",
 		"activeDeadlineSeconds", trainJob.Spec.ActiveDeadlineSeconds,
 		"requeueAfter", requeueAfter)
-	return ctrl.Result{RequeueAfter: requeueAfter}
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
 func (r *TrainJobReconciler) Create(e event.TypedCreateEvent[*trainer.TrainJob]) bool {

--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -125,7 +125,8 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		err = errors.Join(err, statusErr)
 	}
 
-	deadlineResult := r.reconcileDeadline(ctx, &trainJob)
+	deadlineResult, deadlineErr := r.reconcileDeadline(ctx, &trainJob)
+	err = errors.Join(err, deadlineErr)
 
 	if !equality.Semantic.DeepEqual(trainJob.Status, prevTrainJob.Status) {
 		// TODO(astefanutti): Consider using SSA once controller-runtime client has SSA support
@@ -152,9 +153,19 @@ func (r *TrainJobReconciler) reconcileObjects(ctx context.Context, runtime jobru
 	return nil
 }
 
-func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *trainer.TrainJob) ctrl.Result {
-	if trainJob.Spec.ActiveDeadlineSeconds == 0 || trainjob.IsTrainJobFinished(trainJob) || ptr.Deref(trainJob.Spec.Suspend, false) {
-		return ctrl.Result{}
+func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *trainer.TrainJob) (ctrl.Result, error) {
+	deadlineCond := meta.FindStatusCondition(trainJob.Status.Conditions, trainer.TrainJobFailed)
+	deadlineExceeded := deadlineCond != nil &&
+		deadlineCond.Status == metav1.ConditionTrue &&
+		deadlineCond.Reason == trainer.TrainJobDeadlineExceededReason
+	if !deadlineExceeded && (trainJob.Spec.ActiveDeadlineSeconds == 0 || trainjob.IsTrainJobFinished(trainJob) || ptr.Deref(trainJob.Spec.Suspend, false)) {
+		return ctrl.Result{}, nil
+	}
+	if deadlineExceeded {
+		jobSet := &jobsetv1alpha2.JobSet{
+			ObjectMeta: metav1.ObjectMeta{Name: trainJob.Name, Namespace: trainJob.Namespace},
+		}
+		return ctrl.Result{}, client.IgnoreNotFound(r.client.Delete(ctx, jobSet))
 	}
 	startTime := trainJob.CreationTimestamp.Time
 	suspendedCond := meta.FindStatusCondition(trainJob.Status.Conditions, trainer.TrainJobSuspended)
@@ -162,7 +173,7 @@ func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *tr
 		startTime = suspendedCond.LastTransitionTime.Time
 	}
 	if startTime.IsZero() {
-		return ctrl.Result{}
+		return ctrl.Result{}, nil
 	}
 	deadline := startTime.Add(time.Duration(trainJob.Spec.ActiveDeadlineSeconds) * time.Second)
 	now := time.Now()
@@ -175,10 +186,7 @@ func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *tr
 		jobSet := &jobsetv1alpha2.JobSet{
 			ObjectMeta: metav1.ObjectMeta{Name: trainJob.Name, Namespace: trainJob.Namespace},
 		}
-		if err := client.IgnoreNotFound(r.client.Delete(ctx, jobSet)); err != nil {
-			ctrl.LoggerFrom(ctx).V(2).Info("Failed to delete JobSet after deadline exceeded", "error", err)
-		}
-		return ctrl.Result{}
+		return ctrl.Result{}, client.IgnoreNotFound(r.client.Delete(ctx, jobSet))
 	}
 	requeueAfter := time.Until(deadline)
 	if requeueAfter <= 0 {
@@ -187,7 +195,7 @@ func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *tr
 	ctrl.LoggerFrom(ctx).V(2).Info("Scheduling deadline check",
 		"activeDeadlineSeconds", trainJob.Spec.ActiveDeadlineSeconds,
 		"requeueAfter", requeueAfter)
-	return ctrl.Result{RequeueAfter: requeueAfter}
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
 func (r *TrainJobReconciler) Create(e event.TypedCreateEvent[*trainer.TrainJob]) bool {

--- a/pkg/controller/trainjob_controller_test.go
+++ b/pkg/controller/trainjob_controller_test.go
@@ -18,17 +18,20 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2/ktesting"
 	clocktesting "k8s.io/utils/clock/testing"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
@@ -187,7 +190,10 @@ func TestReconcileDeadline(t *testing.T) {
 				clock:  clocktesting.NewFakePassiveClock(tc.now),
 			}
 
-			gotResult := r.reconcileDeadline(ctx, tc.trainJob)
+			gotResult, gotErr := r.reconcileDeadline(ctx, tc.trainJob)
+			if gotErr != nil {
+				t.Fatalf("reconcileDeadline() error = %v", gotErr)
+			}
 
 			if diff := cmp.Diff(tc.wantResult, gotResult); len(diff) != 0 {
 				t.Errorf("Unexpected ctrl.Result (-want, +got): \n%s", diff)
@@ -211,5 +217,52 @@ func TestReconcileDeadline(t *testing.T) {
 				t.Errorf("Expected the child JobSet to be absent, got error: %v", gotJobSetErr)
 			}
 		})
+	}
+}
+
+func TestReconcileDeadline_RetryJobSetDeletion(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+
+	trainJob := utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "train-job").
+		ActiveDeadlineSeconds(1).
+		Obj()
+	trainJob.CreationTimestamp = metav1.NewTime(time.Now().Add(-time.Minute))
+	jobSet := &jobsetv1alpha2.JobSet{
+		ObjectMeta: metav1.ObjectMeta{Name: trainJob.Name, Namespace: trainJob.Namespace},
+	}
+
+	deleteErr := errors.New("error deleting JobSet")
+	deleteCalls := 0
+	clientBuilder := utiltesting.NewClientBuilder().WithObjects(jobSet)
+	clientBuilder.WithInterceptorFuncs(interceptor.Funcs{
+		Delete: func(ctx context.Context, cli client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			deleteCalls++
+			if deleteCalls == 1 {
+				return deleteErr
+			}
+			return cli.Delete(ctx, obj, opts...)
+		},
+	})
+	cli := clientBuilder.Build()
+	r := NewTrainJobReconciler(cli, nil, nil)
+
+	if _, err := r.reconcileDeadline(ctx, trainJob); !errors.Is(err, deleteErr) {
+		t.Fatalf("reconcileDeadline() error = %v, want %v", err, deleteErr)
+	}
+	deadlineCond := meta.FindStatusCondition(trainJob.Status.Conditions, trainer.TrainJobFailed)
+	if deadlineCond == nil || deadlineCond.Reason != trainer.TrainJobDeadlineExceededReason {
+		t.Fatalf("reconcileDeadline() condition = %v, want reason %q", deadlineCond, trainer.TrainJobDeadlineExceededReason)
+	}
+
+	if _, err := r.reconcileDeadline(ctx, trainJob); err != nil {
+		t.Fatalf("reconcileDeadline() retry returned error: %v", err)
+	}
+	if deleteCalls != 2 {
+		t.Errorf("reconcileDeadline() delete calls = %d, want 2", deleteCalls)
+	}
+	if err := cli.Get(ctx, client.ObjectKeyFromObject(jobSet), &jobsetv1alpha2.JobSet{}); !apierrors.IsNotFound(err) {
+		t.Errorf("Get() error = %v, want NotFound", err)
 	}
 }

--- a/pkg/controller/trainjob_controller_test.go
+++ b/pkg/controller/trainjob_controller_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/ktesting"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	utiltesting "github.com/kubeflow/trainer/v2/pkg/util/testing"
+)
+
+func TestReconcileDeadline_RetryJobSetDeletion(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+
+	trainJob := utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "train-job").
+		ActiveDeadlineSeconds(1).
+		Obj()
+	trainJob.CreationTimestamp = metav1.NewTime(time.Now().Add(-time.Minute))
+	jobSet := &jobsetv1alpha2.JobSet{
+		ObjectMeta: metav1.ObjectMeta{Name: trainJob.Name, Namespace: trainJob.Namespace},
+	}
+
+	deleteErr := errors.New("error deleting JobSet")
+	deleteCalls := 0
+	clientBuilder := utiltesting.NewClientBuilder().WithObjects(jobSet)
+	clientBuilder.WithInterceptorFuncs(interceptor.Funcs{
+		Delete: func(ctx context.Context, cli client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			deleteCalls++
+			if deleteCalls == 1 {
+				return deleteErr
+			}
+			return cli.Delete(ctx, obj, opts...)
+		},
+	})
+	cli := clientBuilder.Build()
+	r := NewTrainJobReconciler(cli, nil, nil)
+
+	if _, err := r.reconcileDeadline(ctx, trainJob); !errors.Is(err, deleteErr) {
+		t.Fatalf("reconcileDeadline() error = %v, want %v", err, deleteErr)
+	}
+	deadlineCond := meta.FindStatusCondition(trainJob.Status.Conditions, trainer.TrainJobFailed)
+	if deadlineCond == nil || deadlineCond.Reason != trainer.TrainJobDeadlineExceededReason {
+		t.Fatalf("reconcileDeadline() condition = %v, want reason %q", deadlineCond, trainer.TrainJobDeadlineExceededReason)
+	}
+
+	if _, err := r.reconcileDeadline(ctx, trainJob); err != nil {
+		t.Fatalf("reconcileDeadline() retry returned error: %v", err)
+	}
+	if deleteCalls != 2 {
+		t.Errorf("reconcileDeadline() delete calls = %d, want 2", deleteCalls)
+	}
+	if err := cli.Get(ctx, client.ObjectKeyFromObject(jobSet), &jobsetv1alpha2.JobSet{}); !apierrors.IsNotFound(err) {
+		t.Errorf("Get() error = %v, want NotFound", err)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

- propagates transient JobSet deletion errors after a TrainJob exceeds its active deadline
- keeps deadline-exceeded TrainJobs eligible for cleanup-only retries while runtime object reconciliation remains skipped for terminal jobs
- adds a regression test that fails the first JobSet DELETE and verifies the retry removes it

**Which issue(s) this PR fixes**:
Fixes #3833

**Testing:**

- `go test ./pkg/controller -run TestReconcileDeadline_RetryJobSetDeletion -count=1`
- `go test ./pkg/controller/... -count=1`
- `make test`
- `make vet`
- `golangci-lint` on the changed controller files: 0 issues

**Checklist:**

- [x] Docs are not required; this fixes internal controller cleanup behavior without changing the API

**AI assistance disclosure:** Codex assisted with implementation and technical drafting. I reviewed the control flow and verified the changes with the tests and checks listed above.