### PR TITLE
fix(manifests): install OptimizationJob CRD consistently

### DIFF
--- a/charts/kubeflow-trainer/tests/crd/crd_test.yaml
+++ b/charts/kubeflow-trainer/tests/crd/crd_test.yaml
@@ -18,6 +18,7 @@ templates:
   - crd/trainer.kubeflow.org_trainjobs.yaml
   - crd/trainer.kubeflow.org_trainingruntimes.yaml
   - crd/trainer.kubeflow.org_clustertrainingruntimes.yaml
+  - crd/trainer.kubeflow.org_optimizationjobs.yaml
 
 release:
   name: kubeflow-trainer
@@ -47,6 +48,14 @@ tests:
           apiVersion: apiextensions.k8s.io/v1
           kind: CustomResourceDefinition
           name: clustertrainingruntimes.trainer.kubeflow.org
+
+  - it: Should render the OptimizationJob CRD as a template so it is reconciled on helm upgrade
+    template: crd/trainer.kubeflow.org_optimizationjobs.yaml
+    asserts:
+      - containsDocument:
+          apiVersion: apiextensions.k8s.io/v1
+          kind: CustomResourceDefinition
+          name: optimizationjobs.trainer.kubeflow.org
 
   - it: Should not render the CRDs when crds.enabled is false
     set:

--- a/manifests/base/crds/kustomization.yaml
+++ b/manifests/base/crds/kustomization.yaml
@@ -16,5 +16,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - trainer.kubeflow.org_clustertrainingruntimes.yaml
+  - trainer.kubeflow.org_optimizationjobs.yaml
   - trainer.kubeflow.org_trainingruntimes.yaml
   - trainer.kubeflow.org_trainjobs.yaml


### PR DESCRIPTION
## What this PR does / why we need it

The generated `OptimizationJob` CRD exists in the repository, but it was omitted from the Kustomize CRD resources. As a result, the standard Kustomize installation did not install `optimizationjobs.trainer.kubeflow.org`.

The Helm chart already contains the CRD template, but its CRD test suite did not include or validate the OptimizationJob CRD.

This PR:

* adds the OptimizationJob CRD to the Kustomize CRD resources;
* adds Helm unit-test coverage for the OptimizationJob CRD template;
* verifies during E2E cluster setup that the CRD reaches the `Established` condition for both Kustomize and Helm installations.

This keeps the supported installation methods consistent and adds regression coverage for the OptimizationJob API packaging.

## Validation

* `kubectl kustomize manifests/base/crds`
* `kubectl kustomize manifests/overlays/manager`
* Full Helm unit-test suite: 21 suites and 85 tests passed
* `bash -n hack/e2e-setup-cluster.sh`
* `pre-commit run --files <changed-files>`
* `python hack/boilerplate/boilerplate.py --base-ref upstream/master`
* `git diff --check`

Fixes #3882
Related to #3562

cc : @andreyvelich @robert-bell @Sridhar1030 @akshaychitneni @jaiakash 