### PR TITLE
fix(framework): keep unnamed container ports when upserting

### DIFF
--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -62,8 +62,16 @@ func byEnvVarName(a, b corev1ac.EnvVarApplyConfiguration) bool {
 	return ptr.Equal(a.Name, b.Name)
 }
 
+// byContainerPortOrName reports whether two container ports identify the same port.
+// Kubernetes keys the container ports list by containerPort and protocol, so ports that
+// differ in either field are distinct. The name is only compared when both ports set one,
+// since the name is optional and two unnamed ports must not be treated as equal.
 func byContainerPortOrName(a, b corev1ac.ContainerPortApplyConfiguration) bool {
-	return ptr.Equal(a.ContainerPort, b.ContainerPort) || ptr.Equal(a.Name, b.Name)
+	if a.Name != nil && b.Name != nil && ptr.Equal(a.Name, b.Name) {
+		return true
+	}
+	return ptr.Equal(a.ContainerPort, b.ContainerPort) &&
+		ptr.Deref(a.Protocol, corev1.ProtocolTCP) == ptr.Deref(b.Protocol, corev1.ProtocolTCP)
 }
 
 func byVolumeName(a, b corev1ac.VolumeApplyConfiguration) bool {

--- a/pkg/apply/apply_test.go
+++ b/pkg/apply/apply_test.go
@@ -119,6 +119,23 @@ func TestUpsertPort(t *testing.T) {
 					WithContainerPort(8080),
 			},
 		},
+		"match by port number when the existing port sets an explicit protocol": {
+			existing: []corev1ac.ContainerPortApplyConfiguration{
+				*corev1ac.ContainerPort().
+					WithContainerPort(8080).
+					WithProtocol(corev1.ProtocolTCP),
+			},
+			toUpsert: []corev1ac.ContainerPortApplyConfiguration{
+				*corev1ac.ContainerPort().
+					WithName("http").
+					WithContainerPort(8080),
+			},
+			want: []corev1ac.ContainerPortApplyConfiguration{
+				*corev1ac.ContainerPort().
+					WithName("http").
+					WithContainerPort(8080),
+			},
+		},
 		"insert new port": {
 			existing: []corev1ac.ContainerPortApplyConfiguration{
 				*corev1ac.ContainerPort().WithContainerPort(8080),
@@ -127,7 +144,50 @@ func TestUpsertPort(t *testing.T) {
 				*corev1ac.ContainerPort().WithContainerPort(9090),
 			},
 			want: []corev1ac.ContainerPortApplyConfiguration{
+				*corev1ac.ContainerPort().WithContainerPort(8080),
 				*corev1ac.ContainerPort().WithContainerPort(9090),
+			},
+		},
+		"insert new unnamed port without dropping the existing unnamed ports": {
+			existing: []corev1ac.ContainerPortApplyConfiguration{
+				*corev1ac.ContainerPort().WithContainerPort(8080),
+				*corev1ac.ContainerPort().
+					WithName("metrics").
+					WithContainerPort(9090),
+			},
+			toUpsert: []corev1ac.ContainerPortApplyConfiguration{
+				*corev1ac.ContainerPort().WithContainerPort(29500),
+			},
+			want: []corev1ac.ContainerPortApplyConfiguration{
+				*corev1ac.ContainerPort().WithContainerPort(8080),
+				*corev1ac.ContainerPort().
+					WithName("metrics").
+					WithContainerPort(9090),
+				*corev1ac.ContainerPort().WithContainerPort(29500),
+			},
+		},
+		"insert new port with the same number and a different protocol": {
+			existing: []corev1ac.ContainerPortApplyConfiguration{
+				*corev1ac.ContainerPort().
+					WithName("dns-tcp").
+					WithContainerPort(53).
+					WithProtocol(corev1.ProtocolTCP),
+			},
+			toUpsert: []corev1ac.ContainerPortApplyConfiguration{
+				*corev1ac.ContainerPort().
+					WithName("dns-udp").
+					WithContainerPort(53).
+					WithProtocol(corev1.ProtocolUDP),
+			},
+			want: []corev1ac.ContainerPortApplyConfiguration{
+				*corev1ac.ContainerPort().
+					WithName("dns-tcp").
+					WithContainerPort(53).
+					WithProtocol(corev1.ProtocolTCP),
+				*corev1ac.ContainerPort().
+					WithName("dns-udp").
+					WithContainerPort(53).
+					WithProtocol(corev1.ProtocolUDP),
 			},
 		},
 		"insert new port with different names": {


### PR DESCRIPTION
### What this PR does / why we need it

`apply.UpsertPort` matched two container ports with:

```go
return ptr.Equal(a.ContainerPort, b.ContainerPort) || ptr.Equal(a.Name, b.Name)
```

`ptr.Equal(nil, nil)` returns `true`, so any two ports that both omit the optional `name` field compared as equal and `upsert` overwrote the existing entry in place. When the Torch, JAX or XGBoost plugin injects the trainer port `29500`, the first unnamed port declared by the runtime template was silently dropped from the generated JobSet, with no error, warning or event.

`Protocol` was not part of the comparison either, although Kubernetes keys this list by `containerPort` and `protocol` (`+listMapKey=containerPort`, `+listMapKey=protocol` on `Container.Ports`), so a TCP and a UDP port sharing a number collapsed into one entry.

This PR compares ports the way Kubernetes keys the list, by `containerPort` and `protocol`, and only matches on `name` when both ports set one. A nil `protocol` is treated as `TCP` to match Kubernetes defaulting, so an explicit `protocol: TCP` in a runtime template still merges with an injected port that leaves it unset.

Behaviour before and after, taken from the reproduction in the issue:

```
UpsertPort([{8080, unnamed}, {metrics, 9090}], {29500, unnamed})
  before: [{29500, unnamed}, {metrics, 9090}]                       // 8080 destroyed
  after:  [{8080, unnamed}, {metrics, 9090}, {29500, unnamed}]

Torch.EnforceMLPolicy -> JobSet.Build, runtime template declares port 8080
  before: JobSet container ports: [29500]
  after:  JobSet container ports: [8080, 29500]
```

### Which issue(s) this PR fixes

Fixes #3925

### Notes for reviewers

The existing `"insert new port"` test case asserted the old behaviour despite its name: it upserted `9090` into `[{8080}]` and expected `[{9090}]`. Its expectation is corrected in this PR so that both ports survive. This is the intended behaviour change, not an incidental test fixup, so please flag it if you read the previous semantics as deliberate.

Three cases are added to `TestUpsertPort`:

- an unnamed port is inserted without dropping existing unnamed ports
- ports with the same number and different protocols stay distinct
- an existing port with an explicit `protocol: TCP` still merges with an upserted port that leaves `protocol` unset

### Checklist

- [x] `go build ./...` and `go test ./pkg/...` pass locally
- [x] `gofmt` and `go vet` clean on the changed package
- [x] Commit is signed off (DCO)


