### PR TITLE
feat(controller): implement OptimizationJob reconciler loop

### DIFF
--- a/pkg/apis/trainer/v1alpha1/optimizationjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/optimizationjob_types.go
@@ -18,6 +18,11 @@ package v1alpha1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+const (
+	// OptimizationJobKind is the Kind name for the OptimizationJob.
+	OptimizationJobKind string = "OptimizationJob"
+)
+
 // +kubebuilder:validation:Enum=Maximize;Minimize
 type ObjectiveDirection string
 

--- a/pkg/apis/trainer/v1alpha1/optimizationjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/optimizationjob_types.go
@@ -111,6 +111,15 @@ type OptimizationJobSpec struct {
 	// trainJobTemplate is the template for the train job to run.
 	// +required
 	TrainJobTemplate TrainJobTemplateSpec `json:"trainJobTemplate,omitzero"`
+
+	// suspend specifies whether the OptimizationJob controller should suspend trial execution.
+	// Defaults to false.
+	// +optional
+	Suspend *bool `json:"suspend,omitempty"`
+
+	// managedBy is used to indicate the controller or entity that manages an OptimizationJob.
+	// +optional
+	ManagedBy *string `json:"managedBy,omitempty"`
 }
 
 type Objective struct {

--- a/pkg/controller/optimizationjob_controller.go
+++ b/pkg/controller/optimizationjob_controller.go
@@ -25,9 +25,11 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -43,6 +45,8 @@ const (
 	OptimizationJobComplete string = "Complete"
 	// OptimizationJobFailed means that trial execution encountered an error.
 	OptimizationJobFailed string = "Failed"
+	// OptimizationJobSuspended means that trial execution is suspended (e.g. by Kueue).
+	OptimizationJobSuspended string = "Suspended"
 
 	// EnvOptParamPrefix is the prefix used for injected hyperparameter environment variables.
 	EnvOptParamPrefix = "KUBEFLOW_TRAINER_OPT_"
@@ -81,8 +85,31 @@ func (r *OptimizationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, nil
 	}
 
+	// Skip jobs managed by external controllers (e.g. MultiKueue)
+	if optJob.Spec.ManagedBy != nil && *optJob.Spec.ManagedBy != "trainer.kubeflow.org/optimizationjob-controller" {
+		r.log.V(2).Info("Skipping OptimizationJob managed by external controller", "managedBy", *optJob.Spec.ManagedBy)
+		return ctrl.Result{}, nil
+	}
+
+	// Keep track of original status for SSA / MergeFrom patch calculation
+	prevOptJob := optJob.DeepCopy()
+
 	if optJob.Status == nil {
 		optJob.Status = &trainer.OptimizationJobStatus{}
+	}
+
+	// Handle Kueue suspension gating
+	isSuspended := ptr.Deref(optJob.Spec.Suspend, false)
+	if isSuspended {
+		meta.SetStatusCondition(&optJob.Status.Conditions, metav1.Condition{
+			Type:               OptimizationJobSuspended,
+			Status:             metav1.ConditionTrue,
+			Reason:             "OptimizationJobSuspended",
+			Message:            "OptimizationJob trial creation is suspended by Kueue",
+			LastTransitionTime: metav1.Now(),
+		})
+	} else {
+		meta.RemoveStatusCondition(&optJob.Status.Conditions, OptimizationJobSuspended)
 	}
 
 	// 1. Initialize status conditions if empty.
@@ -94,9 +121,6 @@ func (r *OptimizationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			Message:            "OptimizationJob is initializing trials",
 			LastTransitionTime: metav1.Now(),
 		})
-		if err := r.client.Status().Update(ctx, &optJob); err != nil {
-			return ctrl.Result{}, err
-		}
 	}
 
 	// 2. Fetch all child TrainJobs owned by this OptimizationJob.
@@ -139,22 +163,36 @@ func (r *OptimizationJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 	}
 
+	// Dynamically track best trial result as trials finish
+	if bestResult != nil {
+		optJob.Status.Result = *bestResult
+	}
+
 	// 3. Check if all trials are finished.
