### PR TITLE
fix(operator): keep the TrainJob Failed condition terminal

### DIFF
--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -95,10 +95,6 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// Keep track of the origin TrainJob status
 	prevTrainJob := trainJob.DeepCopy()
 
-	// Let's clear the failed condition that could have been set previously.
-	// An external change to the TrainJob spec may transition it out of the Failed state.
-	removeFailedCondition(&trainJob)
-
 	runtimeRefGK := jobruntimes.RuntimeRefToRuntimeRegistryKey(trainJob.Spec.RuntimeRef)
 	runtime, ok := r.runtimes[runtimeRefGK]
 	if !ok {
@@ -241,14 +237,6 @@ func setFailedCondition(trainJob *trainer.TrainJob, message, reason string) {
 		Reason:  reason,
 	}
 	meta.SetStatusCondition(&trainJob.Status.Conditions, newCond)
-}
-
-func removeFailedCondition(trainJob *trainer.TrainJob) {
-	cond := meta.FindStatusCondition(trainJob.Status.Conditions, trainer.TrainJobFailed)
-	if cond != nil && cond.Reason == trainer.TrainJobDeadlineExceededReason {
-		return
-	}
-	meta.RemoveStatusCondition(&trainJob.Status.Conditions, trainer.TrainJobFailed)
 }
 
 func setTrainJobStatus(ctx context.Context, runtime jobruntimes.Runtime, trainJob *trainer.TrainJob) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes `removeFailedCondition` and its call in `Reconcile`, so the controller can no longer transition a TrainJob out of `Failed`.

The condition was cleared at the top of every loop, which made an already-failed TrainJob look unfinished and caused `reconcileObjects` to recreate its JobSet.

**Which issue(s) this PR fixes**:

Fixes #3779

**Checklist:**

- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing
