### PR TITLE
fix(controller): apply configured health probe endpoint names

### DIFF
--- a/cmd/trainer-controller-manager/main.go
+++ b/cmd/trainer-controller-manager/main.go
@@ -139,7 +139,7 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 
-	setupProbeEndpoints(mgr, certsReady, options.LivenessEndpointName, options.ReadinessEndpointName)
+	setupProbeEndpoints(mgr, certsReady, options)
 	runtimes, err := runtimecore.New(ctx, mgr.GetClient(), mgr.GetFieldIndexer(), &cfg)
 	if err != nil {
 		setupLog.Error(err, "Could not initialize runtimes")
@@ -192,8 +192,9 @@ func setupManagerComponents(mgr ctrl.Manager, runtimes map[string]runtime.Runtim
 	}
 }
 
-func setupProbeEndpoints(mgr ctrl.Manager, certsReady <-chan struct{}, livenessPath, readinessPath string) {
-	defer setupLog.Info("Probe endpoints are configured", "liveness", livenessPath, "readiness", readinessPath)
+func setupProbeEndpoints(mgr ctrl.Manager, certsReady <-chan struct{}, options ctrl.Options) {
+	defer setupLog.Info("Probe endpoints are configured",
+		"liveness", options.LivenessEndpointName, "readiness", options.ReadinessEndpointName)
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/cmd/trainer-controller-manager/main.go
+++ b/cmd/trainer-controller-manager/main.go
@@ -139,7 +139,7 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 
-	setupProbeEndpoints(mgr, certsReady)
+	setupProbeEndpoints(mgr, certsReady, options.LivenessEndpointName, options.ReadinessEndpointName)
 	runtimes, err := runtimecore.New(ctx, mgr.GetClient(), mgr.GetFieldIndexer(), &cfg)
 	if err != nil {
 		setupLog.Error(err, "Could not initialize runtimes")
@@ -192,8 +192,8 @@ func setupManagerComponents(mgr ctrl.Manager, runtimes map[string]runtime.Runtim
 	}
 }
 
-func setupProbeEndpoints(mgr ctrl.Manager, certsReady <-chan struct{}) {
-	defer setupLog.Info("Probe endpoints are configured on healthz and readyz")
+func setupProbeEndpoints(mgr ctrl.Manager, certsReady <-chan struct{}, livenessPath, readinessPath string) {
+	defer setupLog.Info("Probe endpoints are configured", "liveness", livenessPath, "readiness", readinessPath)
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"os"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -46,6 +47,17 @@ func fromFile(path string, scheme *runtime.Scheme, cfg *configapi.Configuration)
 	}
 
 	return nil
+}
+
+// healthEndpointPath returns the probe endpoint name as a rooted path.
+func healthEndpointPath(name string) string {
+	// controller-runtime registers the name as an http.ServeMux pattern, which panics on
+	// a pattern that has no leading slash, and the API and the shipped manifests spell
+	// the names without one.
+	if name == "" || strings.HasPrefix(name, "/") {
+		return name
+	}
+	return "/" + name
 }
 
 // addTo applies the configuration to controller runtime Options.
@@ -75,6 +87,8 @@ func addTo(o *ctrl.Options, cfg *configapi.Configuration) {
 	}
 
 	o.HealthProbeBindAddress = cfg.Health.HealthProbeBindAddress
+	o.ReadinessEndpointName = healthEndpointPath(cfg.Health.ReadinessEndpointName)
+	o.LivenessEndpointName = healthEndpointPath(cfg.Health.LivenessEndpointName)
 
 	if cfg.LeaderElection != nil {
 		if cfg.LeaderElection.LeaderElect != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -308,6 +308,8 @@ this is not: valid: yaml: content
 	// and a manual TLS server is started later in setupManagerComponents.
 	defaultOptions := ctrl.Options{
 		HealthProbeBindAddress: ":8081",
+		ReadinessEndpointName:  "/readyz",
+		LivenessEndpointName:   "/healthz",
 		Metrics: metricsserver.Options{
 			BindAddress: "0",
 		},
@@ -403,6 +405,8 @@ this is not: valid: yaml: content
 			},
 			wantOptions: ctrl.Options{
 				HealthProbeBindAddress: ":8082",
+				ReadinessEndpointName:  "/readyz",
+				LivenessEndpointName:   "/healthz",
 				Metrics: metricsserver.Options{
 					BindAddress: "0",
 				},
@@ -436,6 +440,8 @@ this is not: valid: yaml: content
 			},
 			wantOptions: ctrl.Options{
 				HealthProbeBindAddress: ":8081",
+				ReadinessEndpointName:  "/readyz",
+				LivenessEndpointName:   "/healthz",
 				Metrics: metricsserver.Options{
 					BindAddress: "0",
 				},
@@ -474,6 +480,8 @@ this is not: valid: yaml: content
 			},
 			wantOptions: ctrl.Options{
 				HealthProbeBindAddress: ":8081",
+				ReadinessEndpointName:  "/readyz",
+				LivenessEndpointName:   "/healthz",
 				Metrics: metricsserver.Options{
 					BindAddress: "0",
 				},
@@ -545,6 +553,8 @@ this is not: valid: yaml: content
 			},
 			wantOptions: ctrl.Options{
 				HealthProbeBindAddress: ":8081",
+				ReadinessEndpointName:  "/readyz",
+				LivenessEndpointName:   "/healthz",
 				Metrics: metricsserver.Options{
 					BindAddress: "0",
 				},
@@ -572,6 +582,8 @@ this is not: valid: yaml: content
 			},
 			wantOptions: ctrl.Options{
 				HealthProbeBindAddress: ":8081",
+				ReadinessEndpointName:  "/readyz",
+				LivenessEndpointName:   "/healthz",
 				Metrics: metricsserver.Options{
 					BindAddress: "0",
 				},
@@ -601,6 +613,8 @@ this is not: valid: yaml: content
 			},
 			wantOptions: ctrl.Options{
 				HealthProbeBindAddress: ":8081",
+				ReadinessEndpointName:  "/readyz",
+				LivenessEndpointName:   "/healthz",
 				Metrics: metricsserver.Options{
 					BindAddress: "0",
 				},
@@ -629,6 +643,8 @@ this is not: valid: yaml: content
 			},
 			wantOptions: ctrl.Options{
 				HealthProbeBindAddress: ":9090",
+				ReadinessEndpointName:  "/ready",
+				LivenessEndpointName:   "/alive",
 				Metrics: metricsserver.Options{
 					BindAddress: "0",
 				},
@@ -675,6 +691,8 @@ this is not: valid: yaml: content
 			},
 			wantOptions: ctrl.Options{
 				HealthProbeBindAddress: ":8081",
+				ReadinessEndpointName:  "/readyz",
+				LivenessEndpointName:   "/healthz",
 				Metrics: metricsserver.Options{
 					BindAddress: "0",
 				},
@@ -743,6 +761,34 @@ this is not: valid: yaml: content
 			}
 			if diff := cmp.Diff(tc.wantOptions, options, ctrlOptsCmpOpts...); diff != "" {
 				t.Errorf("Unexpected options (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestHealthEndpointPath(t *testing.T) {
+	testcases := map[string]struct {
+		endpointName string
+		want         string
+	}{
+		"name without leading slash": {
+			endpointName: "readyz",
+			want:         "/readyz",
+		},
+		"name with leading slash": {
+			endpointName: "/readyz",
+			want:         "/readyz",
+		},
+		"empty name is left to controller-runtime defaulting": {
+			endpointName: "",
+			want:         "",
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			if got := healthEndpointPath(tc.endpointName); got != tc.want {
+				t.Errorf("healthEndpointPath(%q) = %q, want %q", tc.endpointName, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

`readinessEndpointName` and `livenessEndpointName` have been exposed in the config API and Helm chart with defaults, but were never passed to the manager. As a result, probes always used controller-runtime's default `/readyz` and `/healthz` endpoints. Renaming an endpoint and updating the Deployment probe therefore caused 404s and left the container permanently unready.

The configured names are now passed to the manager. Because the config values omit the leading `/` (for example, `readinessEndpointName: readyz`) while `http.ServeMux` patterns require one, the endpoints are normalized before registration. This preserves the existing defaults while allowing custom endpoint names.

Invalid endpoint names that `ServeMux` rejects now fail at startup instead of being silently ignored. Validation in the config layer remains unchanged.

## Tests

The `Load` cases and endpoint normalization test both fail without the change.