### PR TITLE
chore(controller): unit test TrainJob deadline reconciliation with a fake clock

### DIFF
--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -52,6 +53,9 @@ type TrainJobReconciler struct {
 	client   client.Client
 	recorder events.EventRecorder
 	runtimes map[string]jobruntimes.Runtime
+	// clock is the time source for the activeDeadlineSeconds arithmetic. Tests
+	// substitute a fake clock so the requeue delay can be asserted exactly.
+	clock clock.PassiveClock
 }
 
 var _ reconcile.Reconciler = (*TrainJobReconciler)(nil)
@@ -67,6 +71,7 @@ func NewTrainJobReconciler(
 		client:   client,
 		recorder: recorder,
 		runtimes: runtimes,
+		clock:    clock.RealClock{},
 	}
 }
 
@@ -161,7 +166,7 @@ func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *tr
 		return ctrl.Result{}
 	}
 	deadline := startTime.Add(time.Duration(trainJob.Spec.ActiveDeadlineSeconds) * time.Second)
-	now := time.Now()
+	now := r.clock.Now()
 	if now.After(deadline) {
 		ctrl.LoggerFrom(ctx).V(2).Info("TrainJob deadline exceeded, marking as failed",
 			"activeDeadlineSeconds", trainJob.Spec.ActiveDeadlineSeconds,
@@ -176,7 +181,7 @@ func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *tr
 		}
 		return ctrl.Result{}
 	}
-	requeueAfter := time.Until(deadline)
+	requeueAfter := deadline.Sub(now)
 	if requeueAfter <= 0 {
 		requeueAfter = 1 * time.Second
 	}

