### PR TITLE
feat(initializer): fall back to legacy PyTorch weights when no safetensors exist

### DIFF
--- a/pkg/initializers/model/huggingface.py
+++ b/pkg/initializers/model/huggingface.py
@@ -43,15 +43,31 @@ class HuggingFace(utils.ModelProvider):
         if self.config.access_token:
             huggingface_hub.login(self.config.access_token)
 
-        # TODO (andreyvelich): We should consider to follow vLLM approach with allow patterns.
+        allow_patterns = ["*.json", "*.safetensors", "*.model", "*.txt"]
+        ignore_patterns = self.config.ignore_patterns
+
+        # By default we skip the legacy, pickle-based PyTorch weight formats
+        # in favor of safetensors, since safetensors is the safer format and
+        # downloading both is wasteful. But some repos only ship the legacy
+        # formats, so if that's the case here, allow them through instead of
+        # silently downloading nothing usable.
         # Ref: https://github.com/kubeflow/trainer/pull/2303#discussion_r1815913663
-        # TODO (andreyvelich): We should update patterns for Mistral model
-        # Ref: https://github.com/kubeflow/trainer/pull/2303#discussion_r1815914270
+        # Ref: https://github.com/kubeflow/trainer/issues/3909
+        legacy_weight_patterns = ["*.bin", "*.pt", "*.pth"]
+        if ignore_patterns and set(legacy_weight_patterns) & set(ignore_patterns):
+            repo_files = huggingface_hub.list_repo_files(model_uri)
+            has_safetensors = any(f.endswith(".safetensors") for f in repo_files)
+            if not has_safetensors:
+                allow_patterns += legacy_weight_patterns
+                ignore_patterns = [
+                    p for p in ignore_patterns if p not in legacy_weight_patterns
+                ]
+
         huggingface_hub.snapshot_download(
             repo_id=model_uri,
             local_dir=utils.MODEL_PATH,
-            allow_patterns=["*.json", "*.safetensors", "*.model", "*.txt"],
-            ignore_patterns=self.config.ignore_patterns,
+            allow_patterns=allow_patterns,
+            ignore_patterns=ignore_patterns,
         )
 
         logging.info("Model has been downloaded")

--- a/pkg/initializers/model/huggingface_test.py
+++ b/pkg/initializers/model/huggingface_test.py
@@ -56,31 +56,76 @@ def test_load_config(test_name, test_config, expected):
     print("Test execution completed")
 
 
