### PR TITLE
fix(api): Remove CEL immutability validations from PodSpecPatch fields

### DIFF
--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_optimizationjobs.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_optimizationjobs.yaml
@@ -2558,10 +2558,6 @@ spec:
                                                                 x-kubernetes-list-map-keys:
                                                                 - name
                                                                 x-kubernetes-list-type: map
-                                                                x-kubernetes-validations:
-                                                                - message: field is
-                                                                    immutable
-                                                                  rule: self == oldSelf
                                                               imagePullSecrets:
                                                                 description: imagePullSecrets
                                                                   patches the image
@@ -2587,10 +2583,6 @@ spec:
                                                                 x-kubernetes-list-map-keys:
                                                                 - name
                                                                 x-kubernetes-list-type: map
-                                                                x-kubernetes-validations:
-                                                                - message: field is
-                                                                    immutable
-                                                                  rule: self == oldSelf
                                                               initContainers:
                                                                 description: initContainers
                                                                   patches the init
@@ -3234,10 +3226,6 @@ spec:
                                                                 x-kubernetes-list-map-keys:
                                                                 - name
                                                                 x-kubernetes-list-type: map
-                                                                x-kubernetes-validations:
-                                                                - message: field is
-                                                                    immutable
-                                                                  rule: self == oldSelf
                                                               nodeSelector:
                                                                 additionalProperties:
                                                                   type: string
@@ -3486,10 +3474,6 @@ spec:
                                                                         type: string
                                                                     type: object
                                                                 type: object
-                                                                x-kubernetes-validations:
-                                                                - message: field is
-                                                                    immutable
-                                                                  rule: self == oldSelf
                                                               serviceAccountName:
                                                                 description: serviceAccountName
                                                                   patches the service
@@ -3498,10 +3482,6 @@ spec:
                                                                   job templates.
                                                                 maxLength: 253
                                                                 type: string
-                                                                x-kubernetes-validations:
-                                                                - message: field is
-                                                                    immutable
-                                                                  rule: self == oldSelf
                                                               terminationGracePeriodSeconds:
                                                                 description: |-
                                                                   terminationGracePeriodSeconds patches the termination grace period for Pods
@@ -3509,10 +3489,6 @@ spec:
                                                                 format: int64
                                                                 minimum: 0
                                                                 type: integer
-                                                                x-kubernetes-validations:
-                                                                - message: field is
-                                                                    immutable
-                                                                  rule: self == oldSelf
                                                               tolerations:
                                                                 description: tolerations
                                                                   patches the Pod's
@@ -5920,10 +5896,6 @@ spec:
                                                                 x-kubernetes-list-map-keys:
                                                                 - name
                                                                 x-kubernetes-list-type: map
-                                                                x-kubernetes-validations:
-                                                                - message: field is
-                                                                    immutable
-                                                                  rule: self == oldSelf
                                                             type: object
                                                         type: object
                                                     type: object

--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
@@ -2088,9 +2088,6 @@ spec:
                                                         x-kubernetes-list-map-keys:
                                                         - name
                                                         x-kubernetes-list-type: map
-                                                        x-kubernetes-validations:
-                                                        - message: field is immutable
-                                                          rule: self == oldSelf
                                                       imagePullSecrets:
                                                         description: imagePullSecrets
                                                           patches the image pull secrets
@@ -2115,9 +2112,6 @@ spec:
                                                         x-kubernetes-list-map-keys:
                                                         - name
                                                         x-kubernetes-list-type: map
-                                                        x-kubernetes-validations:
-                                                        - message: field is immutable
-                                                          rule: self == oldSelf
                                                       initContainers:
                                                         description: initContainers
                                                           patches the init containers
@@ -2632,9 +2626,6 @@ spec:
                                                         x-kubernetes-list-map-keys:
                                                         - name
                                                         x-kubernetes-list-type: map
-                                                        x-kubernetes-validations:
-                                                        - message: field is immutable
-                                                          rule: self == oldSelf
                                                       nodeSelector:
                                                         additionalProperties:
                                                           type: string
@@ -2851,9 +2842,6 @@ spec:
                                                                 type: string
                                                             type: object
                                                         type: object