--- a/pkg/controller/trainjob_controller_test.go
+++ b/pkg/controller/trainjob_controller_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/ktesting"
+	clocktesting "k8s.io/utils/clock/testing"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	"github.com/kubeflow/trainer/v2/pkg/constants"
+	utiltesting "github.com/kubeflow/trainer/v2/pkg/util/testing"
+)
+
+// TestReconcileDeadline covers the activeDeadlineSeconds arithmetic in isolation.
+// The integration suite already asserts the resulting conditions, but it polls with
+// Eventually/Consistently and never inspects the returned ctrl.Result, so the requeue
+// delay itself is only observable here, where the clock is fake and the result exact.
+func TestReconcileDeadline(t *testing.T) {
+	// created is the TrainJob creation timestamp every case is anchored on. Truncated to
+	// the second because metav1.Time serializes at second granularity.
+	created := metav1.NewTime(time.Now().Truncate(time.Second))
+	resumed := metav1.NewTime(created.Add(time.Hour))
+
+	failedCondition := metav1.Condition{
+		Type:    trainer.TrainJobFailed,
+		Status:  metav1.ConditionTrue,
+		Message: constants.TrainJobDeadlineExceededMessage,
+		Reason:  trainer.TrainJobDeadlineExceededReason,
+	}
+	resumedCondition := metav1.Condition{
+		Type:               trainer.TrainJobSuspended,
+		Status:             metav1.ConditionFalse,
+		Message:            constants.TrainJobResumedMessage,
+		Reason:             trainer.TrainJobResumedReason,
+		LastTransitionTime: resumed,
+	}
+
+	cases := map[string]struct {
+		trainJob *trainer.TrainJob
+		// jobSet, when set, is the child JobSet seeded into the fake client.
+		jobSet *jobsetv1alpha2.JobSet
+		// now is the instant the fake clock reports.
+		now time.Time
+
+		wantResult     ctrl.Result
+		wantConditions []metav1.Condition
+		// wantJobSet is true when the child JobSet must survive the reconciliation.
+		wantJobSet bool
+	}{
+		"deadline exceeded fails the TrainJob and deletes the child JobSet": {
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "deadline-job").
+				CreationTimestamp(created).
+				ActiveDeadlineSeconds(60).
+				Obj(),
+			jobSet:         utiltesting.MakeJobSetWrapper(metav1.NamespaceDefault, "deadline-job").Obj(),
+			now:            created.Add(61 * time.Second),
+			wantResult:     ctrl.Result{},
+			wantConditions: []metav1.Condition{failedCondition},
+		},
+		"deadline exceeded still fails the TrainJob when the child JobSet is already gone": {
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "deadline-job").
+				CreationTimestamp(created).
+				ActiveDeadlineSeconds(60).
+				Obj(),
+			now:            created.Add(61 * time.Second),
+			wantResult:     ctrl.Result{},
+			wantConditions: []metav1.Condition{failedCondition},
+		},
+		"active deadline requeues after exactly the remaining duration": {
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "deadline-job").
+				CreationTimestamp(created).
+				ActiveDeadlineSeconds(60).
+				Obj(),
+			jobSet:     utiltesting.MakeJobSetWrapper(metav1.NamespaceDefault, "deadline-job").Obj(),
+			now:        created.Add(20 * time.Second),
+			wantResult: ctrl.Result{RequeueAfter: 40 * time.Second},
+			wantJobSet: true,
+		},
+		"requeue is floored at one second when the deadline is exactly now": {
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "deadline-job").
+				CreationTimestamp(created).
+				ActiveDeadlineSeconds(60).
+				Obj(),
+			// now.After(deadline) is false on equality, so the remaining duration is
+			// zero and must be clamped rather than requeued immediately.
+			now:        created.Add(60 * time.Second),
+			wantResult: ctrl.Result{RequeueAfter: time.Second},
+		},
+		"deadline is measured from the resume transition rather than the creation timestamp": {
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "deadline-job").
+				CreationTimestamp(created).
+				ActiveDeadlineSeconds(60).
+				Conditions(resumedCondition).
+				Obj(),
+			// An hour past creation, but only 20s past the resume, so the job is still
+			// well within its deadline.
+			now:            resumed.Add(20 * time.Second),
+			wantResult:     ctrl.Result{RequeueAfter: 40 * time.Second},
+			wantConditions: []metav1.Condition{resumedCondition},
+		},
+		"zero creation timestamp leaves the TrainJob untouched": {
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "deadline-job").
+				ActiveDeadlineSeconds(60).
+				Obj(),
+			now:        created.Add(time.Hour),
+			wantResult: ctrl.Result{},
+		},
+		"no deadline configured leaves the TrainJob untouched": {
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "deadline-job").
+				CreationTimestamp(created).
+				Obj(),
+			now:        created.Add(time.Hour),
+			wantResult: ctrl.Result{},
+		},
+		"suspended TrainJob does not start the deadline timer": {
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "deadline-job").
+				CreationTimestamp(created).
+				ActiveDeadlineSeconds(60).
+				Suspend(true).
+				Obj(),
+			jobSet:     utiltesting.MakeJobSetWrapper(metav1.NamespaceDefault, "deadline-job").Obj(),
+			now:        created.Add(time.Hour),
+			wantResult: ctrl.Result{},
+			wantJobSet: true,
+		},
+		"finished TrainJob is not failed again once the deadline passes": {
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "deadline-job").
+				CreationTimestamp(created).
+				ActiveDeadlineSeconds(60).
+				Conditions(metav1.Condition{
+					Type:   trainer.TrainJobComplete,
+					Status: metav1.ConditionTrue,
+					Reason: "Complete",
+				}).
+				Obj(),
+			jobSet: utiltesting.MakeJobSetWrapper(metav1.NamespaceDefault, "deadline-job").Obj(),
+			now:    created.Add(time.Hour),
+			wantConditions: []metav1.Condition{{
+				Type:   trainer.TrainJobComplete,
+				Status: metav1.ConditionTrue,
+				Reason: "Complete",
+			}},
+			wantResult: ctrl.Result{},
+			wantJobSet: true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			var cancel func()
+			ctx, cancel = context.WithCancel(ctx)
+			t.Cleanup(cancel)
+
+			builder := utiltesting.NewClientBuilder().WithObjects(tc.trainJob)
+			if tc.jobSet != nil {
+				builder = builder.WithObjects(tc.jobSet)
+			}
+			cli := builder.Build()
+
+			r := &TrainJobReconciler{
+				client: cli,
+				clock:  clocktesting.NewFakePassiveClock(tc.now),
+			}
+
+			gotResult := r.reconcileDeadline(ctx, tc.trainJob)
+
+			if diff := cmp.Diff(tc.wantResult, gotResult); len(diff) != 0 {
+				t.Errorf("Unexpected ctrl.Result (-want, +got): \n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantConditions, tc.trainJob.Status.Conditions,
+				cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
+			); len(diff) != 0 {
+				t.Errorf("Unexpected TrainJob conditions (-want, +got): \n%s", diff)
+			}
+
+			// reconcileDeadline deletes the child JobSet by name, so absence is the
+			// signal that the deadline path ran to completion.
+			gotJobSetErr := cli.Get(ctx, client.ObjectKey{
+				Namespace: metav1.NamespaceDefault,
+				Name:      tc.trainJob.Name,
+			}, &jobsetv1alpha2.JobSet{})
+			switch {
+			case tc.wantJobSet && gotJobSetErr != nil:
+				t.Errorf("Expected the child JobSet to be preserved, got error: %v", gotJobSetErr)
+			case !tc.wantJobSet && !apierrors.IsNotFound(gotJobSetErr):
+				t.Errorf("Expected the child JobSet to be absent, got error: %v", gotJobSetErr)
+			}
+		})
+	}
+}

