### PR TITLE
chore: Nominate robert-bell as Kubeflow Trainer reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,5 +11,6 @@ reviewers:
   - akshaychitneni
   - jinchihe
   - kuizhiqing
+  - robert-bell
 emeritus_approvers:
   - zw0610


### PR DESCRIPTION
I would like to nominate @robert-bell as Kubeflow Trainer reviewer 🎉 

Rob was involved in Trainer development over the past 6 months and contributed many features such as TrainJob status server, snapshot, and more!

- PR contributions: https://github.com/kubeflow/trainer/pulls?q=commenter%3Arobert-bell+is%3Aopen+is%3Aclosed+
- Requirements: https://github.com/kubeflow/community/blob/master/community-membership.md#reviewer

Thank you for your great work @robert-bell! 

/hold for review
/assign @astefanutti @tenzen-y @akshaychitneni @kubeflow/wg-training-chairs 