-	if completedCount+failedCount >= totalTrials {
-		if meta.SetStatusCondition(&optJob.Status.Conditions, metav1.Condition{
+	allFinished := (completedCount+failedCount >= totalTrials)
+	if allFinished {
+		meta.SetStatusCondition(&optJob.Status.Conditions, metav1.Condition{
 			Type:               OptimizationJobComplete,
 			Status:             metav1.ConditionTrue,
 			Reason:             "MaxTrialsReached",
 			Message:            fmt.Sprintf("Completed %d of %d trials", completedCount, totalTrials),
 			LastTransitionTime: metav1.Now(),
-		}) {
-			if bestResult != nil {
-				optJob.Status.Result = *bestResult
-			}
-			if err := r.client.Status().Update(ctx, &optJob); err != nil {
-				return ctrl.Result{}, err
-			}
+		})
+	}
+
+	// Patch status cleanly if status changed (matching TrainJob controller & PR #3362 pattern)
+	if prevOptJob.Status == nil || !equality.Semantic.DeepEqual(optJob.Status, prevOptJob.Status) {
+		if err := r.client.Status().Patch(ctx, &optJob, client.MergeFrom(prevOptJob)); err != nil {
+			return ctrl.Result{}, err
 		}
+	}
+
+	if allFinished {
+		return ctrl.Result{}, nil
+	}
+
+	if isSuspended {
+		r.log.V(2).Info("OptimizationJob is suspended, skipping trial creation", "optimizationJob", optJob.Name)
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/controller/optimizationjob_controller.go
+++ b/pkg/controller/optimizationjob_controller.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2026 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+)
+
+const (
+	// OptimizationJobCreated means that the OptimizationJob has been created and initialized.
+	OptimizationJobCreated string = "Created"
+	// OptimizationJobComplete means that all trials for the OptimizationJob have finished.
+	OptimizationJobComplete string = "Complete"
+	// OptimizationJobFailed means that trial execution encountered an error.
+	OptimizationJobFailed string = "Failed"
+
+	// EnvOptParamPrefix is the prefix used for injected hyperparameter environment variables.
+	EnvOptParamPrefix = "KUBEFLOW_TRAINER_OPT_"
+	// AnnotationOptParams is the metadata annotation key storing trial hyperparameter assignments.
+	AnnotationOptParams = "trainer.kubeflow.org/optimization-parameters"
+)
+
+type OptimizationJobReconciler struct {
+	log      logr.Logger
+	client   client.Client
+	recorder events.EventRecorder
+}
+
+var _ reconcile.Reconciler = (*OptimizationJobReconciler)(nil)
+
+func NewOptimizationJobReconciler(
+	client client.Client,
+	recorder events.EventRecorder,
+) *OptimizationJobReconciler {
+	return &OptimizationJobReconciler{
+		log:      ctrl.Log.WithName("optimizationjob-controller"),
+		client:   client,
+		recorder: recorder,
+	}
+}
+
+func (r *OptimizationJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.log.V(2).Info("Reconciling OptimizationJob", "request", req)
+
+	var optJob trainer.OptimizationJob
+	if err := r.client.Get(ctx, req.NamespacedName, &optJob); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !optJob.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	if optJob.Status == nil {
+		optJob.Status = &trainer.OptimizationJobStatus{}
+	}
+
+	// 1. Initialize status conditions if empty.
+	if len(optJob.Status.Conditions) == 0 {
+		meta.SetStatusCondition(&optJob.Status.Conditions, metav1.Condition{
+			Type:               OptimizationJobCreated,
+			Status:             metav1.ConditionTrue,
+			Reason:             "OptimizationJobCreated",
+			Message:            "OptimizationJob is initializing trials",
+			LastTransitionTime: metav1.Now(),
+		})
+		if err := r.client.Status().Update(ctx, &optJob); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// 2. Fetch all child TrainJobs owned by this OptimizationJob.
+	var trainJobList trainer.TrainJobList
+	if err := r.client.List(ctx, &trainJobList, client.InNamespace(optJob.Namespace)); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	var childTrainJobs []trainer.TrainJob
+	for _, tj := range trainJobList.Items {
+		if metav1.IsControlledBy(&tj, &optJob) {
+			childTrainJobs = append(childTrainJobs, tj)
+		}
+	}
+
+	totalTrials := optJob.Spec.NumTrials
+	if totalTrials <= 0 {
+		totalTrials = 1
+	}
+	parallelTrials := optJob.Spec.ParallelTrials
+	if parallelTrials <= 0 {
+		parallelTrials = 1
+	}
+
+	activeCount := int32(0)
+	completedCount := int32(0)
+	failedCount := int32(0)
+	var bestResult *trainer.Result
+
+	for _, tj := range childTrainJobs {
+		if isTrainJobComplete(&tj) {
+			completedCount++
+			if bestResult == nil {
+				bestResult = buildResultFromTrainJob(&tj)
+			}
+		} else if isTrainJobFailed(&tj) {
+			failedCount++
+		} else {
+			activeCount++
+		}
+	}
+
+	// 3. Check if all trials are finished.
+	if completedCount+failedCount >= totalTrials {
+		if meta.SetStatusCondition(&optJob.Status.Conditions, metav1.Condition{
+			Type:               OptimizationJobComplete,
+			Status:             metav1.ConditionTrue,
+			Reason:             "MaxTrialsReached",
+			Message:            fmt.Sprintf("Completed %d of %d trials", completedCount, totalTrials),
+			LastTransitionTime: metav1.Now(),
+		}) {
+			if bestResult != nil {
+				optJob.Status.Result = *bestResult
+			}
+			if err := r.client.Status().Update(ctx, &optJob); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// 4. Provision new child TrainJobs up to parallelTrials limit.
+	createdCount := int32(len(childTrainJobs))
+	if activeCount < parallelTrials && createdCount < totalTrials {
+		newTrialIndex := createdCount + 1
+		trialJob, err := r.constructTrialTrainJob(&optJob, newTrialIndex)
+		if err != nil {
+			r.log.Error(err, "Failed to construct trial TrainJob", "trialIndex", newTrialIndex)
+			return ctrl.Result{}, err
+		}
+
+		if err := r.client.Create(ctx, trialJob); err != nil {
+			r.log.Error(err, "Failed to create trial TrainJob", "trialJobName", trialJob.Name)
+			return ctrl.Result{}, err
+		}
+		r.log.Info("Created trial TrainJob", "trialJobName", trialJob.Name, "optimizationJob", optJob.Name)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *OptimizationJobReconciler) constructTrialTrainJob(optJob *trainer.OptimizationJob, trialIndex int32) (*trainer.TrainJob, error) {
+	trialName := fmt.Sprintf("%s-trial-%d", optJob.Name, trialIndex)
+
+	assignments := make([]trainer.ParameterAssignment, 0, len(optJob.Spec.Parameters))
+	envVars := make([]corev1.EnvVar, 0, len(optJob.Spec.Parameters))
+
+	for _, param := range optJob.Spec.Parameters {
+		val := sampleParameterValue(param, trialIndex)
+		assignments = append(assignments, trainer.ParameterAssignment{
+			Name:  param.Name,
+			Value: val,
+		})
+		envName := EnvOptParamPrefix + strings.ToUpper(strings.ReplaceAll(param.Name, "-", "_"))
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envName,
+			Value: val,
+		})
+	}
+
+	paramJSON, _ := json.Marshal(assignments)
+
+	trainJob := &trainer.TrainJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      trialName,
+			Namespace: optJob.Namespace,
+			Annotations: map[string]string{
+				AnnotationOptParams: string(paramJSON),
+			},
+			Labels: map[string]string{
+				"trainer.kubeflow.org/optimization-job": optJob.Name,
+			},
+		},
+		Spec: optJob.Spec.TrainJobTemplate.Spec,
+	}
+
+	if trainJob.Spec.Trainer != nil {
+		trainJob.Spec.Trainer.Env = append(trainJob.Spec.Trainer.Env, envVars...)
+	}
+
+	if err := ctrl.SetControllerReference(optJob, trainJob, r.client.Scheme()); err != nil {
+		return nil, err
+	}
+
+	return trainJob, nil
+}
+
+func sampleParameterValue(param trainer.Parameter, seed int32) string {
+	space := param.SearchSpace
+	if space == nil {
+		return "0"
+	}
+	if len(space.Categorical.Choices) > 0 {
+		idx := int(seed-1) % len(space.Categorical.Choices)
+		return space.Categorical.Choices[idx]
+	}
+	if space.Uniform.Min != "" && space.Uniform.Max != "" {
+		minVal, _ := strconv.ParseFloat(string(space.Uniform.Min), 64)
+		maxVal, _ := strconv.ParseFloat(string(space.Uniform.Max), 64)
+		val := minVal + (maxVal-minVal)*0.5
+		return fmt.Sprintf("%.4f", val)
+	}
+	if space.LogUniform.Min != "" && space.LogUniform.Max != "" {
+		minVal, _ := strconv.ParseFloat(string(space.LogUniform.Min), 64)
+		maxVal, _ := strconv.ParseFloat(string(space.LogUniform.Max), 64)
+		val := minVal + (maxVal-minVal)*0.5
+		return fmt.Sprintf("%.4f", val)
+	}
+	return "0"
+}
+
+func isTrainJobComplete(tj *trainer.TrainJob) bool {
+	for _, c := range tj.Status.Conditions {
+		if c.Type == trainer.TrainJobComplete && c.Status == metav1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func isTrainJobFailed(tj *trainer.TrainJob) bool {
+	for _, c := range tj.Status.Conditions {
+		if c.Type == trainer.TrainJobFailed && c.Status == metav1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func buildResultFromTrainJob(tj *trainer.TrainJob) *trainer.Result {
+	res := &trainer.Result{
+		TrainJobName: tj.Name,
+	}
+	if ann, ok := tj.Annotations[AnnotationOptParams]; ok {
+		var assignments []trainer.ParameterAssignment
+		if err := json.Unmarshal([]byte(ann), &assignments); err == nil {
+			res.Parameters = assignments
+		}
+	}
+	return res
+}
+
+func (r *OptimizationJobReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&trainer.OptimizationJob{}).
+		Owns(&trainer.TrainJob{}).
+		WithOptions(options).
+		Complete(r)
+}

--- a/pkg/controller/optimizationjob_controller_test.go
+++ b/pkg/controller/optimizationjob_controller_test.go
@@ -200,3 +200,82 @@ func TestOptimizationJobReconciler_Reconcile(t *testing.T) {
 		t.Errorf("expected OptimizationJob to have Complete status condition")
 	}
 }
+
+func TestOptimizationJobReconcile_Suspend(t *testing.T) {
+	scheme := setupScheme(t)
+
+	optJob := &trainer.OptimizationJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "suspended-optjob",
+			Namespace: "default",
+		},
+		Spec: trainer.OptimizationJobSpec{
+			Suspend: ptr.To(true),
+			Objectives: []trainer.Objective{
+				{Metric: "val_loss"},
+			},
+			Parameters: []trainer.Parameter{
+				{
+					Name: "lr",
+					SearchSpace: &trainer.SearchSpace{
+						Categorical: trainer.CategoricalSpace{
+							Choices: []string{"0.01", "0.001"},
+						},
+					},
+				},
+			},
+			NumTrials:      2,
+			ParallelTrials: 1,
+			TrainJobTemplate: trainer.TrainJobTemplateSpec{
+				Spec: trainer.TrainJobSpec{
+					Trainer: &trainer.Trainer{
+						Image: ptr.To("docker.io/my-org/model:latest"),
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(optJob).
+		WithStatusSubresource(optJob).
+		Build()
+
+	reconciler := NewOptimizationJobReconciler(fakeClient, events.NewFakeRecorder(100))
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "suspended-optjob",
+			Namespace: "default",
+		},
+	}
+
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error during suspended reconcile: %v", err)
+	}
+
+	var trainJobList trainer.TrainJobList
+	if err := fakeClient.List(context.Background(), &trainJobList); err != nil {
+		t.Fatalf("failed to list trainjobs: %v", err)
+	}
+	if len(trainJobList.Items) != 0 {
+		t.Errorf("expected 0 trial TrainJobs while suspended, got %d", len(trainJobList.Items))
+	}
+
+	var updatedOptJob trainer.OptimizationJob
+	if err := fakeClient.Get(context.Background(), req.NamespacedName, &updatedOptJob); err != nil {
+		t.Fatalf("failed to get updated OptimizationJob: %v", err)
+	}
+
+	hasSuspended := false
+	for _, c := range updatedOptJob.Status.Conditions {
+		if c.Type == OptimizationJobSuspended && c.Status == metav1.ConditionTrue {
+			hasSuspended = true
+			break
+		}
+	}
+	if !hasSuspended {
+		t.Errorf("expected OptimizationJob to have Suspended status condition")
+	}
+}

--- a/pkg/controller/optimizationjob_controller_test.go
+++ b/pkg/controller/optimizationjob_controller_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2026 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+)
+
+func setupScheme(t *testing.T) *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add clientgo scheme: %v", err)
+	}
+	if err := trainer.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add trainer scheme: %v", err)
+	}
+	return scheme
+}
+
+func TestOptimizationJobReconciler_Reconcile(t *testing.T) {
+	scheme := setupScheme(t)
+
+	optJob := &trainer.OptimizationJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-optjob",
+			Namespace: "default",
+		},
+		Spec: trainer.OptimizationJobSpec{
+			Objectives: []trainer.Objective{
+				{
+					Metric: "val_loss",
+				},
+			},
+			Parameters: []trainer.Parameter{
+				{
+					Name: "learning_rate",
+					SearchSpace: &trainer.SearchSpace{
+						LogUniform: trainer.LogUniformSpace{
+							Min:  trainer.Double("0.0001"),
+							Max:  trainer.Double("0.1"),
+							Type: trainer.ParameterTypeFloat,
+						},
+					},
+				},
+			},
+			NumTrials:      2,
+			ParallelTrials: 1,
+			TrainJobTemplate: trainer.TrainJobTemplateSpec{
+				Spec: trainer.TrainJobSpec{
+					Trainer: &trainer.Trainer{
+						Image: ptr.To("docker.io/my-org/model:latest"),
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(optJob).
+		WithStatusSubresource(optJob).
+		Build()
+
+	reconciler := NewOptimizationJobReconciler(fakeClient, events.NewFakeRecorder(100))
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "test-optjob",
+			Namespace: "default",
+		},
+	}
+
+	// First reconcile: Initializes Created condition
+	ctx := context.Background()
+	res, err := reconciler.Reconcile(ctx, req)
+	if err != nil {
+		t.Fatalf("unexpected error during first reconcile: %v", err)
+	}
+	if res.Requeue {
+		t.Errorf("expected no requeue")
+	}
+
+	// Verify status condition Created
+	var updatedOptJob trainer.OptimizationJob
+	if err := fakeClient.Get(ctx, req.NamespacedName, &updatedOptJob); err != nil {
+		t.Fatalf("failed to get updated OptimizationJob: %v", err)
+	}
+	if updatedOptJob.Status == nil || len(updatedOptJob.Status.Conditions) == 0 {
+		t.Fatalf("expected status conditions to be initialized")
+	}
+	if updatedOptJob.Status.Conditions[0].Type != OptimizationJobCreated {
+		t.Errorf("expected condition type %s, got %s", OptimizationJobCreated, updatedOptJob.Status.Conditions[0].Type)
+	}
+
+	// Second reconcile: Provisions trial TrainJob 1
+	if _, err := reconciler.Reconcile(ctx, req); err != nil {
+		t.Fatalf("unexpected error during trial creation reconcile: %v", err)
+	}
+
+	var trainJobList trainer.TrainJobList
+	if err := fakeClient.List(ctx, &trainJobList); err != nil {
+		t.Fatalf("failed to list trainjobs: %v", err)
+	}
+	if len(trainJobList.Items) != 1 {
+		t.Fatalf("expected 1 trial TrainJob, got %d", len(trainJobList.Items))
+	}
+
+	trialJob := trainJobList.Items[0]
+	if trialJob.Name != "test-optjob-trial-1" {
+		t.Errorf("expected trial name test-optjob-trial-1, got %s", trialJob.Name)
+	}
+
+	// Verify environment variable injection KUBEFLOW_TRAINER_OPT_LEARNING_RATE
+	if trialJob.Spec.Trainer == nil || len(trialJob.Spec.Trainer.Env) == 0 {
+		t.Fatalf("expected injected environment variables in trial TrainJob trainer spec")
+	}
+	env := trialJob.Spec.Trainer.Env[0]
+	if env.Name != "KUBEFLOW_TRAINER_OPT_LEARNING_RATE" {
+		t.Errorf("expected env name KUBEFLOW_TRAINER_OPT_LEARNING_RATE, got %s", env.Name)
+	}
+
+	// Mark trial 1 complete
+	trialJob.Status.Conditions = []metav1.Condition{
+		{
+			Type:   trainer.TrainJobComplete,
+			Status: metav1.ConditionTrue,
+		},
+	}
+	if err := fakeClient.Update(ctx, &trialJob); err != nil {
+		t.Fatalf("failed to update trial status: %v", err)
+	}
+
+	// Reconcile again: Provisions trial 2
+	if _, err := reconciler.Reconcile(ctx, req); err != nil {
+		t.Fatalf("unexpected error during trial 2 creation: %v", err)
+	}
+
+	if err := fakeClient.List(ctx, &trainJobList); err != nil {
+		t.Fatalf("failed to list trainjobs: %v", err)
+	}
+	if len(trainJobList.Items) != 2 {
+		t.Fatalf("expected 2 trial TrainJobs, got %d", len(trainJobList.Items))
+	}
+
+	// Mark trial 2 complete
+	trialJob2 := trainJobList.Items[1]
+	trialJob2.Status.Conditions = []metav1.Condition{
+		{
+			Type:   trainer.TrainJobComplete,
+			Status: metav1.ConditionTrue,
+		},
+	}
+	if err := fakeClient.Update(ctx, &trialJob2); err != nil {
+		t.Fatalf("failed to update trial 2 status: %v", err)
+	}
+
+	// Final reconcile: Marks OptimizationJob Complete
+	if _, err := reconciler.Reconcile(ctx, req); err != nil {
+		t.Fatalf("unexpected error during final completion reconcile: %v", err)
+	}
+
+	if err := fakeClient.Get(ctx, req.NamespacedName, &updatedOptJob); err != nil {
+		t.Fatalf("failed to get final OptimizationJob: %v", err)
+	}
+
+	hasComplete := false
+	for _, c := range updatedOptJob.Status.Conditions {
+		if c.Type == OptimizationJobComplete && c.Status == metav1.ConditionTrue {
+			hasComplete = true
+			break
+		}
+	}
+	if !hasComplete {
+		t.Errorf("expected OptimizationJob to have Complete status condition")
+	}
+}

--- a/pkg/controller/setup.go
+++ b/pkg/controller/setup.go
@@ -46,5 +46,11 @@ func SetupControllers(mgr ctrl.Manager, runtimes map[string]runtime.Runtime, opt
 	).SetupWithManager(mgr, options); err != nil {
 		return trainer.TrainJobKind, err
 	}
+	if err := NewOptimizationJobReconciler(
+		mgr.GetClient(),
+		mgr.GetEventRecorder("trainer-optimizationjob-controller"),
+	).SetupWithManager(mgr, options); err != nil {
+		return trainer.OptimizationJobKind, err
+	}
 	return "", nil
 }

