### PR TITLE
chore(operator): drop unused test-only helpers from pkg/features

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -17,13 +17,9 @@ limitations under the License.
 package features
 
 import (
-	"fmt"
-	"testing"
-
 	"k8s.io/apimachinery/pkg/util/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/featuregate"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 )
 
 func init() {
@@ -48,18 +44,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	TrainJobStatus: {Default: false, PreRelease: featuregate.Alpha},
 }
 
-func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) {
-	featuregatetesting.SetFeatureGateDuringTest(tb, utilfeature.DefaultFeatureGate, f, value)
-}
-
 // Enabled is helper for `utilfeature.DefaultFeatureGate.Enabled()`
 func Enabled(f featuregate.Feature) bool {
 	return utilfeature.DefaultFeatureGate.Enabled(f)
-}
-
-// SetEnable helper function that can be used to set the enabled value of a feature gate,
-// it should only be used in integration test pending the merge of
-// https://github.com/kubernetes/kubernetes/pull/118346
-func SetEnable(f featuregate.Feature, v bool) error {
-	return utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=%v", f, v))
 }


### PR DESCRIPTION
## Summary

`pkg/features` is imported by the controller manager, so the two test-only helpers it exported linked the standard library `testing` package — along with `component-base/featuregate/testing`, `klog/v2/ktesting` and `internal/sysinfo` — into the shipped binary. It was the only non-test file in the repository importing `testing`.

Neither helper has a call site anywhere in the tree. Both arrived with the feature-gate scaffolding in #3102 and were never picked up; tests set gates through the manager's `--feature-gates` flag instead. The upstream issue `SetEnable` was waiting on (kubernetes/kubernetes#118346) has since been closed without merging, so its note can no longer come true. A test that needs to flip a gate can call `featuregatetesting.SetFeatureGateDuringTest` directly.

## Tests

`go build ./...`, `go vet ./...`, `golangci-lint run` and `go test ./pkg/... ./cmd/...` all pass. The manager's dependency graph drops from 886 to 882 packages.

## Compatibility

Both helpers are exported, so this breaks any out-of-tree importer. A deprecation cycle would not help here — `testing` stays linked for as long as the functions exist — but I'm happy to switch to a `// Deprecated:` marker if you prefer.

**Which issue(s) this PR fixes**:

N/A

**Checklist:**

- [x] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing