### PR TITLE
fix(framework): stop Flux reconcile panic on unset trainer fields

### DIFF
--- a/pkg/runtime/framework/plugins/flux/flux.go
+++ b/pkg/runtime/framework/plugins/flux/flux.go
@@ -135,7 +135,12 @@ func (f *Flux) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) e
 	originalCmd := getOriginalCommand(trainJob, info)
 
 	// Update the command here so we wrap the original command saved earlier
-	// Also clear existing args so only the Flux entrypoint controls execution
+	// Also clear existing args so only the Flux entrypoint controls execution.
+	// The JobSet builder only propagates a command from a non-nil Trainer, so one has to
+	// exist to carry the Flux entrypoint even when the TrainJob did not set it.
+	if trainJob.Spec.Trainer == nil {
+		trainJob.Spec.Trainer = &trainer.Trainer{}
+	}
 	trainJob.Spec.Trainer.Command = []string{"/bin/bash", "/etc/flux-config/entrypoint.sh", originalCmd}
 	trainJob.Spec.Trainer.Args = nil
 
@@ -268,9 +273,11 @@ func (f *Flux) brokerSettingsFromEnvironment(trainJob *trainer.TrainJob, info *r
 
 	// TrainJob (user) gets first preference
 	// If the variable name matches one of our Flux settings, override it
-	for _, envar := range trainJob.Spec.Trainer.Env {
-		if _, ok := settings[envar.Name]; ok {
-			settings[envar.Name] = envar.Value
+	if trainJob.Spec.Trainer != nil {
+		for _, envar := range trainJob.Spec.Trainer.Env {
+			if _, ok := settings[envar.Name]; ok {
+				settings[envar.Name] = envar.Value
+			}
 		}
 	}
 	return settings
@@ -306,9 +313,11 @@ func (f *Flux) buildInitScriptConfigMap(
 	settings map[string]string,
 ) (*corev1ac.ConfigMapApplyConfiguration, error) {
 
+	numNodes := getNumNodes(info)
+
 	// The entrypoint script finishes Flux setup and executes the wrapped application
-	initScript := generateInitEntrypoint(trainJob, settings)
-	entrypointScript := f.generateFluxEntrypoint(trainJob, info)
+	initScript := generateInitEntrypoint(trainJob, settings, numNodes)
+	entrypointScript := f.generateFluxEntrypoint(trainJob, info, numNodes)
 
 	// Build the ConfigMap using the Apply Configuration pattern
 	configMapName := fmt.Sprintf("%s-flux-entrypoint", trainJob.Name)
@@ -386,8 +395,16 @@ func getOriginalCommand(trainJob *trainer.TrainJob, info *runtime.Info) string {
 	return strings.TrimSpace(fullCommand)
 }
 
+// getNumNodes returns the node count for the Flux job. The trainer PodSet already carries
+// the TrainJob's numNodes by the time the component builder plugins run, so the runtime is
+// the single source for it here.
+func getNumNodes(info *runtime.Info) int32 {
+	trainerPS := info.FindPodSetByAncestor(constants.AncestorTrainer)
+	return ptr.Deref(ptr.Deref(trainerPS, runtime.PodSet{}).Count, 1)
+}
+
 // generateFluxEntrypoint generates the flux entrypoint to prepare the view and run the job
-func (f *Flux) generateFluxEntrypoint(trainJob *trainer.TrainJob, info *runtime.Info) string {
+func (f *Flux) generateFluxEntrypoint(trainJob *trainer.TrainJob, info *runtime.Info, numNodes int32) string {
 	mainHost := fmt.Sprintf("%s-%s-0-0", trainJob.Name, constants.Node)
 
 	// Derive number of tasks
@@ -396,13 +413,12 @@ func (f *Flux) generateFluxEntrypoint(trainJob *trainer.TrainJob, info *runtime.
 	var tasks int32
 	var flags string
 
-	nodes := *trainJob.Spec.Trainer.NumNodes
-	if trainJob.Spec.Trainer.NumProcPerNode != nil {
-		tasks = *trainJob.Spec.Trainer.NumProcPerNode
+	if jobTrainer := trainJob.Spec.Trainer; jobTrainer != nil && jobTrainer.NumProcPerNode != nil {
+		tasks = *jobTrainer.NumProcPerNode
 	} else {
 		tasks = *info.RuntimePolicy.MLPolicySource.Flux.NumProcPerNode
 	}
-	flags = fmt.Sprintf("-N %d -n %d", nodes, tasks*nodes)
+	flags = fmt.Sprintf("-N %d -n %d", numNodes, tasks*numNodes)
 
 	// Derive number of GPUs from resources. In Flux, -g is --gpus-per-task
 	resourcesPerNode := ptr.Deref(runtime.ExtractResourcePerNodeFromRuntime(info), corev1.ResourceRequirements{})
@@ -427,6 +443,7 @@ func (f *Flux) generateFluxEntrypoint(trainJob *trainer.TrainJob, info *runtime.
 func generateInitEntrypoint(
 	trainJob *trainer.TrainJob,
 	settings map[string]string,
+	numNodes int32,
 ) string {
 
 	// fluxRoot for the view is in /opt/view/lib
@@ -434,11 +451,9 @@ func generateInitEntrypoint(
 	// github.com:converged-computing/flux-views.git
 	fluxRoot := "/opt/view"
 	mainHost := fmt.Sprintf("%s-0", trainJob.Name)
-	size := *trainJob.Spec.Trainer.NumNodes
 
 	// Generate hostlists. The hostname (prefix) is the trainJob Name
-	// We need the initial jobset size, and container command	size := *trainJob.Spec.Trainer.NumNodes
-	hosts := generateHostlist(trainJob.Name, size)
+	hosts := generateHostlist(trainJob.Name, numNodes)
 	brokerConfig := generateBrokerConfig(trainJob, hosts, settings)
 
 	return fmt.Sprintf(initTemplate, fluxRoot, mainHost, hosts, brokerConfig)

--- a/pkg/runtime/framework/plugins/flux/flux_test.go
+++ b/pkg/runtime/framework/plugins/flux/flux_test.go
@@ -520,3 +520,174 @@ func TestGetOriginalCommand(t *testing.T) {
 		})
 	}
 }
+
+func TestOptionalTrainerFields(t *testing.T) {
+	cases := map[string]struct {
+		podSetCount int32
+		jobTrainer  *trainer.Trainer
+		// wantCommand is only asserted when set.
+		wantCommand []string
+		wantFlags   string
+		// wantViewImage defaults to constants.FluxInstallerImage when empty.
+		wantViewImage string
+		wantHostlist  string
+	}{
+		"trainer is not set": {
+			podSetCount:  3,
+			wantCommand:  []string{"/bin/bash", "/etc/flux-config/entrypoint.sh", "python train.py"},
+			wantFlags:    "-N 3 -n 3",
+			wantHostlist: "test-job-node-0-[0-2]",
+		},
+		"num nodes is not set": {
+			podSetCount:  2,
+			jobTrainer:   utiltesting.MakeTrainJobTrainerWrapper().Container("image", []string{"python", "train.py"}, nil, nil).Obj(),
+			wantFlags:    "-N 2 -n 2",
+			wantHostlist: "test-job-node-0-[0-1]",
+		},
+		"env and num proc per node from the TrainJob are applied": {
+			podSetCount: 3,
+			jobTrainer: utiltesting.MakeTrainJobTrainerWrapper().
+				NumProcPerNode(2).
+				Env(corev1.EnvVar{Name: "FLUX_VIEW_IMAGE", Value: "example.com/flux-view:test"}).
+				Obj(),
+			wantFlags:     "-N 3 -n 6",
+			wantViewImage: "example.com/flux-view:test",
+			wantHostlist:  "test-job-node-0-[0-2]",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			cli := utiltesting.NewClientBuilder().Build()
+			p, err := New(ctx, cli, nil, nil)
+			if err != nil {
+				t.Fatalf("Failed to initialize Flux plugin: %v", err)
+			}
+
+			info := &runtime.Info{
+				RuntimePolicy: runtime.RuntimePolicy{
+					MLPolicySource: &trainer.MLPolicySource{
+						Flux: &trainer.FluxMLPolicySource{
+							NumProcPerNode: ptr.To[int32](1),
+						},
+					},
+				},
+				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: v1alpha2.JobSetSpec().
+						WithReplicatedJobs(
+							v1alpha2.ReplicatedJob().
+								WithName(constants.Node).
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithContainers(
+													corev1ac.Container().WithName(constants.Node),
+												),
+											),
+										),
+									),
+								),
+						),
+					PodSets: []runtime.PodSet{
+						{
+							Name:       constants.Node,
+							Ancestor:   ptr.To(constants.AncestorTrainer),
+							Count:      ptr.To(tc.podSetCount),
+							Containers: []runtime.Container{{Name: constants.Node, Command: []string{"python", "train.py"}}},
+						},
+					},
+				},
+			}
+			trainJob := utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+				UID("test-uid").
+				Trainer(tc.jobTrainer).
+				Obj()
+
+			if err = p.(framework.EnforceMLPolicyPlugin).EnforceMLPolicy(info, trainJob); err != nil {
+				t.Fatalf("Unexpected error from EnforceMLPolicy: %v", err)
+			}
+
+			// The Flux entrypoint has to wrap the runtime's command even when the TrainJob
+			// carried no trainer of its own.
+			if tc.wantCommand != nil {
+				if diff := gocmp.Diff(tc.wantCommand, trainJob.Spec.Trainer.Command); len(diff) != 0 {
+					t.Errorf("Unexpected trainer command (-want, +got): %s", diff)
+				}
+			}
+
+			var viewImage string
+			for _, ic := range info.FindPodSetByAncestor(constants.AncestorTrainer).InitContainers {
+				if ic.Name == constants.FluxInstallerContainerName {
+					viewImage = ic.Image
+				}
+			}
+			if want := cmp.Or(tc.wantViewImage, constants.FluxInstallerImage); viewImage != want {
+				t.Errorf("flux-installer image = %q; want %q", viewImage, want)
+			}
+
+			var objs []apiruntime.ApplyConfiguration
+			if objs, err = p.(framework.ComponentBuilderPlugin).Build(ctx, info, trainJob); err != nil {
+				t.Fatalf("Unexpected error from Build: %v", err)
+			}
+			typedObjs, err := utiltesting.ToObject(cli.Scheme(), objs...)
+			if err != nil {
+				t.Fatalf("Failed to convert objects: %v", err)
+			}
+
+			var configMap *corev1.ConfigMap
+			for _, obj := range typedObjs {
+				if cm, ok := obj.(*corev1.ConfigMap); ok {
+					configMap = cm
+				}
+			}
+			if configMap == nil {
+				t.Fatal("Build did not return the Flux entrypoint ConfigMap")
+			}
+			if !strings.Contains(configMap.Data["entrypoint.sh"], tc.wantFlags) {
+				t.Errorf("entrypoint.sh does not contain the Flux flags %q", tc.wantFlags)
+			}
+			if !strings.Contains(configMap.Data["init.sh"], tc.wantHostlist) {
+				t.Errorf("init.sh does not contain the hostlist %q", tc.wantHostlist)
+			}
+		})
+	}
+}
+
+func TestGetNumNodes(t *testing.T) {
+	cases := map[string]struct {
+		podSets []runtime.PodSet
+		want    int32
+	}{
+		"count of the trainer PodSet": {
+			podSets: []runtime.PodSet{{
+				Name:     constants.Node,
+				Ancestor: ptr.To(constants.AncestorTrainer),
+				Count:    ptr.To[int32](3),
+			}},
+			want: 3,
+		},
+		"trainer PodSet is matched by ancestor rather than by name": {
+			podSets: []runtime.PodSet{{
+				Name:     "worker",
+				Ancestor: ptr.To(constants.AncestorTrainer),
+				Count:    ptr.To[int32](5),
+			}},
+			want: 5,
+		},
+		"single node when the runtime has no trainer PodSet": {
+			podSets: []runtime.PodSet{{Name: constants.DatasetInitializer}},
+			want:    1,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			info := &runtime.Info{TemplateSpec: runtime.TemplateSpec{PodSets: tc.podSets}}
+			if got := getNumNodes(info); got != tc.want {
+				t.Errorf("getNumNodes() = %d; want %d", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`spec.trainer` and `spec.trainer.numNodes` are optional, undefaulted, and not required by `Flux.Validate`, so a TrainJob that omits either is admitted and then panics the Flux plugin. controller-runtime recovers the panic and requeues, so the TrainJob never gets a JobSet and retries forever while the manager logs a stack trace each round. Every example under `examples/flux/` sets `numNodes`, which is why the path has gone unnoticed.

## Change

An unset `numNodes` now falls back to the count the runtime derived for the trainer PodSet, which is `mlPolicy.numNodes`. A TrainJob value still wins, because plugins are constructed by ranging over a map and Flux cannot assume the plugin that copies `numNodes` onto the PodSet has run first.

**Checklist:**

- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing