### PR TITLE
fix(initializer): allow GGUF files in HuggingFace model snapshot download

### DIFF
--- a/pkg/initializers/model/huggingface.py
+++ b/pkg/initializers/model/huggingface.py
@@ -43,14 +43,13 @@ class HuggingFace(utils.ModelProvider):
         if self.config.access_token:
             huggingface_hub.login(self.config.access_token)
 
-        # TODO (andreyvelich): We should consider to follow vLLM approach with allow patterns.
+        # TODO (andreyvelich): We should consider to follow vLLM approach with allow patterns,
+        # including a fallback to *.bin/*.pt/*.pth when a repo has no safetensors.
         # Ref: https://github.com/kubeflow/trainer/pull/2303#discussion_r1815913663
-        # TODO (andreyvelich): We should update patterns for Mistral model
-        # Ref: https://github.com/kubeflow/trainer/pull/2303#discussion_r1815914270
         huggingface_hub.snapshot_download(
             repo_id=model_uri,
             local_dir=utils.MODEL_PATH,
-            allow_patterns=["*.json", "*.safetensors", "*.model", "*.txt"],
+            allow_patterns=["*.json", "*.safetensors", "*.model", "*.txt", "*.gguf"],
             ignore_patterns=self.config.ignore_patterns,
         )
 

--- a/pkg/initializers/model/huggingface_test.py
+++ b/pkg/initializers/model/huggingface_test.py
@@ -110,7 +110,7 @@ def test_download_model(test_name, test_case):
         mock_download.assert_called_once_with(
             repo_id=test_case["expected_repo_id"],
             local_dir=utils.MODEL_PATH,
-            allow_patterns=["*.json", "*.safetensors", "*.model", "*.txt"],
+            allow_patterns=["*.json", "*.safetensors", "*.model", "*.txt", "*.gguf"],
             ignore_patterns=test_case["config"]["ignore_patterns"],
         )
     print("Test execution completed")


### PR DESCRIPTION
Fixes #3884

Adds `*.gguf` to `allow_patterns` in the HuggingFace model initializer so quantized GGUF repos actually download something.

Checked the other two cases from the issue before touching anything:

- Mistral's `params.json` and `consolidated.*.safetensors` already match the existing `*.json`/`*.safetensors` patterns (glob `*` crosses `.`/`/` fine), so there was nothing to fix there.
- `*.bin`/`*.pt`/`*.pth` are excluded on purpose via the default `ignore_patterns` in `pkg/initializers/types/types.py` - safetensors is preferred over pickle-based checkpoints for security reasons (see #2303, discussion r1815914270). `ignore_patterns` wins over `allow_patterns`, so adding those extensions to `allow_patterns` alone wouldn't do anything for the default config anyway. Doing this properly needs repo-format detection (only allow bin/pt/pth when no safetensors exist), which is a bigger change - split it out to #3909 rather than bundle it here.

More context in the comment on #3884.

## Test plan
- [x] `pytest pkg/initializers/model/huggingface_test.py` passes
- [x] pre-commit hooks (isort/black/flake8) pass