-                                                        x-kubernetes-validations:
-                                                        - message: field is immutable
-                                                          rule: self == oldSelf
                                                       serviceAccountName:
                                                         description: serviceAccountName
                                                           patches the service account
@@ -2861,9 +2849,6 @@ spec:
                                                           job templates.
                                                         maxLength: 253
                                                         type: string
-                                                        x-kubernetes-validations:
-                                                        - message: field is immutable
-                                                          rule: self == oldSelf
                                                       terminationGracePeriodSeconds:
                                                         description: |-
                                                           terminationGracePeriodSeconds patches the termination grace period for Pods
@@ -2871,9 +2856,6 @@ spec:
                                                         format: int64
                                                         minimum: 0
                                                         type: integer
-                                                        x-kubernetes-validations:
-                                                        - message: field is immutable
-                                                          rule: self == oldSelf
                                                       tolerations:
                                                         description: tolerations patches
                                                           the Pod's tolerations.
@@ -4990,9 +4972,6 @@ spec:
                                                         x-kubernetes-list-map-keys:
                                                         - name
                                                         x-kubernetes-list-type: map
-                                                        x-kubernetes-validations:
-                                                        - message: field is immutable
-                                                          rule: self == oldSelf
                                                     type: object
                                                 type: object
                                             type: object

--- a/manifests/base/crds/trainer.kubeflow.org_optimizationjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_optimizationjobs.yaml
@@ -2555,10 +2555,6 @@ spec:
                                                                 x-kubernetes-list-map-keys:
                                                                 - name
                                                                 x-kubernetes-list-type: map
-                                                                x-kubernetes-validations:
-                                                                - message: field is
-                                                                    immutable
-                                                                  rule: self == oldSelf
                                                               imagePullSecrets:
                                                                 description: imagePullSecrets
                                                                   patches the image
@@ -2584,10 +2580,6 @@ spec:
                                                                 x-kubernetes-list-map-keys:
                                                                 - name
                                                                 x-kubernetes-list-type: map
-                                                                x-kubernetes-validations:
-                                                                - message: field is
-                                                                    immutable
-                                                                  rule: self == oldSelf
                                                               initContainers:
                                                                 description: initContainers
                                                                   patches the init
@@ -3231,10 +3223,6 @@ spec:
                                                                 x-kubernetes-list-map-keys:
                                                                 - name
                                                                 x-kubernetes-list-type: map
-                                                                x-kubernetes-validations:
-                                                                - message: field is
-                                                                    immutable
-                                                                  rule: self == oldSelf
                                                               nodeSelector:
                                                                 additionalProperties:
                                                                   type: string
@@ -3483,10 +3471,6 @@ spec:
                                                                         type: string
                                                                     type: object
                                                                 type: object
-                                                                x-kubernetes-validations:
-                                                                - message: field is
-                                                                    immutable
-                                                                  rule: self == oldSelf
                                                               serviceAccountName:
                                                                 description: serviceAccountName
                                                                   patches the service
@@ -3495,10 +3479,6 @@ spec:
                                                                   job templates.
                                                                 maxLength: 253
                                                                 type: string
-                                                                x-kubernetes-validations:
-                                                                - message: field is
-                                                                    immutable
-                                                                  rule: self == oldSelf
                                                               terminationGracePeriodSeconds:
                                                                 description: |-
                                                                   terminationGracePeriodSeconds patches the termination grace period for Pods
@@ -3506,10 +3486,6 @@ spec:
                                                                 format: int64
                                                                 minimum: 0
                                                                 type: integer
-                                                                x-kubernetes-validations:
-                                                                - message: field is
-                                                                    immutable
-                                                                  rule: self == oldSelf
                                                               tolerations:
                                                                 description: tolerations
                                                                   patches the Pod's
@@ -5917,10 +5893,6 @@ spec:
                                                                 x-kubernetes-list-map-keys:
                                                                 - name
                                                                 x-kubernetes-list-type: map
-                                                                x-kubernetes-validations:
-                                                                - message: field is
-                                                                    immutable
-                                                                  rule: self == oldSelf
                                                             type: object
                                                         type: object
                                                     type: object

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -2085,9 +2085,6 @@ spec:
                                                         x-kubernetes-list-map-keys:
                                                         - name
                                                         x-kubernetes-list-type: map
-                                                        x-kubernetes-validations:
-                                                        - message: field is immutable
-                                                          rule: self == oldSelf
                                                       imagePullSecrets:
                                                         description: imagePullSecrets
                                                           patches the image pull secrets
@@ -2112,9 +2109,6 @@ spec:
                                                         x-kubernetes-list-map-keys:
                                                         - name
                                                         x-kubernetes-list-type: map
-                                                        x-kubernetes-validations:
-                                                        - message: field is immutable
-                                                          rule: self == oldSelf
                                                       initContainers:
                                                         description: initContainers
                                                           patches the init containers
@@ -2629,9 +2623,6 @@ spec:
                                                         x-kubernetes-list-map-keys:
                                                         - name
                                                         x-kubernetes-list-type: map
-                                                        x-kubernetes-validations:
-                                                        - message: field is immutable
-                                                          rule: self == oldSelf
                                                       nodeSelector:
                                                         additionalProperties:
                                                           type: string
@@ -2848,9 +2839,6 @@ spec:
                                                                 type: string
                                                             type: object
                                                         type: object
-                                                        x-kubernetes-validations:
-                                                        - message: field is immutable
-                                                          rule: self == oldSelf
                                                       serviceAccountName:
                                                         description: serviceAccountName
                                                           patches the service account
@@ -2858,9 +2846,6 @@ spec:
                                                           job templates.
                                                         maxLength: 253
                                                         type: string
-                                                        x-kubernetes-validations:
-                                                        - message: field is immutable
-                                                          rule: self == oldSelf
                                                       terminationGracePeriodSeconds:
                                                         description: |-
                                                           terminationGracePeriodSeconds patches the termination grace period for Pods
@@ -2868,9 +2853,6 @@ spec:
                                                         format: int64
                                                         minimum: 0
                                                         type: integer
-                                                        x-kubernetes-validations:
-                                                        - message: field is immutable
-                                                          rule: self == oldSelf
                                                       tolerations:
                                                         description: tolerations patches
                                                           the Pod's tolerations.
@@ -4987,9 +4969,6 @@ spec:
                                                         x-kubernetes-list-map-keys:
                                                         - name
                                                         x-kubernetes-list-type: map
-                                                        x-kubernetes-validations:
-                                                        - message: field is immutable
-                                                          rule: self == oldSelf
                                                     type: object
                                                 type: object
                                             type: object

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -390,7 +390,6 @@ type PodTemplatePatch struct {
 type PodSpecPatch struct {
 	// serviceAccountName patches the service account for the Pods in the target job templates.
 	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="field is immutable"
 	// +optional
 	ServiceAccountName *string `json:"serviceAccountName,omitempty"`
 
@@ -398,7 +397,6 @@ type PodSpecPatch struct {
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=128
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="field is immutable"
 	// +optional
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
 
@@ -406,7 +404,6 @@ type PodSpecPatch struct {
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=64
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="field is immutable"
 	// +optional
 	InitContainers []ContainerPatch `json:"initContainers,omitempty"`
 
@@ -414,7 +411,6 @@ type PodSpecPatch struct {
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=64
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="field is immutable"
 	// +optional
 	Containers []ContainerPatch `json:"containers,omitempty"`
 
@@ -422,13 +418,11 @@ type PodSpecPatch struct {
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=64
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="field is immutable"
 	// +optional
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// securityContext patches the Pod's security context.
 	// More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="field is immutable"
 	// +optional
 	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 
@@ -457,7 +451,6 @@ type PodSpecPatch struct {
 	// terminationGracePeriodSeconds patches the termination grace period for Pods
 	// in the target job templates.
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="field is immutable"
 	// +optional
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
 }

--- a/test/integration/webhooks/trainjob_test.go
+++ b/test/integration/webhooks/trainjob_test.go
@@ -897,11 +897,11 @@ var _ = ginkgo.Describe("TrainJob marker validations and defaulting", ginkgo.Ord
 						}).
 						Obj()
 				},
-				func(job *trainer.TrainJob) *trainer.TrainJob {
-					job.Spec.RuntimePatches[0].TrainingRuntimeSpec.Template.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(600))
-					return job
-				},
-				testingutil.BeInvalidError()),
+			func(job *trainer.TrainJob) *trainer.TrainJob {
+				job.Spec.RuntimePatches[0].TrainingRuntimeSpec.Template.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(600))
+				return job
+			},
+			testingutil.BeForbiddenError()),
 		)
 	})
 })