+DEFAULT_ALLOW_PATTERNS = ["*.json", "*.safetensors", "*.model", "*.txt"]
+DEFAULT_IGNORE_PATTERNS = ["*.msgpack", "*.h5", "*.bin", "*.pt", "*.pth"]
+
+
 @pytest.mark.parametrize(
     "test_name, test_case",
     [
         (
-            "Successful download with token",
+            "Successful download with token, repo has safetensors",
             {
                 "config": {
                     "storage_uri": "hf://username/model-name",
-                    "ignore_patterns": ["*.msgpack", "*.h5", "*.bin", "*.pt", "*.pth"],
+                    "ignore_patterns": DEFAULT_IGNORE_PATTERNS,
                     "access_token": "test_token",
                 },
                 "should_login": True,
                 "expected_repo_id": "username/model-name",
+                "repo_files": ["config.json", "model.safetensors"],
+                "expect_list_repo_files": True,
+                "expected_allow_patterns": DEFAULT_ALLOW_PATTERNS,
+                "expected_ignore_patterns": DEFAULT_IGNORE_PATTERNS,
             },
         ),
         (
-            "Successful download without token",
+            "Successful download without token, repo has safetensors",
             {
                 "config": {
                     "storage_uri": "hf://org/model-v1",
-                    "ignore_patterns": ["*.msgpack", "*.h5", "*.bin", "*.pt", "*.pth"],
+                    "ignore_patterns": DEFAULT_IGNORE_PATTERNS,
                     "access_token": None,
                 },
                 "should_login": False,
                 "expected_repo_id": "org/model-v1",
+                "repo_files": ["config.json", "model.safetensors"],
+                "expect_list_repo_files": True,
+                "expected_allow_patterns": DEFAULT_ALLOW_PATTERNS,
+                "expected_ignore_patterns": DEFAULT_IGNORE_PATTERNS,
+            },
+        ),
+        (
+            "Repo has no safetensors, falls back to legacy weights",
+            {
+                "config": {
+                    "storage_uri": "hf://org/legacy-model",
+                    "ignore_patterns": DEFAULT_IGNORE_PATTERNS,
+                    "access_token": None,
+                },
+                "should_login": False,
+                "expected_repo_id": "org/legacy-model",
+                "repo_files": ["config.json", "pytorch_model.bin"],
+                "expect_list_repo_files": True,
+                "expected_allow_patterns": DEFAULT_ALLOW_PATTERNS
+                + ["*.bin", "*.pt", "*.pth"],
+                "expected_ignore_patterns": ["*.msgpack", "*.h5"],
+            },
+        ),
+        (
+            "Custom ignore_patterns without legacy formats skips repo listing",
+            {
+                "config": {
+                    "storage_uri": "hf://org/custom-model",
+                    "ignore_patterns": ["*.msgpack"],
+                    "access_token": None,
+                },
+                "should_login": False,
+                "expected_repo_id": "org/custom-model",
+                "repo_files": [],
+                "expect_list_repo_files": False,
+                "expected_allow_patterns": DEFAULT_ALLOW_PATTERNS,
+                "expected_ignore_patterns": ["*.msgpack"],
             },
         ),
     ],
@@ -95,7 +140,9 @@ def test_download_model(test_name, test_case):
 
     with patch("huggingface_hub.login") as mock_login, patch(
         "huggingface_hub.snapshot_download"
-    ) as mock_download:
+    ) as mock_download, patch(
+        "huggingface_hub.list_repo_files", return_value=test_case["repo_files"]
+    ) as mock_list_files:
 
         # Execute download
         huggingface_model_instance.download_model()
@@ -106,11 +153,18 @@ def test_download_model(test_name, test_case):
         else:
             mock_login.assert_not_called()
 
+        # Verify we only pay for the repo listing call when we actually need
+        # to decide on legacy weight formats
+        if test_case["expect_list_repo_files"]:
+            mock_list_files.assert_called_once_with(test_case["expected_repo_id"])
+        else:
+            mock_list_files.assert_not_called()
+
         # Verify download parameters
         mock_download.assert_called_once_with(
             repo_id=test_case["expected_repo_id"],
             local_dir=utils.MODEL_PATH,
-            allow_patterns=["*.json", "*.safetensors", "*.model", "*.txt"],
-            ignore_patterns=test_case["config"]["ignore_patterns"],
+            allow_patterns=test_case["expected_allow_patterns"],
+            ignore_patterns=test_case["expected_ignore_patterns"],
         )
     print("Test execution completed")


### PR DESCRIPTION
Fixes #3909

Follow-up to #3884/#3910. That PR added `*.gguf` to `allow_patterns` but deliberately left `*.bin`/`*.pt`/`*.pth` alone, since those are excluded by default via `ignore_patterns` in favor of safetensors (pickle-based checkpoints can run arbitrary code on load, safetensors can't - see #2303, r1815914270). That's the right default, but it means repos that only ship the legacy formats and have no safetensors at all were downloading nothing usable.

This checks whether a repo actually has safetensors before deciding what to do:

- If `ignore_patterns` doesn't touch bin/pt/pth (user already customized it), we don't bother calling the HF API at all and just pass things through as-is.
- If it does (default case), we call `list_repo_files` once. If safetensors exist, behavior is unchanged from today. If not, we allow bin/pt/pth for that download and drop them from the ignore list so they're not immediately filtered back out.

Only one extra API call, and only when it's actually needed to make a decision.

## Test plan
- [x] `pytest pkg/initializers/model/huggingface_test.py` - covers repo-with-safetensors (unchanged behavior), repo-without-safetensors (fallback triggers), and custom ignore_patterns (listing call skipped)
- [x] pre-commit hooks pass
