### PR TITLE
ci(manifests): verify CRD packaging consistency

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -48,6 +48,10 @@ jobs:
         run: |
           make generate
           git diff --exit-code || (echo 'Please run "make generate" to generate assets' && exit 1);
+      - name: Verify CRD packaging
+        run: |
+          make verify-crd-packaging
+          make test-crd-packaging
       - name: Check go fmt
         run: |
           make fmt

--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,14 @@ generate: go-mod-download manifests helm-docs ## Generate APIs.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate/boilerplate.go.txt" paths="./pkg/apis/config/v1alpha1/..."
 	CONTAINER_RUNTIME=$(CONTAINER_RUNTIME) hack/python-api/gen-api.sh
 
+.PHONY: verify-crd-packaging
+verify-crd-packaging: ## Verify CRDs are packaged consistently for Kustomize and Helm.
+	hack/verify-crd-packaging.sh
+
+.PHONY: test-crd-packaging
+test-crd-packaging: ## Run tests for the CRD packaging verifier.
+	hack/verify-crd-packaging_test.sh
+
 .PHONY: go-mod-download
 go-mod-download: ## Run go mod download to download modules.
 	go mod download

--- a/hack/verify-crd-packaging.sh
+++ b/hack/verify-crd-packaging.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${1:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+
+GENERATED_CRD_DIR="${REPO_ROOT}/manifests/base/crds"
+KUSTOMIZATION_FILE="${GENERATED_CRD_DIR}/kustomization.yaml"
+HELM_CRD_DIR="${REPO_ROOT}/charts/kubeflow-trainer/templates/crd"
+HELM_CRD_TEST_FILE="${REPO_ROOT}/charts/kubeflow-trainer/tests/crd/crd_test.yaml"
+
+require_directory() {
+  local directory=$1
+  if [[ ! -d "${directory}" ]]; then
+    echo "CRD packaging verification failed: directory not found: ${directory}" >&2
+    exit 1
+  fi
+}
+
+require_file() {
+  local file=$1
+  if [[ ! -f "${file}" ]]; then
+    echo "CRD packaging verification failed: file not found: ${file}" >&2
+    exit 1
+  fi
+}
+
+list_generated_crds() {
+  find "${GENERATED_CRD_DIR}" -maxdepth 1 -type f \
+    -name 'trainer.kubeflow.org_*.yaml' -exec basename {} \; | LC_ALL=C sort -u
+}
+
+list_kustomize_resources() {
+  awk '
+    /^resources:[[:space:]]*$/ { in_resources = 1; next }
+    /^[^[:space:]]/ { in_resources = 0 }
+    in_resources && $1 == "-" && $2 ~ /^trainer\.kubeflow\.org_[[:alnum:]_.-]+\.yaml$/ {
+      print $2
+    }
+  ' "${KUSTOMIZATION_FILE}" | LC_ALL=C sort -u
+}
+
+list_helm_crds() {
+  find "${HELM_CRD_DIR}" -maxdepth 1 -type f \
+    -name 'trainer.kubeflow.org_*.yaml' -exec basename {} \; | LC_ALL=C sort -u
+}
+
+list_helm_test_suite_templates() {
+  awk '
+    /^templates:[[:space:]]*$/ { in_templates = 1; next }
+    /^[^[:space:]]/ { in_templates = 0 }
+    in_templates && $1 == "-" && $2 ~ /^crd\/trainer\.kubeflow\.org_[[:alnum:]_.-]+\.yaml$/ {
+      sub(/^crd\//, "", $2)
+      print $2
+    }
+  ' "${HELM_CRD_TEST_FILE}" | LC_ALL=C sort -u
+}
+
+list_helm_test_cases() {
+  awk '
+    /^tests:[[:space:]]*$/ { in_tests = 1; next }
+    /^[^[:space:]]/ { in_tests = 0 }
+    in_tests && $1 == "template:" && $2 ~ /^crd\/trainer\.kubeflow\.org_[[:alnum:]_.-]+\.yaml$/ {
+      sub(/^crd\//, "", $2)
+      print $2
+    }
+  ' "${HELM_CRD_TEST_FILE}" | LC_ALL=C sort -u
+}
+
+print_entries() {
+  local prefix=$1
+  local entries=$2
+
+  while IFS= read -r entry; do
+    [[ -n "${entry}" ]] && printf '  - %s: %s\n' "${prefix}" "${entry}" >&2
+  done <<<"${entries}"
+}
+
+compare_inventory() {
+  local inventory_name=$1
+  local expected_file=$2
+  local actual_file=$3
+  local missing_entries
+  local stale_entries
+
+  missing_entries="$(comm -23 "${expected_file}" "${actual_file}")"
+  stale_entries="$(comm -13 "${expected_file}" "${actual_file}")"
+
+  if [[ -z "${missing_entries}" && -z "${stale_entries}" ]]; then
+    return 0
+  fi
+
+  echo "${inventory_name}:" >&2
+  print_entries "missing" "${missing_entries}"
+  print_entries "stale" "${stale_entries}"
+  return 1
+}
+
+require_directory "${GENERATED_CRD_DIR}"
+require_directory "${HELM_CRD_DIR}"
+require_file "${KUSTOMIZATION_FILE}"
+require_file "${HELM_CRD_TEST_FILE}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+list_generated_crds >"${TMP_DIR}/generated"
+list_kustomize_resources >"${TMP_DIR}/kustomize"
+list_helm_crds >"${TMP_DIR}/helm"
+list_helm_test_suite_templates >"${TMP_DIR}/helm-test-suite"
+list_helm_test_cases >"${TMP_DIR}/helm-test-cases"
+
+if [[ ! -s "${TMP_DIR}/generated" ]]; then
+  echo "CRD packaging verification failed: no generated Trainer CRDs were found" >&2
+  exit 1
+fi
+
+verification_failed=false
+
+compare_inventory \
+  "Kustomize CRD resources" "${TMP_DIR}/generated" "${TMP_DIR}/kustomize" || verification_failed=true
+compare_inventory \
+  "Helm CRD templates" "${TMP_DIR}/generated" "${TMP_DIR}/helm" || verification_failed=true
+compare_inventory \
+  "Helm CRD test suite templates" "${TMP_DIR}/generated" "${TMP_DIR}/helm-test-suite" || verification_failed=true
+compare_inventory \
+  "Helm CRD test cases" "${TMP_DIR}/generated" "${TMP_DIR}/helm-test-cases" || verification_failed=true
+
+if [[ "${verification_failed}" == true ]]; then
+  echo "CRD packaging verification failed" >&2
+  exit 1
+fi
+
+echo "CRD packaging verification passed"

--- a/hack/verify-crd-packaging_test.sh
+++ b/hack/verify-crd-packaging_test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERIFIER="${SCRIPT_DIR}/verify-crd-packaging.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+create_fixture() {
+  local fixture_root=$1
+
+  mkdir -p \
+    "${fixture_root}/manifests/base/crds" \
+    "${fixture_root}/charts/kubeflow-trainer/templates/crd" \
+    "${fixture_root}/charts/kubeflow-trainer/tests/crd"
+
+  touch \
+    "${fixture_root}/manifests/base/crds/trainer.kubeflow.org_optimizationjobs.yaml" \
+    "${fixture_root}/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml" \
+    "${fixture_root}/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_optimizationjobs.yaml" \
+    "${fixture_root}/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml"
+
+  cat >"${fixture_root}/manifests/base/crds/kustomization.yaml" <<'EOF'
+resources:
+  - trainer.kubeflow.org_optimizationjobs.yaml
+  - trainer.kubeflow.org_trainjobs.yaml
+EOF
+
+  cat >"${fixture_root}/charts/kubeflow-trainer/tests/crd/crd_test.yaml" <<'EOF'
+templates:
+  - crd/trainer.kubeflow.org_optimizationjobs.yaml
+  - crd/trainer.kubeflow.org_trainjobs.yaml
+tests:
+  - it: tests OptimizationJob
+    template: crd/trainer.kubeflow.org_optimizationjobs.yaml
+  - it: tests TrainJob
+    template: crd/trainer.kubeflow.org_trainjobs.yaml
+EOF
+}
+
+remove_matching_line() {
+  local pattern=$1
+  local file=$2
+
+  awk -v pattern="${pattern}" 'index($0, pattern) == 0' "${file}" >"${file}.tmp"
+  mv "${file}.tmp" "${file}"
+}
+
+expect_failure() {
+  local test_name=$1
+  local expected_message=$2
+  local fixture_root=$3
+  local output
+
+  if output="$(${VERIFIER} "${fixture_root}" 2>&1)"; then
+    echo "FAIL: ${test_name}: verifier unexpectedly passed" >&2
+    exit 1
+  fi
+
+  if [[ "${output}" != *"${expected_message}"* ]]; then
+    echo "FAIL: ${test_name}: expected output to contain: ${expected_message}" >&2
+    echo "Actual output:" >&2
+    echo "${output}" >&2
+    exit 1
+  fi
+}
+
+baseline="${TMP_DIR}/baseline"
+create_fixture "${baseline}"
+"${VERIFIER}" "${baseline}" >/dev/null
+
+missing_kustomize="${TMP_DIR}/missing-kustomize"
+create_fixture "${missing_kustomize}"
+remove_matching_line "trainer.kubeflow.org_optimizationjobs.yaml" \
+  "${missing_kustomize}/manifests/base/crds/kustomization.yaml"
+expect_failure "missing Kustomize resource" \
+  "missing: trainer.kubeflow.org_optimizationjobs.yaml" "${missing_kustomize}"
+
+missing_helm="${TMP_DIR}/missing-helm"
+create_fixture "${missing_helm}"
+rm "${missing_helm}/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_optimizationjobs.yaml"
+expect_failure "missing Helm template" \
+  "missing: trainer.kubeflow.org_optimizationjobs.yaml" "${missing_helm}"
+
+missing_test_suite="${TMP_DIR}/missing-test-suite"
+create_fixture "${missing_test_suite}"
+remove_matching_line "  - crd/trainer.kubeflow.org_optimizationjobs.yaml" \
+  "${missing_test_suite}/charts/kubeflow-trainer/tests/crd/crd_test.yaml"
+expect_failure "missing Helm test suite template" \
+  "Helm CRD test suite templates:" "${missing_test_suite}"
+
+missing_test_case="${TMP_DIR}/missing-test-case"
+create_fixture "${missing_test_case}"
+remove_matching_line "template: crd/trainer.kubeflow.org_optimizationjobs.yaml" \
+  "${missing_test_case}/charts/kubeflow-trainer/tests/crd/crd_test.yaml"
+expect_failure "missing Helm test case" \
+  "Helm CRD test cases:" "${missing_test_case}"
+
+stale_kustomize="${TMP_DIR}/stale-kustomize"
+create_fixture "${stale_kustomize}"
+echo "  - trainer.kubeflow.org_stale.yaml" >> \
+  "${stale_kustomize}/manifests/base/crds/kustomization.yaml"
+expect_failure "stale Kustomize resource" \
+  "stale: trainer.kubeflow.org_stale.yaml" "${stale_kustomize}"
+
+stale_helm="${TMP_DIR}/stale-helm"
+create_fixture "${stale_helm}"
+touch "${stale_helm}/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_stale.yaml"
+expect_failure "stale Helm template" \
+  "stale: trainer.kubeflow.org_stale.yaml" "${stale_helm}"
+
+stale_test_suite="${TMP_DIR}/stale-test-suite"
+create_fixture "${stale_test_suite}"
+test_file="${stale_test_suite}/charts/kubeflow-trainer/tests/crd/crd_test.yaml"
+awk '
+  /^tests:/ { print "  - crd/trainer.kubeflow.org_stale.yaml" }
+  { print }
+' "${test_file}" >"${test_file}.tmp"
+mv "${test_file}.tmp" "${test_file}"
+expect_failure "stale Helm test suite template" \
+  "stale: trainer.kubeflow.org_stale.yaml" "${stale_test_suite}"
+
+stale_test_case="${TMP_DIR}/stale-test-case"
+create_fixture "${stale_test_case}"
+echo "    template: crd/trainer.kubeflow.org_stale.yaml" >> \
+  "${stale_test_case}/charts/kubeflow-trainer/tests/crd/crd_test.yaml"
+expect_failure "stale Helm test case" \
+  "stale: trainer.kubeflow.org_stale.yaml" "${stale_test_case}"
+
+echo "CRD packaging verifier tests passed"


### PR DESCRIPTION
## What this PR does

Adds a focused CI check that keeps Trainer CRD packaging consistent across Kustomize and Helm.

The generated CRDs under `manifests/base/crds` are treated as the source inventory. The verifier compares that inventory with:

- `manifests/base/crds/kustomization.yaml`;
- Helm CRD template files;
- the Helm unit-test suite's `templates` list;
- the individual Helm CRD test cases.

A mismatch fails with the affected inventory and the exact missing or stale filename.

## Why we need it

#3883 fixed an OptimizationJob CRD that had been generated but omitted from the Kustomize resources and Helm tests. Generation CI could not detect that class of problem because those inventories are maintained separately.

This check turns that packaging expectation into an explicit invariant, so the next CRD addition or removal fails early with an actionable message.

## Implementation

- Adds `hack/verify-crd-packaging.sh` without introducing new dependencies.
- Adds fixture-based regression tests for the valid baseline and each missing/stale inventory case.
- Exposes `make verify-crd-packaging` and `make test-crd-packaging`.
- Runs both targets in the existing generation CI job.

## Validation

- `hack/verify-crd-packaging.sh`
- `hack/verify-crd-packaging_test.sh`
- Shell syntax validation with `bash -n`
- GitHub Actions workflow YAML parsing
- Boilerplate verification
- `git diff --check`

Fixes #3907
Follow-up to #3883