### PR TITLE
fix(framework): validate all ReplicatedJobs in Volcano priorityClassName check

### DIFF
--- a/charts/kubeflow-trainer/templates/rbac/clusterrole.yaml
+++ b/charts/kubeflow-trainer/templates/rbac/clusterrole.yaml
@@ -91,6 +91,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - scheduling.volcano.sh
   - scheduling.x-k8s.io
   resources:

--- a/manifests/base/rbac/role.yaml
+++ b/manifests/base/rbac/role.yaml
@@ -88,6 +88,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - scheduling.volcano.sh
   - scheduling.x-k8s.io
   resources:

--- a/pkg/runtime/framework/plugins/volcano/volcano.go
+++ b/pkg/runtime/framework/plugins/volcano/volcano.go
@@ -109,11 +109,8 @@ func (v *Volcano) Validate(ctx context.Context, info *runtime.Info, _, newObj *t
 				priorityClassName := rj.Template.Spec.Template.Spec.PriorityClassName
 				if priorityClassName != nil {
 					pcName := *priorityClassName
-					// Skip two special keywords which indicate the highest priorities.
-					if pcName == "system-cluster-critical" || pcName == "system-node-critical" {
-						continue
-					}
-					// Any other name must be defined by creating a PriorityClass object with that name.
+					// Every name, including the built-in system-cluster-critical and
+					// system-node-critical, must resolve to a PriorityClass object.
 					var pc schedulingv1.PriorityClass
 					if err := v.client.Get(ctx, types.NamespacedName{Name: pcName}, &pc); err != nil {
 						allErrs = append(allErrs, field.Invalid(specPath.Child("templateSpec").Child("priorityClassName"),

--- a/pkg/runtime/framework/plugins/volcano/volcano.go
+++ b/pkg/runtime/framework/plugins/volcano/volcano.go
@@ -109,9 +109,9 @@ func (v *Volcano) Validate(ctx context.Context, info *runtime.Info, _, newObj *t
 				priorityClassName := rj.Template.Spec.Template.Spec.PriorityClassName
 				if priorityClassName != nil {
 					pcName := *priorityClassName
-					// Skip two special keywords which indicate the highest priorities
+					// Skip two special keywords which indicate the highest priorities.
 					if pcName == "system-cluster-critical" || pcName == "system-node-critical" {
-						return nil, allErrs
+						continue
 					}
 					// Any other name must be defined by creating a PriorityClass object with that name.
 					var pc schedulingv1.PriorityClass

--- a/pkg/runtime/framework/plugins/volcano/volcano.go
+++ b/pkg/runtime/framework/plugins/volcano/volcano.go
@@ -71,6 +71,7 @@ const Name = "Volcano"
 // +kubebuilder:rbac:groups=scheduling.volcano.sh,resources=podgroups,verbs=create;get;list;watch;update;patch
 // +kubebuilder:rbac:groups=node.k8s.io,resources=runtimeclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=limitranges,verbs=get;list;watch
+// +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=get;list;watch
 
 func New(_ context.Context, client client.Client, _ client.FieldIndexer, _ *configapi.Configuration) (framework.Plugin, error) {
 	return &Volcano{

--- a/pkg/runtime/framework/plugins/volcano/volcano_test.go
+++ b/pkg/runtime/framework/plugins/volcano/volcano_test.go
@@ -496,7 +496,7 @@ func TestValidate(t *testing.T) {
 			},
 			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").Obj(),
 		},
-		"reserved priorityClassName on one ReplicatedJob must not skip validation of the rest": {
+		"a valid priorityClassName on one ReplicatedJob must not skip validation of the rest": {
 			info: runtime.NewInfo(
 				runtime.WithPodGroupPolicy(&trainer.PodGroupPolicy{
 					PodGroupPolicySource: trainer.PodGroupPolicySource{
@@ -529,6 +529,12 @@ func TestValidate(t *testing.T) {
 						),
 				),
 			),
+			objs: []client.Object{
+				&schedulingv1.PriorityClass{
+					ObjectMeta: metav1.ObjectMeta{Name: "system-cluster-critical"},
+					Value:      2000000000,
+				},
+			},
 			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").Obj(),
 			wantError: field.ErrorList{
 				field.Invalid(
@@ -538,7 +544,7 @@ func TestValidate(t *testing.T) {
 				),
 			},
 		},
-		"reserved priorityClassName on multiple ReplicatedJobs are all skipped": {
+		"built-in system priorityClassNames are validated like any other name": {
 			info: runtime.NewInfo(
 				runtime.WithPodGroupPolicy(&trainer.PodGroupPolicy{
 					PodGroupPolicySource: trainer.PodGroupPolicySource{
@@ -571,6 +577,16 @@ func TestValidate(t *testing.T) {
 						),
 				),
 			),
+			objs: []client.Object{
+				&schedulingv1.PriorityClass{
+					ObjectMeta: metav1.ObjectMeta{Name: "system-cluster-critical"},
+					Value:      2000000000,
+				},
+				&schedulingv1.PriorityClass{
+					ObjectMeta: metav1.ObjectMeta{Name: "system-node-critical"},
+					Value:      2000001000,
+				},
+			},
 			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").Obj(),
 		},
 	}

--- a/pkg/runtime/framework/plugins/volcano/volcano_test.go
+++ b/pkg/runtime/framework/plugins/volcano/volcano_test.go
@@ -496,6 +496,83 @@ func TestValidate(t *testing.T) {
 			},
 			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").Obj(),
 		},
+		"reserved priorityClassName on one ReplicatedJob must not skip validation of the rest": {
+			info: runtime.NewInfo(
+				runtime.WithPodGroupPolicy(&trainer.PodGroupPolicy{
+					PodGroupPolicySource: trainer.PodGroupPolicySource{
+						Volcano: &trainer.VolcanoPodGroupPolicySource{},
+					},
+				}),
+				runtime.WithTemplateSpecObjApply(
+					jobsetv1alpha2ac.JobSetSpec().
+						WithReplicatedJobs(
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithPriorityClassName("system-cluster-critical"),
+											),
+										),
+									),
+								),
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithPriorityClassName("non-existent"),
+											),
+										),
+									),
+								),
+						),
+				),
+			),
+			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").Obj(),
+			wantError: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec").Child("templateSpec").Child("priorityClassName"),
+					"non-existent",
+					`PriorityClass "non-existent" doesn't exist: priorityclasses.scheduling.k8s.io "non-existent" not found`,
+				),
+			},
+		},
+		"reserved priorityClassName on multiple ReplicatedJobs are all skipped": {
+			info: runtime.NewInfo(
+				runtime.WithPodGroupPolicy(&trainer.PodGroupPolicy{
+					PodGroupPolicySource: trainer.PodGroupPolicySource{
+						Volcano: &trainer.VolcanoPodGroupPolicySource{},
+					},
+				}),
+				runtime.WithTemplateSpecObjApply(
+					jobsetv1alpha2ac.JobSetSpec().
+						WithReplicatedJobs(
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithPriorityClassName("system-cluster-critical"),
+											),
+										),
+									),
+								),
+							jobsetv1alpha2ac.ReplicatedJob().
+								WithTemplate(batchv1ac.JobTemplateSpec().
+									WithSpec(batchv1ac.JobSpec().
+										WithTemplate(corev1ac.PodTemplateSpec().
+											WithSpec(corev1ac.PodSpec().
+												WithPriorityClassName("system-node-critical"),
+											),
+										),
+									),
+								),
+						),
+				),
+			),
+			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").Obj(),
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
## What this PR does / why we need it