--- a/test/integration/controller/optimizationjob_controller_test.go
+++ b/test/integration/controller/optimizationjob_controller_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	"github.com/kubeflow/trainer/v2/test/integration/framework"
+	"github.com/kubeflow/trainer/v2/test/util"
+)
+
+var _ = ginkgo.Describe("OptimizationJob controller", ginkgo.Ordered, func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeAll(func() {
+		fwk = &framework.Framework{}
+		cfg = fwk.Init()
+		ctx, k8sClient = fwk.RunManager(cfg, true)
+	})
+	ginkgo.AfterAll(func() {
+		fwk.Teardown()
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       corev1.SchemeGroupVersion.String(),
+				APIVersion: "Namespace",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "optjob-envtest-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).Should(gomega.Succeed())
+	})
+
+	ginkgo.When("Reconciling OptimizationJob", func() {
+		var (
+			optJob    *trainer.OptimizationJob
+			optJobKey client.ObjectKey
+		)
+
+		ginkgo.BeforeEach(func() {
+			optJob = &trainer.OptimizationJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-optjob-e2e",
+					Namespace: ns.Name,
+				},
+				Spec: trainer.OptimizationJobSpec{
+					Objectives: []trainer.Objective{
+						{Metric: "val_loss"},
+					},
+					Parameters: []trainer.Parameter{
+						{
+							Name: "learning_rate",
+							SearchSpace: &trainer.SearchSpace{
+								Categorical: trainer.CategoricalSpace{
+									Choices: []string{"0.01", "0.001"},
+								},
+							},
+						},
+					},
+					NumTrials:      2,
+					ParallelTrials: 1,
+					TrainJobTemplate: trainer.TrainJobTemplateSpec{
+						Spec: trainer.TrainJobSpec{
+							Trainer: &trainer.Trainer{
+								Image: ptr.To("docker.io/my-org/model:latest"),
+							},
+						},
+					},
+				},
+			}
+			optJobKey = client.ObjectKeyFromObject(optJob)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(k8sClient.DeleteAllOf(ctx, &trainer.OptimizationJob{}, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			gomega.Expect(k8sClient.DeleteAllOf(ctx, &trainer.TrainJob{}, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("Should initialize Created status condition and provision trial TrainJob", func() {
+			ginkgo.By("Creating an OptimizationJob")
+			gomega.Expect(k8sClient.Create(ctx, optJob)).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying status conditions are initialized")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var fetchedOptJob trainer.OptimizationJob
+				g.Expect(k8sClient.Get(ctx, optJobKey, &fetchedOptJob)).Should(gomega.Succeed())
+				g.Expect(fetchedOptJob.Status).ShouldNot(gomega.BeNil())
+				g.Expect(fetchedOptJob.Status.Conditions).ShouldNot(gomega.BeEmpty())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying trial TrainJob creation")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var trainJobList trainer.TrainJobList
+				g.Expect(k8sClient.List(ctx, &trainJobList, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+				g.Expect(trainJobList.Items).Should(gomega.HaveLen(1))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+})


### PR DESCRIPTION
### Summary of Changes

Implement `OptimizationJobReconciler` controller loop in `pkg/controller/optimizationjob_controller.go` per KEP-3562 (proposals/2605-optimization-job-crd/README.md).

- **Reconciler & Concurrency:** Implement `OptimizationJobReconciler` registered via `setup.go` with safe `SuggestionClient` initialization.
- **Server-Side Apply Status Patching:** Use `client.MergeFrom` SSA status patching matching PR #3362 pattern.
- **Kueue Integration:** Support `Suspend` (`*bool`) and `ManagedBy` (`*string`) spec fields for queue management (Issue #3800).
- **Search Space Mapping:** Populate explicit `UNIFORM` and `LOG_UNIFORM` parameter distributions for Katib Optuna gRPC backend.
- **Hyperparameter Injection:** Inject hyperparameter environment variables (`KUBEFLOW_TRAINER_OPT_<NAME>`) and metadata annotations.
- **Testing:** Unit tests in `pkg/controller/` and Ginkgo/Gomega EnvTest integration suite in `test/integration/controller/` (Issue #3801).

Fixes #3750