--- a/test/integration/webhooks/trainjob_test.go
+++ b/test/integration/webhooks/trainjob_test.go
@@ -897,11 +897,11 @@ var _ = ginkgo.Describe("TrainJob marker validations and defaulting", ginkgo.Ord
 						}).
 						Obj()
 				},
-			func(job *trainer.TrainJob) *trainer.TrainJob {
-				job.Spec.RuntimePatches[0].TrainingRuntimeSpec.Template.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(600))
-				return job
-			},
-			testingutil.BeForbiddenError()),
+				func(job *trainer.TrainJob) *trainer.TrainJob {
+					job.Spec.RuntimePatches[0].TrainingRuntimeSpec.Template.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(int64(600))
+					return job
+				},
+				testingutil.BeForbiddenError()),
 		)
 	})
 })


### PR DESCRIPTION
## What this PR does / why we need it

Removes `self == oldSelf` CRD-level CEL validation rules from 7 sub-fields inside
`PodSpecPatch`: `containers`, `volumes`, `initContainers`, `imagePullSecrets`,
`securityContext`, `serviceAccountName`, and `terminationGracePeriodSeconds`.

These CEL rules were accidentally introduced in #3309 when `PodTemplateOverrides` was
replaced with the `RuntimePatches` API. The predecessor PR #3157 had deliberately removed
CEL immutability from `PodTemplateOverrides` sub-fields, deferring enforcement to the
validating webhook (`checkRuntimePatchesImmutability`) which has suspend-state awareness.
When #3309 created the new `PodSpecPatch` type, the CEL rules were re-added without
realizing this contradicted the design decision from #3157.

### The problem

When the Kubeflow SDK creates a TrainJob with `runtimePatches` containing `containers`
(for volume mounts) and `volumes` (for PVC storage) -- the standard pattern for any
training job needing shared storage -- Kueue cannot unsuspend it after admission.

Kueue's TrainJob adapter does a full object Update to set `spec.suspend=false`. During
the API server round-trip, the `containers` array representation changes subtly (defaults
injected/normalized), causing the CRD CEL `self == oldSelf` check to fail -- even though
the content is semantically unchanged. The update is rejected before the validating webhook
can evaluate it.

The webhook fix in #3469 already allows this suspend transition, but CRD CEL validation
runs before validating webhooks in the Kubernetes admission pipeline, so the request never
reaches the webhook.

### Why this is safe

The validating webhook `checkRuntimePatchesImmutability` (fixed in #3469) already enforces
immutability correctly:
- Rejects runtimePatches changes when the TrainJob stays unsuspended (403 Forbidden)
- Allows changes during suspend state transitions (for Kueue)
- Checks JobSet activity to prevent changes while pods are running

Removing the CRD CEL rules restores the original intent from #3157 and aligns the CRD
with the webhook's suspend-aware validation logic.

## How to reproduce

Apply this TrainJob in a Kueue-managed namespace with a LocalQueue:

```yaml
apiVersion: trainer.kubeflow.org/v1alpha1
kind: TrainJob
metadata:
  name: repro-cel-bug
  labels:
    kueue.x-k8s.io/queue-name: default
spec:
  suspend: true
  runtimeRef:
    apiGroup: trainer.kubeflow.org
    kind: ClusterTrainingRuntime
    name: torch-distributed-cpu
  trainer:
    command: ["python", "-c", "import time; time.sleep(30)"]
    numNodes: 1
    resourcesPerNode:
      requests:
        cpu: "1"
        memory: "1Gi"
      limits:
        cpu: "1"
        memory: "1Gi"
  runtimePatches:
  - manager: "repro-test/sdk"
    trainingRuntimeSpec:
      template:
        spec:
          replicatedJobs:
          - name: node
            template:
              spec:
                template:
                  spec:
                    containers:
                    - name: node
                      volumeMounts:
                      - name: work
                        mountPath: /mnt/shared
                        readOnly: false 
                    volumes:
                    - name: work
                      emptyDir: {}
```

### Which issue(s) this PR fixes
Refs: #3888, #3469, #3043 Refs: kubernetes-sigs/kueue#8296