--- a/pkg/util/testing/wrapper.go
+++ b/pkg/util/testing/wrapper.go
@@ -659,6 +659,18 @@ func (t *TrainJobWrapper) ManagedBy(m string) *TrainJobWrapper {
 	return t
 }
 
+func (t *TrainJobWrapper) CreationTimestamp(creationTimestamp metav1.Time) *TrainJobWrapper {
+	t.ObjectMeta.CreationTimestamp = creationTimestamp
+	return t
+}
+
+func (t *TrainJobWrapper) Conditions(conditions ...metav1.Condition) *TrainJobWrapper {
+	if len(conditions) != 0 {
+		t.Status.Conditions = append(t.Status.Conditions, conditions...)
+	}
+	return t
+}
+
 func (t *TrainJobWrapper) Obj() *trainer.TrainJob {
 	return &t.TrainJob
 }


### PR DESCRIPTION
Fixes #3914

## Summary

`reconcileDeadline` returns a `ctrl.Result` whose `RequeueAfter` decides when the next deadline check happens, and nothing asserted that value.

The deadline *behaviour* is already covered by the integration suite (`test/integration/controller/trainjob_controller_test.go`) and by e2e, but those poll with `Eventually`/`Consistently` and only observe the resulting conditions — they never inspect the returned `ctrl.Result`, and by construction can't assert requeue timing. That left four branches with no coverage:

- the `requeueAfter <= 0 → 1 * time.Second` floor
- the `startTime.IsZero()` early return
- the suspended-condition start-time override, i.e. the deadline being measured from `LastTransitionTime` of a `Suspended=False` condition rather than `CreationTimestamp`
- the exact `RequeueAfter` for an active deadline

They also weren't *assertable*, because `reconcileDeadline` read the wall clock directly, so a unit test could only check `RequeueAfter` within a tolerance band — the kind of assertion that turns flaky in CI.

## Changes

**`pkg/controller/trainjob_controller.go`** (+7/−2)
- `TrainJobReconciler` gains a `clock clock.PassiveClock` field, defaulted to `clock.RealClock{}` in `NewTrainJobReconciler`. This mirrors what `TrainJobDefaulter` already does in `pkg/webhooks/trainjob_webhook.go`.
- `time.Now()` → `r.clock.Now()`.
- `time.Until(deadline)` → `deadline.Sub(now)`, so both time reads come from the same source. Without this the fake clock and the wall clock would mix and every requeue would collapse onto the 1s floor.

Behaviour is unchanged with a real clock.

**`pkg/controller/trainjob_controller_test.go`** (new, +215) — nine map-based cases over `reconcileDeadline`, using `clocktesting.NewFakePassiveClock` and a fake client, comparing the returned `ctrl.Result` and the resulting conditions with `cmp.Diff`:

| Case | Asserts |
|---|---|
| deadline exceeded | `Failed`/`DeadlineExceeded` condition + child JobSet deleted |
| deadline exceeded, JobSet already gone | condition still set, `IgnoreNotFound` path |
| active deadline | `RequeueAfter` is exactly the remaining duration |
| deadline exactly now | requeue floored at 1s rather than requeued immediately |
| resumed job | deadline measured from the resume transition, not creation |
| zero creation timestamp | no-op |
| no deadline configured | no-op |
| suspended | timer does not start, JobSet preserved |
| finished | not failed again once the deadline passes |

**`pkg/util/testing/wrapper.go`** (+12) — `TrainJobWrapper.CreationTimestamp` and `.Conditions`, needed to build the fixtures above. Both additive; `.Conditions` mirrors the existing `JobSetWrapper.Conditions`.

## Testing

- `go test ./pkg/controller/...` — all 9 subtests pass
- `go test ./pkg/controller/... ./pkg/util/... ./pkg/webhooks/...` — pass
- `go vet ./...` and `go build ./...` — clean
- Mutation-checked the new tests rather than trusting a green run. Each of these breaks at least one case: reverting `deadline.Sub(now)` to `time.Until(deadline)` (3 failures), removing the 1s floor, ignoring the resume transition time, removing the `IsZero` guard, removing the JobSet deletion, and removing the suspended/finished guard (2 failures). No case is vacuous.

## Notes

The issue proposed also threading the clock through `pkg/controller/setup.go`. That turned out to be unnecessary: the tests live in `package controller`, so they can build the struct literal directly with a fake clock — exactly how `pkg/webhooks/trainjob_webhook_test.go` does it. Defaulting to `RealClock` inside the constructor keeps the exported signature and every caller unchanged, so `setup.go` is untouched.
