### PR TITLE
fix(api): validate coscheduling schedule timeout

### DIFF
--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_clustertrainingruntimes.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_clustertrainingruntimes.yaml
@@ -185,6 +185,7 @@ spec:
                         description: scheduleTimeoutSeconds is the maximum duration
                           to schedule PodGroup for gang-scheduling.
                         format: int32
+                        minimum: 0
                         type: integer
                     type: object
                   volcano:

--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_clustertrainingruntimes.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_clustertrainingruntimes.yaml
@@ -205,6 +205,10 @@ spec:
                           Defaults to 60 seconds.
                         format: int32
                         type: integer
+                        x-kubernetes-validations:
+                        - message: scheduleTimeoutSeconds must be greater than or
+                            equal to 0
+                          rule: self >= 0
                     type: object
                   volcano:
                     description: volcano plugin for gang-scheduling.

--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainingruntimes.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainingruntimes.yaml
@@ -185,6 +185,7 @@ spec:
                         description: scheduleTimeoutSeconds is the maximum duration
                           to schedule PodGroup for gang-scheduling.
                         format: int32
+                        minimum: 0
                         type: integer
                     type: object
                   volcano:

--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainingruntimes.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainingruntimes.yaml
@@ -205,6 +205,10 @@ spec:
                           Defaults to 60 seconds.
                         format: int32
                         type: integer
+                        x-kubernetes-validations:
+                        - message: scheduleTimeoutSeconds must be greater than or
+                            equal to 0
+                          rule: self >= 0
                     type: object
                   volcano:
                     description: volcano plugin for gang-scheduling.

--- a/manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
@@ -202,6 +202,10 @@ spec:
                           Defaults to 60 seconds.
                         format: int32
                         type: integer
+                        x-kubernetes-validations:
+                        - message: scheduleTimeoutSeconds must be greater than or
+                            equal to 0
+                          rule: self >= 0
                     type: object
                   volcano:
                     description: volcano plugin for gang-scheduling.

--- a/manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_clustertrainingruntimes.yaml
@@ -182,6 +182,7 @@ spec:
                         description: scheduleTimeoutSeconds is the maximum duration
                           to schedule PodGroup for gang-scheduling.
                         format: int32
+                        minimum: 0
                         type: integer
                     type: object
                   volcano:

--- a/manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
@@ -202,6 +202,10 @@ spec:
                           Defaults to 60 seconds.
                         format: int32
                         type: integer
+                        x-kubernetes-validations:
+                        - message: scheduleTimeoutSeconds must be greater than or
+                            equal to 0
+                          rule: self >= 0
                     type: object
                   volcano:
                     description: volcano plugin for gang-scheduling.

--- a/manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainingruntimes.yaml
@@ -182,6 +182,7 @@ spec:
                         description: scheduleTimeoutSeconds is the maximum duration
                           to schedule PodGroup for gang-scheduling.
                         format: int32
+                        minimum: 0
                         type: integer
                     type: object
                   volcano:

--- a/pkg/apis/trainer/v1alpha1/trainingruntime_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainingruntime_types.go
@@ -157,6 +157,7 @@ type CoschedulingPodGroupPolicySource struct {
 	// If the scheduling timeout is equal to 0, the default value is used.
 	// Defaults to 60 seconds.
 	// +kubebuilder:default=60
+	// +kubebuilder:validation:XValidation:rule="self >= 0",message="scheduleTimeoutSeconds must be greater than or equal to 0"
 	// +optional
 	ScheduleTimeoutSeconds *int32 `json:"scheduleTimeoutSeconds,omitempty"`
 }

--- a/pkg/apis/trainer/v1alpha1/trainingruntime_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainingruntime_types.go
@@ -157,6 +157,7 @@ type CoschedulingPodGroupPolicySource struct {
 	// If the scheduling timeout is equal to 0, the default value is used.
 	// Defaults to 60 seconds.
 	// +kubebuilder:default=60
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	ScheduleTimeoutSeconds *int32 `json:"scheduleTimeoutSeconds,omitempty"`
 }