`Volcano.Validate` iterates `jobSetSpec.ReplicatedJobs` to check each job's `priorityClassName`. This PR fixes three problems found in that path. The second and third were surfaced by the KinD verification @robert-bell asked for in review.

### 1. Validation stopped at the first reserved priority class

When a `ReplicatedJob` used a reserved priority class (`system-cluster-critical` or `system-node-critical`), the loop returned early instead of continuing to the next job, so validation was silently skipped for every `ReplicatedJob` listed after it.

A TrainJob could therefore be admitted with an invalid `priorityClassName` on a later `ReplicatedJob`, only surfacing as a pod scheduling failure at runtime instead of being rejected at admission time. The early `return nil, allErrs` is now a `continue`.

### 2. The reserved priority classes did not need special handling

`system-cluster-critical` and `system-node-critical` are real `PriorityClass` objects created by kube-apiserver at bootstrap, so they resolve through the same `client.Get` as any other name. The skip was unnecessary and only served to hide the bug above. It has been removed, so every name is validated identically.

Confirmed against a live cluster: both resolve normally, with values 2000000000 and 2000001000.

### 3. The controller had no RBAC permission to read PriorityClasses

This is a pre-existing bug on master, independent of the two changes above.

The plugin validates `spec.priorityClassName` with a `client.Get` on the named `PriorityClass`, but the controller `ClusterRole` never granted any access to `scheduling.k8s.io/priorityclasses`. Because the plugin uses the cached controller-runtime client, the missing permission makes the `PriorityClass` informer fail to list, the cache never syncs, and the `Get` blocks until the webhook times out.

Creating a TrainJob whose runtime sets a `priorityClassName` fails with:

```
Internal error occurred: failed calling webhook
"validator.trainjob.trainer.kubeflow.org": context deadline exceeded
```

This affects any user-defined priority class today. It is included here because the priority class validation this PR fixes cannot work without it, but I am happy to split it into its own PR if you would prefer to review it separately.

## Validation

Unit and build checks:

- `go build ./...`
- `go vet ./...`
- `go test ./pkg/runtime/framework/plugins/volcano/...`

End to end in KinD (Kubernetes 1.36, Volcano 1.12.1), per @robert-bell's request in review:

- Without the RBAC rule, a TrainJob using a `priorityClassName` fails admission with the webhook timeout above.
- With the RBAC rule, the same TrainJob is admitted, the PodGroup is created, and the job runs to completion under Volcano scheduling with `system-cluster-critical` set.
- A TrainJob referencing a `priorityClassName` that does not exist is correctly rejected at admission time.

New test cases cover a reserved-priority job followed by an invalid one (should still error), and the reserved names being validated like any other name. The existing suite only covered single-`ReplicatedJob` scenarios.

Fixes #3917
