### PR TITLE
feat(operator): Add PreComponentBuilder and PodSpec plugins

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -42,13 +42,13 @@ jobs:
           scopes: |
             api
             ci
+            controller
             deps
             docs
             examples
-            exporter
+            framework
             initializer
             manifests
-            operator
             runtimes
             scripts
             test

--- a/pkg/runtime/core/trainingruntime.go
+++ b/pkg/runtime/core/trainingruntime.go
@@ -112,6 +112,13 @@ func (r *TrainingRuntime) NewObjects(ctx context.Context, trainJob *trainer.Trai
 	return r.framework.RunComponentBuilderPlugins(ctx, info, trainJob)
 }
 
+// RuntimeInfo builds the Info object for a TrainJob and consolidates it through the
+// Build Phase extension points, in this order:
+//  1. EnforceMLPolicy, then EnforcePodGroupPolicy, for the parameters declared in the
+//     runtime `.spec.mlPolicy` and `.spec.podGroupPolicy`.
+//  2. EnforcePodSpec, for the PodSet concerns enabled outside of MLPolicy and PodGroupPolicy APIs.
+//  3. SyncPodNetwork and SyncParallelCount, which consolidate the Info object with the
+//     concrete runtime template.
 func (r *TrainingRuntime) RuntimeInfo(
 	trainJob *trainer.TrainJob, runtimeTemplateSpec any, mlPolicy *trainer.MLPolicy, podGroupPolicy *trainer.PodGroupPolicy,
 ) (*runtime.Info, error) {
@@ -130,8 +137,10 @@ func (r *TrainingRuntime) RuntimeInfo(
 	if err = r.framework.RunEnforcePodGroupPolicyPlugins(info, trainJob); err != nil {
 		return nil, err
 	}
-
-	if err = r.framework.RunPodNetworkPlugins(info, trainJob); err != nil {
+	if err = r.framework.RunEnforcePodSpecPlugins(info, trainJob); err != nil {
+		return nil, err
+	}
+	if err = r.framework.RunPreComponentBuilderPlugins(info, trainJob); err != nil {
 		return nil, err
 	}
 

--- a/pkg/runtime/core/trainingruntime.go
+++ b/pkg/runtime/core/trainingruntime.go
@@ -117,8 +117,7 @@ func (r *TrainingRuntime) NewObjects(ctx context.Context, trainJob *trainer.Trai
 //  1. EnforceMLPolicy, then EnforcePodGroupPolicy, for the parameters declared in the
 //     runtime `.spec.mlPolicy` and `.spec.podGroupPolicy`.
 //  2. EnforcePodSpec, for the PodSet concerns enabled outside of MLPolicy and PodGroupPolicy APIs.
-//  3. SyncPodNetwork and SyncParallelCount, which consolidate the Info object with the
-//     concrete runtime template.
+//  3. PreBuildSync, which consolidates the Info object with the concrete runtime template.
 func (r *TrainingRuntime) RuntimeInfo(
 	trainJob *trainer.TrainJob, runtimeTemplateSpec any, mlPolicy *trainer.MLPolicy, podGroupPolicy *trainer.PodGroupPolicy,
 ) (*runtime.Info, error) {

--- a/pkg/runtime/framework/core/framework.go
+++ b/pkg/runtime/framework/core/framework.go
@@ -40,9 +40,10 @@ type Framework struct {
 	plugins                      map[string]framework.Plugin
 	enforceMLPlugins             []framework.EnforceMLPolicyPlugin
 	enforcePodGroupPolicyPlugins []framework.EnforcePodGroupPolicyPlugin
+	enforcePodSpecPlugins        []framework.EnforcePodSpecPlugin
 	customValidationPlugins      []framework.CustomValidationPlugin
 	watchExtensionPlugins        []framework.WatchExtensionPlugin
-	podNetworkPlugins            []framework.PodNetworkPlugin
+	preComponentBuilderPlugins   []framework.PreComponentBuilderPlugin
 	componentBuilderPlugins      []framework.ComponentBuilderPlugin
 	trainJobStatusPlugin         framework.TrainJobStatusPlugin
 }
@@ -68,14 +69,17 @@ func New(ctx context.Context, c client.Client, r fwkplugins.Registry, indexer cl
 		if p, ok := plugin.(framework.EnforcePodGroupPolicyPlugin); ok {
 			f.enforcePodGroupPolicyPlugins = append(f.enforcePodGroupPolicyPlugins, p)
 		}
+		if p, ok := plugin.(framework.EnforcePodSpecPlugin); ok {
+			f.enforcePodSpecPlugins = append(f.enforcePodSpecPlugins, p)
+		}
 		if p, ok := plugin.(framework.CustomValidationPlugin); ok {
 			f.customValidationPlugins = append(f.customValidationPlugins, p)
 		}
 		if p, ok := plugin.(framework.WatchExtensionPlugin); ok {
 			f.watchExtensionPlugins = append(f.watchExtensionPlugins, p)
 		}
-		if p, ok := plugin.(framework.PodNetworkPlugin); ok {
-			f.podNetworkPlugins = append(f.podNetworkPlugins, p)
+		if p, ok := plugin.(framework.PreComponentBuilderPlugin); ok {
+			f.preComponentBuilderPlugins = append(f.preComponentBuilderPlugins, p)
 		}
 		if p, ok := plugin.(framework.ComponentBuilderPlugin); ok {
 			f.componentBuilderPlugins = append(f.componentBuilderPlugins, p)
@@ -91,6 +95,8 @@ func New(ctx context.Context, c client.Client, r fwkplugins.Registry, indexer cl
 	return f, nil
 }
 
+// RunEnforceMLPolicyPlugins configures the ML framework specific parameters declared in
+// the runtime `.spec.mlPolicy` on the Info object.
 func (f *Framework) RunEnforceMLPolicyPlugins(info *runtime.Info, trainJob *trainer.TrainJob) error {
 	for _, plugin := range f.enforceMLPlugins {
 		if err := plugin.EnforceMLPolicy(info, trainJob); err != nil {
@@ -100,9 +106,26 @@ func (f *Framework) RunEnforceMLPolicyPlugins(info *runtime.Info, trainJob *trai
 	return nil
 }
 
+// RunEnforcePodGroupPolicyPlugins configures the gang-scheduling parameters declared in
+// the runtime `.spec.podGroupPolicy` on the Info object. It must run after
+// RunEnforceMLPolicyPlugins, which can still adjust the PodSet counts.
 func (f *Framework) RunEnforcePodGroupPolicyPlugins(info *runtime.Info, trainJob *trainer.TrainJob) error {
 	for _, plugin := range f.enforcePodGroupPolicyPlugins {
 		if err := plugin.EnforcePodGroupPolicy(info, trainJob); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RunEnforcePodSpecPlugins mutates the PodSpec of the Info PodSets.
+// It must run after RunEnforceMLPolicyPlugins and RunEnforcePodGroupPolicyPlugins.
+func (f *Framework) RunEnforcePodSpecPlugins(info *runtime.Info, trainJob *trainer.TrainJob) error {
+	if info == nil {
+		return nil
+	}
+	for _, plugin := range f.enforcePodSpecPlugins {
+		if err := plugin.EnforcePodSpec(info.TemplateSpec.PodSets, trainJob); err != nil {
 			return err
 		}
 	}
@@ -124,21 +147,20 @@ func (f *Framework) RunCustomValidationPlugins(ctx context.Context, info *runtim
 	return aggregatedWarnings, aggregatedErrors
 }
 
-func (f *Framework) RunPodNetworkPlugins(info *runtime.Info, trainJob *trainer.TrainJob) error {
-	for _, plugin := range f.podNetworkPlugins {
-		if err := plugin.IdentifyPodNetwork(info, trainJob); err != nil {
+// RunPreComponentBuilderPlugins consolidates the Info object with the concrete runtime
+// template. It must complete before RunComponentBuilderPlugins materializes any object.
+func (f *Framework) RunPreComponentBuilderPlugins(info *runtime.Info, trainJob *trainer.TrainJob) error {
+	for _, plugin := range f.preComponentBuilderPlugins {
+		if err := plugin.PreBuildSync(info, trainJob); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
+// RunComponentBuilderPlugins materializes the Kubernetes objects for a TrainJob from the
+// consolidated Info object. It must run after RunPreComponentBuilderPlugins.
 func (f *Framework) RunComponentBuilderPlugins(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
-	for _, plugin := range f.componentBuilderPlugins {
-		if err := plugin.SyncParallelCount(info); err != nil {
-			return nil, err
-		}
-	}
 	var objs []apiruntime.ApplyConfiguration
 	for _, plugin := range f.componentBuilderPlugins {
 		components, err := plugin.Build(ctx, info, trainJob)

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -118,7 +118,7 @@ func TestNew(t *testing.T) {
 					&jobset.JobSet{},
 					&mpi.MPI{},
 				},
-				podNetworkPlugins: []framework.PodNetworkPlugin{
+				preComponentBuilderPlugins: []framework.PreComponentBuilderPlugin{
 					&jobset.JobSet{},
 				},
 				componentBuilderPlugins: []framework.ComponentBuilderPlugin{
@@ -2566,7 +2566,7 @@ func TestTrainJobStatusPlugins(t *testing.T) {
 	}
 }
 
-func TestPodNetworkPlugins(t *testing.T) {
+func TestRunPreComponentBuilderPlugins(t *testing.T) {
 	cases := map[string]struct {
 		registry        fwkplugins.Registry
 		runtimeInfo     *runtime.Info
@@ -2574,7 +2574,7 @@ func TestPodNetworkPlugins(t *testing.T) {
 		wantError       error
 		wantRuntimeInfo *runtime.Info
 	}{
-		"Pod network is calculated by jobset plugin": {
+		"Pod network and parallel count are synced by jobset plugin": {
 			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
 				Obj(),
 			registry: fwkplugins.NewRegistry(),
@@ -2633,8 +2633,8 @@ func TestPodNetworkPlugins(t *testing.T) {
 								WithName(constants.Node).
 								WithTemplate(batchv1ac.JobTemplateSpec().
 									WithSpec(batchv1ac.JobSpec().
-										WithParallelism(1).
-										WithCompletions(1).
+										WithParallelism(2).
+										WithCompletions(2).
 										WithTemplate(corev1ac.PodTemplateSpec().
 											WithSpec(corev1ac.PodSpec().
 												WithContainers(
@@ -2666,7 +2666,7 @@ func TestPodNetworkPlugins(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = fwk.RunPodNetworkPlugins(tc.runtimeInfo, tc.trainJob)
+			err = fwk.RunPreComponentBuilderPlugins(tc.runtimeInfo, tc.trainJob)
 			if diff := cmp.Diff(tc.wantError, err); len(diff) != 0 {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}

--- a/pkg/runtime/framework/interface.go
+++ b/pkg/runtime/framework/interface.go
@@ -41,25 +41,40 @@ type WatchExtensionPlugin interface {
 	ReconcilerBuilders() []runtime.ReconcilerBuilder
 }
 
+// EnforcePodGroupPolicyPlugin configures gang-scheduling parameters declared in the
+// runtime `.spec.podGroupPolicy` on the Info object.
 type EnforcePodGroupPolicyPlugin interface {
 	Plugin
 	EnforcePodGroupPolicy(info *runtime.Info, trainJob *trainer.TrainJob) error
 }
 
+// EnforceMLPolicyPlugin configures the ML framework specific parameters declared in
+// the runtime `.spec.mlPolicy` on the Info object.
 type EnforceMLPolicyPlugin interface {
 	Plugin
 	EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) error
 }
 
-type PodNetworkPlugin interface {
+// EnforcePodSpecPlugin mutates the PodSpec of a TrainJob's PodSets for
+// concerns that are not driven by MLPolicy or PodGroupPolicy APIs.
+type EnforcePodSpecPlugin interface {
 	Plugin
-	IdentifyPodNetwork(info *runtime.Info, trainJob *trainer.TrainJob) error
+	EnforcePodSpec(podSets runtime.PodSets, trainJob *trainer.TrainJob) error
 }
 
+// PreComponentBuilderPlugin consolidates the Info object with the concrete runtime
+// template before any component is materialized. Only the plugin that owns the runtime
+// template (e.g. JobSet) can implement it, since consolidation requires knowledge of the
+// template shape.
+type PreComponentBuilderPlugin interface {
+	Plugin
+	PreBuildSync(info *runtime.Info, trainJob *trainer.TrainJob) error
+}
+
+// ComponentBuilderPlugin materializes the Kubernetes objects for a TrainJob from the
+// consolidated Info object.
 type ComponentBuilderPlugin interface {
 	Plugin
-	// SyncParallelCount propagates PodSets.Count into template-level Parallelism/Completions.
-	SyncParallelCount(info *runtime.Info) error
 	Build(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error)
 }
 

--- a/pkg/runtime/framework/plugins/coscheduling/coscheduling.go
+++ b/pkg/runtime/framework/plugins/coscheduling/coscheduling.go
@@ -90,8 +90,6 @@ func (c *CoScheduling) EnforcePodGroupPolicy(info *runtime.Info, trainJob *train
 	return nil
 }
 
-func (c *CoScheduling) SyncParallelCount(_ *runtime.Info) error { return nil }
-
 func (c *CoScheduling) Build(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
 	if info == nil || info.RuntimePolicy.PodGroupPolicy == nil || info.RuntimePolicy.PodGroupPolicy.Coscheduling == nil || trainJob == nil {
 		return nil, nil

--- a/pkg/runtime/framework/plugins/flux/flux.go
+++ b/pkg/runtime/framework/plugins/flux/flux.go
@@ -207,8 +207,6 @@ func (f *Flux) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) e
 	return nil
 }
 
-func (f *Flux) SyncParallelCount(_ *runtime.Info) error { return nil }
-
 // Build creates the extra config map (configuration) and curve secret for Flux.
 func (f *Flux) Build(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
 

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -66,7 +66,7 @@ type JobSet struct {
 }
 
 var _ framework.WatchExtensionPlugin = (*JobSet)(nil)
-var _ framework.PodNetworkPlugin = (*JobSet)(nil)
+var _ framework.PreComponentBuilderPlugin = (*JobSet)(nil)
 var _ framework.ComponentBuilderPlugin = (*JobSet)(nil)
 var _ framework.TrainJobStatusPlugin = (*JobSet)(nil)
 var _ framework.CustomValidationPlugin = (*JobSet)(nil)
@@ -270,7 +270,18 @@ func (j *JobSet) ReconcilerBuilders() []runtime.ReconcilerBuilder {
 	}
 }
 
-func (j *JobSet) IdentifyPodNetwork(info *runtime.Info, trainJob *trainer.TrainJob) error {
+// PreBuildSync consolidates the Info object with the JobSet template before any
+// component is materialized.
+func (j *JobSet) PreBuildSync(info *runtime.Info, trainJob *trainer.TrainJob) error {
+	if err := j.SyncPodNetwork(info, trainJob); err != nil {
+		return err
+	}
+	return j.SyncParallelCount(info)
+}
+
+// SyncPodNetwork identifies the Pod-to-Pod communication network endpoints for each Pod
+// and stores them in PodSets.Endpoints.
+func (j *JobSet) SyncPodNetwork(info *runtime.Info, trainJob *trainer.TrainJob) error {
 	if info == nil || trainJob == nil {
 		return nil
 	}
@@ -299,6 +310,7 @@ func (j *JobSet) IdentifyPodNetwork(info *runtime.Info, trainJob *trainer.TrainJ
 	return nil
 }
 
+// SyncParallelCount propagates PodSets.Count into template-level Parallelism/Completions.
 func (j *JobSet) SyncParallelCount(info *runtime.Info) error {
 	if info == nil {
 		return nil

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -273,15 +273,15 @@ func (j *JobSet) ReconcilerBuilders() []runtime.ReconcilerBuilder {
 // PreBuildSync consolidates the Info object with the JobSet template before any
 // component is materialized.
 func (j *JobSet) PreBuildSync(info *runtime.Info, trainJob *trainer.TrainJob) error {
-	if err := j.SyncPodNetwork(info, trainJob); err != nil {
+	if err := j.syncPodNetwork(info, trainJob); err != nil {
 		return err
 	}
-	return j.SyncParallelCount(info)
+	return j.syncParallelCount(info)
 }
 
 // SyncPodNetwork identifies the Pod-to-Pod communication network endpoints for each Pod
 // and stores them in PodSets.Endpoints.
-func (j *JobSet) SyncPodNetwork(info *runtime.Info, trainJob *trainer.TrainJob) error {
+func (j *JobSet) syncPodNetwork(info *runtime.Info, trainJob *trainer.TrainJob) error {
 	if info == nil || trainJob == nil {
 		return nil
 	}
@@ -311,7 +311,7 @@ func (j *JobSet) SyncPodNetwork(info *runtime.Info, trainJob *trainer.TrainJob) 
 }
 
 // SyncParallelCount propagates PodSets.Count into template-level Parallelism/Completions.
-func (j *JobSet) SyncParallelCount(info *runtime.Info) error {
+func (j *JobSet) syncParallelCount(info *runtime.Info) error {
 	if info == nil {
 		return nil
 	}

--- a/pkg/runtime/framework/plugins/jobset/jobset_test.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset_test.go
@@ -187,6 +187,7 @@ func TestJobSet(t *testing.T) {
 								WithTemplate(batchv1ac.JobTemplateSpec().
 									WithSpec(batchv1ac.JobSpec().
 										WithParallelism(2).
+										WithCompletions(2).
 										WithTemplate(corev1ac.PodTemplateSpec().
 											WithSpec(corev1ac.PodSpec().
 												WithContainers(
@@ -322,7 +323,7 @@ func TestJobSet(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to initialize JobSet plugin: %v", err)
 			}
-			err = p.(framework.PodNetworkPlugin).IdentifyPodNetwork(tc.info, tc.trainJob)
+			err = p.(framework.PreComponentBuilderPlugin).PreBuildSync(tc.info, tc.trainJob)
 			if diff := cmp.Diff(tc.wantError, err, cmpopts.EquateErrors()); len(diff) != 0 {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}
@@ -331,7 +332,7 @@ func TestJobSet(t *testing.T) {
 				cmpopts.SortMaps(func(a, b string) bool { return a < b }),
 				utiltesting.PodSetEndpointsCmpOpts,
 			); len(diff) != 0 {
-				t.Errorf("Unexpected Info from IdentifyPodNetwork (-want,+got):\n%s", diff)
+				t.Errorf("Unexpected Info from PreBuildSync (-want,+got):\n%s", diff)
 			}
 		})
 	}
@@ -2744,7 +2745,7 @@ func TestSyncParallelCount(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to initialize JobSet plugin: %v", err)
 			}
-			err = p.(framework.ComponentBuilderPlugin).SyncParallelCount(tc.info)
+			err = p.(*JobSet).SyncParallelCount(tc.info)
 			if diff := cmp.Diff(tc.wantError, err, cmpopts.EquateErrors()); len(diff) != 0 {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}

--- a/pkg/runtime/framework/plugins/jobset/jobset_test.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset_test.go
@@ -311,6 +311,172 @@ func TestJobSet(t *testing.T) {
 				},
 			},
 		},
+		"parallelism and completions are synced for multiple podSets matched by replicatedJob name": {
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "trainJob").
+				Obj(),
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:  constants.Launcher,
+							Count: ptr.To[int32](1),
+						},
+						{
+							Name:  constants.Node,
+							Count: ptr.To[int32](5),
+						},
+					},
+					ObjApply: jobsetv1alpha2ac.JobSetSpec().
+						WithReplicatedJobs(
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithName(constants.Launcher).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(1).
+										WithCompletions(1).
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithName(constants.Node).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(2).
+										WithCompletions(2).
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+						),
+				},
+			},
+			wantInfo: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:  constants.Launcher,
+							Count: ptr.To[int32](1),
+							Endpoints: func(yield func(string) bool) {
+								yield("trainJob-launcher-0-0.trainJob")
+							},
+						},
+						{
+							Name:  constants.Node,
+							Count: ptr.To[int32](5),
+							Endpoints: func(yield func(string) bool) {
+								yield("trainJob-node-0-0.trainJob")
+								yield("trainJob-node-0-1.trainJob")
+								yield("trainJob-node-0-2.trainJob")
+								yield("trainJob-node-0-3.trainJob")
+								yield("trainJob-node-0-4.trainJob")
+							},
+						},
+					},
+					ObjApply: jobsetv1alpha2ac.JobSetSpec().
+						WithReplicatedJobs(
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithName(constants.Launcher).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(1).
+										WithCompletions(1).
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithName(constants.Node).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(5).
+										WithCompletions(5).
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+						),
+				},
+			},
+		},
+		"podSet with no matching replicatedJob name is skipped": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:  "non-existent",
+							Count: ptr.To[int32](3),
+						},
+					},
+					ObjApply: jobsetv1alpha2ac.JobSetSpec().
+						WithReplicatedJobs(
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithName(constants.Node).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(1).
+										WithCompletions(1).
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+						),
+				},
+			},
+			wantInfo: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:  "non-existent",
+							Count: ptr.To[int32](3),
+						},
+					},
+					ObjApply: jobsetv1alpha2ac.JobSetSpec().
+						WithReplicatedJobs(
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithName(constants.Node).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithParallelism(1).
+										WithCompletions(1).
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+						),
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -2429,331 +2595,6 @@ func TestBuild(t *testing.T) {
 				}),
 			); len(diff) != 0 {
 				t.Errorf("Unexpected objects from Build (-want, +got): %s", diff)
-			}
-		})
-	}
-}
-
-func TestSyncParallelCount(t *testing.T) {
-	cases := map[string]struct {
-		info      *runtime.Info
-		wantInfo  *runtime.Info
-		wantError error
-	}{
-		"no action when info is nil": {},
-		"no action when template.spec is not JobSet": {
-			info: &runtime.Info{
-				TemplateSpec: runtime.TemplateSpec{
-					PodSets: []runtime.PodSet{
-						{
-							Name:  constants.Node,
-							Count: ptr.To[int32](3),
-						},
-					},
-					ObjApply: batchv1ac.JobSpec(),
-				},
-			},
-			wantInfo: &runtime.Info{
-				TemplateSpec: runtime.TemplateSpec{
-					PodSets: []runtime.PodSet{
-						{
-							Name:  constants.Node,
-							Count: ptr.To[int32](3),
-						},
-					},
-					ObjApply: batchv1ac.JobSpec(),
-				},
-			},
-		},
-		"parallelism and completions are synced for matching replicatedJob by name": {
-			info: &runtime.Info{
-				TemplateSpec: runtime.TemplateSpec{
-					PodSets: []runtime.PodSet{
-						{
-							Name:  constants.Node,
-							Count: ptr.To[int32](4),
-						},
-					},
-					ObjApply: jobsetv1alpha2ac.JobSetSpec().
-						WithReplicatedJobs(
-							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.Node).
-								WithTemplate(batchv1ac.JobTemplateSpec().
-									WithSpec(batchv1ac.JobSpec().
-										WithParallelism(1).
-										WithCompletions(1).
-										WithTemplate(corev1ac.PodTemplateSpec().
-											WithSpec(corev1ac.PodSpec().
-												WithContainers(
-													corev1ac.Container().WithName(constants.Node),
-												),
-											),
-										),
-									),
-								),
-						),
-				},
-			},
-			wantInfo: &runtime.Info{
-				TemplateSpec: runtime.TemplateSpec{
-					PodSets: []runtime.PodSet{
-						{
-							Name:  constants.Node,
-							Count: ptr.To[int32](4),
-						},
-					},
-					ObjApply: jobsetv1alpha2ac.JobSetSpec().
-						WithReplicatedJobs(
-							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.Node).
-								WithTemplate(batchv1ac.JobTemplateSpec().
-									WithSpec(batchv1ac.JobSpec().
-										WithParallelism(4).
-										WithCompletions(4).
-										WithTemplate(corev1ac.PodTemplateSpec().
-											WithSpec(corev1ac.PodSpec().
-												WithContainers(
-													corev1ac.Container().WithName(constants.Node),
-												),
-											),
-										),
-									),
-								),
-						),
-				},
-			},
-		},
-		"multiple podSets synced to corresponding replicatedJobs": {
-			info: &runtime.Info{
-				TemplateSpec: runtime.TemplateSpec{
-					PodSets: []runtime.PodSet{
-						{
-							Name:  constants.Launcher,
-							Count: ptr.To[int32](1),
-						},
-						{
-							Name:  constants.Node,
-							Count: ptr.To[int32](5),
-						},
-					},
-					ObjApply: jobsetv1alpha2ac.JobSetSpec().
-						WithReplicatedJobs(
-							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.Launcher).
-								WithTemplate(batchv1ac.JobTemplateSpec().
-									WithSpec(batchv1ac.JobSpec().
-										WithParallelism(1).
-										WithCompletions(1).
-										WithTemplate(corev1ac.PodTemplateSpec().
-											WithSpec(corev1ac.PodSpec().
-												WithContainers(
-													corev1ac.Container().WithName(constants.Node),
-												),
-											),
-										),
-									),
-								),
-							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.Node).
-								WithTemplate(batchv1ac.JobTemplateSpec().
-									WithSpec(batchv1ac.JobSpec().
-										WithParallelism(2).
-										WithCompletions(2).
-										WithTemplate(corev1ac.PodTemplateSpec().
-											WithSpec(corev1ac.PodSpec().
-												WithContainers(
-													corev1ac.Container().WithName(constants.Node),
-												),
-											),
-										),
-									),
-								),
-						),
-				},
-			},
-			wantInfo: &runtime.Info{
-				TemplateSpec: runtime.TemplateSpec{
-					PodSets: []runtime.PodSet{
-						{
-							Name:  constants.Launcher,
-							Count: ptr.To[int32](1),
-						},
-						{
-							Name:  constants.Node,
-							Count: ptr.To[int32](5),
-						},
-					},
-					ObjApply: jobsetv1alpha2ac.JobSetSpec().
-						WithReplicatedJobs(
-							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.Launcher).
-								WithTemplate(batchv1ac.JobTemplateSpec().
-									WithSpec(batchv1ac.JobSpec().
-										WithParallelism(1).
-										WithCompletions(1).
-										WithTemplate(corev1ac.PodTemplateSpec().
-											WithSpec(corev1ac.PodSpec().
-												WithContainers(
-													corev1ac.Container().WithName(constants.Node),
-												),
-											),
-										),
-									),
-								),
-							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.Node).
-								WithTemplate(batchv1ac.JobTemplateSpec().
-									WithSpec(batchv1ac.JobSpec().
-										WithParallelism(5).
-										WithCompletions(5).
-										WithTemplate(corev1ac.PodTemplateSpec().
-											WithSpec(corev1ac.PodSpec().
-												WithContainers(
-													corev1ac.Container().WithName(constants.Node),
-												),
-											),
-										),
-									),
-								),
-						),
-				},
-			},
-		},
-		"podSet with nil count is skipped": {
-			info: &runtime.Info{
-				TemplateSpec: runtime.TemplateSpec{
-					PodSets: []runtime.PodSet{
-						{
-							Name: constants.Node,
-						},
-					},
-					ObjApply: jobsetv1alpha2ac.JobSetSpec().
-						WithReplicatedJobs(
-							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.Node).
-								WithTemplate(batchv1ac.JobTemplateSpec().
-									WithSpec(batchv1ac.JobSpec().
-										WithParallelism(2).
-										WithCompletions(2).
-										WithTemplate(corev1ac.PodTemplateSpec().
-											WithSpec(corev1ac.PodSpec().
-												WithContainers(
-													corev1ac.Container().WithName(constants.Node),
-												),
-											),
-										),
-									),
-								),
-						),
-				},
-			},
-			wantInfo: &runtime.Info{
-				TemplateSpec: runtime.TemplateSpec{
-					PodSets: []runtime.PodSet{
-						{
-							Name: constants.Node,
-						},
-					},
-					ObjApply: jobsetv1alpha2ac.JobSetSpec().
-						WithReplicatedJobs(
-							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.Node).
-								WithTemplate(batchv1ac.JobTemplateSpec().
-									WithSpec(batchv1ac.JobSpec().
-										WithParallelism(2).
-										WithCompletions(2).
-										WithTemplate(corev1ac.PodTemplateSpec().
-											WithSpec(corev1ac.PodSpec().
-												WithContainers(
-													corev1ac.Container().WithName(constants.Node),
-												),
-											),
-										),
-									),
-								),
-						),
-				},
-			},
-		},
-		"podSet with no matching replicatedJob name is skipped": {
-			info: &runtime.Info{
-				TemplateSpec: runtime.TemplateSpec{
-					PodSets: []runtime.PodSet{
-						{
-							Name:  "non-existent",
-							Count: ptr.To[int32](3),
-						},
-					},
-					ObjApply: jobsetv1alpha2ac.JobSetSpec().
-						WithReplicatedJobs(
-							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.Node).
-								WithTemplate(batchv1ac.JobTemplateSpec().
-									WithSpec(batchv1ac.JobSpec().
-										WithParallelism(1).
-										WithCompletions(1).
-										WithTemplate(corev1ac.PodTemplateSpec().
-											WithSpec(corev1ac.PodSpec().
-												WithContainers(
-													corev1ac.Container().WithName(constants.Node),
-												),
-											),
-										),
-									),
-								),
-						),
-				},
-			},
-			wantInfo: &runtime.Info{
-				TemplateSpec: runtime.TemplateSpec{
-					PodSets: []runtime.PodSet{
-						{
-							Name:  "non-existent",
-							Count: ptr.To[int32](3),
-						},
-					},
-					ObjApply: jobsetv1alpha2ac.JobSetSpec().
-						WithReplicatedJobs(
-							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.Node).
-								WithTemplate(batchv1ac.JobTemplateSpec().
-									WithSpec(batchv1ac.JobSpec().
-										WithParallelism(1).
-										WithCompletions(1).
-										WithTemplate(corev1ac.PodTemplateSpec().
-											WithSpec(corev1ac.PodSpec().
-												WithContainers(
-													corev1ac.Container().WithName(constants.Node),
-												),
-											),
-										),
-									),
-								),
-						),
-				},
-			},
-		},
-	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
-			var cancel func()
-			ctx, cancel = context.WithCancel(ctx)
-			t.Cleanup(cancel)
-			cli := utiltesting.NewClientBuilder().Build()
-			p, err := New(ctx, cli, nil, nil)
-			if err != nil {
-				t.Fatalf("Failed to initialize JobSet plugin: %v", err)
-			}
-			err = p.(*JobSet).SyncParallelCount(tc.info)
-			if diff := cmp.Diff(tc.wantError, err, cmpopts.EquateErrors()); len(diff) != 0 {
-				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
-			}
-			if diff := cmp.Diff(tc.wantInfo, tc.info,
-				cmpopts.SortSlices(func(a, b string) bool { return a < b }),
-				cmpopts.SortMaps(func(a, b string) bool { return a < b }),
-			); len(diff) != 0 {
-				t.Errorf("Unexpected Info from SyncParallelCount (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/runtime/framework/plugins/mpi/mpi.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi.go
@@ -253,8 +253,6 @@ func (m *MPI) ReconcilerBuilders() []runtime.ReconcilerBuilder {
 	}
 }
 
-func (m *MPI) SyncParallelCount(_ *runtime.Info) error { return nil }
-
 func (m *MPI) Build(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
 	if info == nil || info.RuntimePolicy.MLPolicySource == nil || info.RuntimePolicy.MLPolicySource.MPI == nil {
 		return nil, nil

--- a/pkg/runtime/framework/plugins/trainjobstatus/trainjobstatus.go
+++ b/pkg/runtime/framework/plugins/trainjobstatus/trainjobstatus.go
@@ -63,7 +63,7 @@ type Status struct {
 }
 
 var _ framework.ComponentBuilderPlugin = (*Status)(nil)
-var _ framework.EnforceMLPolicyPlugin = (*Status)(nil)
+var _ framework.EnforcePodSpecPlugin = (*Status)(nil)
 
 func New(_ context.Context, c client.Client, _ client.FieldIndexer, cfg *configapi.Configuration) (framework.Plugin, error) {
 	return &Status{client: c, cfg: cfg}, nil
@@ -73,8 +73,11 @@ func (p *Status) Name() string {
 	return Name
 }
 
-func (p *Status) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) error {
-	if info == nil || trainJob == nil {
+// EnforcePodSpec injects the status server endpoint, its CA certificate, and the
+// projected service account token into every trainer container, so the instrumented
+// runtime can report the TrainJob status back to the control plane.
+func (p *Status) EnforcePodSpec(podSets runtime.PodSets, trainJob *trainer.TrainJob) error {
+	if podSets == nil || trainJob == nil {
 		return nil
 	}
 
@@ -86,7 +89,7 @@ func (p *Status) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob)
 	volume := createTokenVolume(trainJob)
 
 	// Inject into all trainer containers
-	trainerPS := info.FindPodSetByAncestor(constants.AncestorTrainer)
+	trainerPS := podSets.FindByAncestor(constants.AncestorTrainer)
 	if trainerPS != nil {
 		for i := range trainerPS.Containers {
 			apply.UpsertEnvVars(&trainerPS.Containers[i].Env, envVars...)
@@ -97,8 +100,6 @@ func (p *Status) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob)
 
 	return nil
 }
-
-func (p *Status) SyncParallelCount(_ *runtime.Info) error { return nil }
 
 func (p *Status) Build(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
 	if info == nil || trainJob == nil {

--- a/pkg/runtime/framework/plugins/trainjobstatus/trainjobstatus_test.go
+++ b/pkg/runtime/framework/plugins/trainjobstatus/trainjobstatus_test.go
@@ -40,7 +40,7 @@ import (
 	utiltesting "github.com/kubeflow/trainer/v2/pkg/util/testing"
 )
 
-func TestEnforceMLPolicy(t *testing.T) {
+func TestEnforcePodSpec(t *testing.T) {
 	cases := map[string]struct {
 		info      *runtime.Info
 		trainJob  *trainer.TrainJob
@@ -284,16 +284,16 @@ func TestEnforceMLPolicy(t *testing.T) {
 				t.Fatalf("Failed to initialize Status plugin: %v", err)
 			}
 
-			err = p.(framework.EnforceMLPolicyPlugin).EnforceMLPolicy(tc.info, tc.trainJob)
+			err = p.(framework.EnforcePodSpecPlugin).EnforcePodSpec(tc.info.TemplateSpec.PodSets, tc.trainJob)
 			if diff := gocmp.Diff(tc.wantError, err, cmpopts.EquateErrors()); len(diff) != 0 {
-				t.Errorf("Unexpected error from EnforceMLPolicy (-want, +got): %s", diff)
+				t.Errorf("Unexpected error from EnforcePodSpec (-want, +got): %s", diff)
 			}
 
 			if diff := gocmp.Diff(tc.wantInfo, tc.info,
 				cmpopts.SortSlices(func(a, b string) bool { return a < b }),
 				cmpopts.SortMaps(func(a, b int) bool { return a < b }),
 			); len(diff) != 0 {
-				t.Errorf("Unexpected info from EnforceMLPolicy (-want, +got): %s", diff)
+				t.Errorf("Unexpected info from EnforcePodSpec (-want, +got): %s", diff)
 			}
 		})
 	}

--- a/pkg/runtime/framework/plugins/volcano/volcano.go
+++ b/pkg/runtime/framework/plugins/volcano/volcano.go
@@ -138,8 +138,6 @@ func (v *Volcano) EnforcePodGroupPolicy(info *runtime.Info, trainJob *trainer.Tr
 	return nil
 }
 
-func (v *Volcano) SyncParallelCount(_ *runtime.Info) error { return nil }
-
 func (v *Volcano) Build(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
 	if info == nil || info.RuntimePolicy.PodGroupPolicy == nil || info.RuntimePolicy.PodGroupPolicy.Volcano == nil || trainJob == nil {
 		return nil, nil

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -42,7 +42,7 @@ type Info struct {
 	// Scheduler parameters to add to the RuntimeJobTemplate.
 	Scheduler *Scheduler
 	// TemplateSpec is TrainingRuntime Template object.
-	// ObjApply podSpecs and this PodSets should be kept in sync by PreComponentBuilderPlugin.SyncParallelCount.
+	// ObjApply PodSpecs and PodSets should be kept in sync by PreComponentBuilderPlugin.PreBuildSync.
 	TemplateSpec TemplateSpec
 }
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -42,7 +42,7 @@ type Info struct {
 	// Scheduler parameters to add to the RuntimeJobTemplate.
 	Scheduler *Scheduler
 	// TemplateSpec is TrainingRuntime Template object.
-	// ObjApply podSpecs and this PodSets should be kept in sync by ComponentBuilderPlugin.SyncParallelCount.
+	// ObjApply podSpecs and this PodSets should be kept in sync by PreComponentBuilderPlugin.SyncParallelCount.
 	TemplateSpec TemplateSpec
 }
 
@@ -57,8 +57,11 @@ type TemplateSpec struct {
 	ObjApply any
 	// PodSets is a set of Pod extracted from ObjApply.
 	// This is abstract concept to represent multiple PodSpec as a unit.
-	PodSets []PodSet
+	PodSets PodSets
 }
+
+// PodSets is the collection of PodSet extracted from the runtime template.
+type PodSets []PodSet
 
 type PodSet struct {
 	// PodSet name is the name to identify PodSpec.
@@ -214,10 +217,7 @@ func (i *Info) FindContainerByPodSetAncestorContainerName(psAncestor, containerN
 }
 
 func (i *Info) FindPodSetByAncestor(ancestor string) *PodSet {
-	if idx := slices.IndexFunc(i.TemplateSpec.PodSets, func(ps PodSet) bool { return ptr.Equal(ps.Ancestor, &ancestor) }); idx != -1 {
-		return &i.TemplateSpec.PodSets[idx]
-	}
-	return nil
+	return i.TemplateSpec.PodSets.FindByAncestor(ancestor)
 }
 
 func (i *Info) FindPodSetByName(psName string) *PodSet {
@@ -239,6 +239,15 @@ func (i *Info) FindContainerByPodSetName(psName, containerName string) *Containe
 	}
 	if idx := slices.IndexFunc(ps.InitContainers, func(c Container) bool { return c.Name == containerName }); idx != -1 {
 		return &ps.InitContainers[idx]
+	}
+	return nil
+}
+
+// FindByAncestor finds the PodSet built from the given
+// `trainer.kubeflow.org/trainjob-ancestor-step` label value.
+func (ps PodSets) FindByAncestor(ancestor string) *PodSet {
+	if idx := slices.IndexFunc(ps, func(p PodSet) bool { return ptr.Equal(p.Ancestor, &ancestor) }); idx != -1 {
+		return &ps[idx]
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/trainer/pull/3361, https://github.com/kubeflow/trainer/issues/3347

As we discussed, we want to introduce a few changes to our Extension Framework:
1. Add `PreComponentBuilderPlugins` to run steps which adjust Info object before the build phase activated.
2. Add `PodSpecPlugins` to enforce changes to Info object that are not driven by `PodGroupPolicy or MLPolicy` API fields.


Ref: https://youtu.be/ly_cAdpPdrc?t=1420


/assign @robert-bell @Sridhar1030 @akshaychitneni @tenzen-y @astefanutti @krishdef7