--- a/test/integration/webhooks/clustertrainingruntime_webhook_test.go
+++ b/test/integration/webhooks/clustertrainingruntime_webhook_test.go
@@ -59,8 +59,8 @@ var _ = ginkgo.Describe("ClusterTrainingRuntime Webhook", ginkgo.Ordered, func()
 	})
 
 	ginkgo.When("Creating ClusterTrainingRuntime", func() {
-		ginkgo.DescribeTable("", func(runtime func() *trainer.ClusterTrainingRuntime) {
-			gomega.Expect(k8sClient.Create(ctx, runtime())).Should(gomega.Succeed())
+		ginkgo.DescribeTable("", func(runtime func() *trainer.ClusterTrainingRuntime, errorMatcher gomega.OmegaMatcher) {
+			gomega.Expect(k8sClient.Create(ctx, runtime())).Should(errorMatcher)
 		},
 			ginkgo.Entry("Should succeed to create ClusterTrainingRuntime",
 				func() *trainer.ClusterTrainingRuntime {
@@ -70,7 +70,38 @@ var _ = ginkgo.Describe("ClusterTrainingRuntime Webhook", ginkgo.Ordered, func()
 							testingutil.MakeTrainingRuntimeSpecWrapper(baseRuntime.Spec).
 								Obj()).
 						Obj()
-				}),
+				},
+				gomega.Succeed()),
+			ginkgo.Entry("Should fail to create ClusterTrainingRuntime with a negative coscheduling timeout",
+				func() *trainer.ClusterTrainingRuntime {
+					baseRuntime := testingutil.MakeClusterTrainingRuntimeWrapper(clTrainingRuntimeName)
+					return baseRuntime.
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(baseRuntime.Spec).
+							PodGroupPolicyCoschedulingSchedulingTimeout(-1).
+							Obj()).
+						Obj()
+				},
+				testingutil.BeInvalidError()),
+			ginkgo.Entry("Should succeed to create ClusterTrainingRuntime with a zero coscheduling timeout",
+				func() *trainer.ClusterTrainingRuntime {
+					baseRuntime := testingutil.MakeClusterTrainingRuntimeWrapper(clTrainingRuntimeName)
+					return baseRuntime.
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(baseRuntime.Spec).
+							PodGroupPolicyCoschedulingSchedulingTimeout(0).
+							Obj()).
+						Obj()
+				},
+				gomega.Succeed()),
+			ginkgo.Entry("Should succeed to create ClusterTrainingRuntime with a positive coscheduling timeout",
+				func() *trainer.ClusterTrainingRuntime {
+					baseRuntime := testingutil.MakeClusterTrainingRuntimeWrapper(clTrainingRuntimeName)
+					return baseRuntime.
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(baseRuntime.Spec).
+							PodGroupPolicyCoschedulingSchedulingTimeout(60).
+							Obj()).
+						Obj()
+				},
+				gomega.Succeed()),
 		)
 	})
 })

--- a/test/integration/webhooks/trainingruntime_webhook_test.go
+++ b/test/integration/webhooks/trainingruntime_webhook_test.go
@@ -240,6 +240,39 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 				},
 				testingutil.BeInvalidError(),
 			),
+			ginkgo.Entry("Should fail to create trainingRuntime with a negative coscheduling timeout",
+				func() *trainer.TrainingRuntime {
+					baseRuntime := testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime")
+					return baseRuntime.
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(baseRuntime.Spec).
+							PodGroupPolicyCoschedulingSchedulingTimeout(-1).
+							Obj()).
+						Obj()
+				},
+				testingutil.BeInvalidError(),
+			),
+			ginkgo.Entry("Should succeed to create trainingRuntime with a zero coscheduling timeout",
+				func() *trainer.TrainingRuntime {
+					baseRuntime := testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime")
+					return baseRuntime.
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(baseRuntime.Spec).
+							PodGroupPolicyCoschedulingSchedulingTimeout(0).
+							Obj()).
+						Obj()
+				},
+				gomega.Succeed(),
+			),
+			ginkgo.Entry("Should succeed to create trainingRuntime with a positive coscheduling timeout",
+				func() *trainer.TrainingRuntime {
+					baseRuntime := testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime")
+					return baseRuntime.
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(baseRuntime.Spec).
+							PodGroupPolicyCoschedulingSchedulingTimeout(60).
+							Obj()).
+						Obj()
+				},
+				gomega.Succeed(),
+			),
 		)
 		ginkgo.DescribeTable("Defaulting TrainingRuntime on creation", func(trainingRuntime func() *trainer.TrainingRuntime, wantTrainingRuntime func() *trainer.TrainingRuntime) {
 			created := trainingRuntime()

--- a/test/integration/webhooks/trainingruntime_webhook_test.go
+++ b/test/integration/webhooks/trainingruntime_webhook_test.go
@@ -222,6 +222,39 @@ var _ = ginkgo.Describe("TrainingRuntime marker validations and defaulting", gin
 				},
 				testingutil.BeInvalidError(),
 			),
+			ginkgo.Entry("Should fail to create trainingRuntime with a negative coscheduling timeout",
+				func() *trainer.TrainingRuntime {
+					baseRuntime := testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime")
+					return baseRuntime.
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(baseRuntime.Spec).
+							PodGroupPolicyCoschedulingSchedulingTimeout(-1).
+							Obj()).
+						Obj()
+				},
+				testingutil.BeInvalidError(),
+			),
+			ginkgo.Entry("Should succeed to create trainingRuntime with a zero coscheduling timeout",
+				func() *trainer.TrainingRuntime {
+					baseRuntime := testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime")
+					return baseRuntime.
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(baseRuntime.Spec).
+							PodGroupPolicyCoschedulingSchedulingTimeout(0).
+							Obj()).
+						Obj()
+				},
+				gomega.Succeed(),
+			),
+			ginkgo.Entry("Should succeed to create trainingRuntime with a positive coscheduling timeout",
+				func() *trainer.TrainingRuntime {
+					baseRuntime := testingutil.MakeTrainingRuntimeWrapper(ns.Name, "runtime")
+					return baseRuntime.
+						RuntimeSpec(testingutil.MakeTrainingRuntimeSpecWrapper(baseRuntime.Spec).
+							PodGroupPolicyCoschedulingSchedulingTimeout(60).
+							Obj()).
+						Obj()
+				},
+				gomega.Succeed(),
+			),
 		)
 		ginkgo.DescribeTable("Defaulting TrainingRuntime on creation", func(trainingRuntime func() *trainer.TrainingRuntime, wantTrainingRuntime func() *trainer.TrainingRuntime) {
 			created := trainingRuntime()


### PR DESCRIPTION
**What this PR does / why we need it**:

- Rejects negative `scheduleTimeoutSeconds` values at CRD admission with a CEL validation.
- Regenerates the namespaced and cluster-scoped CRDs, including the Helm chart copies.
- Adds admission coverage showing that negative values are rejected while zero and positive values remain valid for both `TrainingRuntime` and `ClusterTrainingRuntime`.

This prevents an invalid negative duration from being forwarded to the scheduler-plugins PodGroup while preserving the documented zero/default behavior.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #3836

**Checklist:**

- [x] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing (not applicable; this enforces the field's existing documented timeout semantics)

**Tests:**

- `make test`
- `make vet`
- Focused Kubernetes 1.35 envtest admission suite: 6/6 specs passed
- `golangci-lint-kube-api-linter` for `./pkg/apis/trainer/v1alpha1/...`

**AI assistance disclosure:**

OpenAI Codex assisted with repository inspection, implementation, test drafting, generation, and validation. I reviewed and verified the resulting changes and test behavior.