### PR TITLE
fix(initializer): use watch API to wait for the cache LeaderWorkerSet

### DIFF
--- a/pkg/initializers/dataset/cache.py
+++ b/pkg/initializers/dataset/cache.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import logging
-import time
 from urllib.parse import urlparse
 
-from kubernetes import client, config
+from kubernetes import client, config, watch
 from kubernetes.client.rest import ApiException
 
 import pkg.initializers.types.types as types
@@ -89,6 +88,7 @@ class CacheInitializer(utils.DatasetProvider):
         readiness_period = int(self.config.readiness_period_seconds)
         readiness_timeout = int(self.config.readiness_timeout_seconds)
         readiness_failure_threshold = int(self.config.readiness_failure_threshold)
+        cache_ready_timeout = int(self.config.cache_ready_timeout_seconds)
         namespace = get_namespace()
         metadata_loc = self.config.metadata_loc
         table_name = self.table_name
@@ -306,31 +306,37 @@ class CacheInitializer(utils.DatasetProvider):
                 else:
                     raise e
 
-            # Wait for LeaderWorkerSet to become ready
-            # TODO:// refactor to use watch API
-            while True:
-                try:
-                    lws = custom_api.get_namespaced_custom_object(
-                        group="leaderworkerset.x-k8s.io",
-                        version="v1",
-                        plural="leaderworkersets",
-                        name=lws_body["metadata"]["name"],
-                        namespace=namespace,
-                    )
-
-                    conditions = lws.get("status", {}).get("conditions", [])
+            # Wait for LeaderWorkerSet to become ready. The watch delivers the
+            # current state as an ADDED event before any updates, so a cluster
+            # that is already available is picked up on the first event.
+            lws_name = lws_body["metadata"]["name"]
+            w = watch.Watch()
+            try:
+                for event in w.stream(
+                    custom_api.list_namespaced_custom_object,
+                    group="leaderworkerset.x-k8s.io",
+                    version="v1",
+                    plural="leaderworkersets",
+                    namespace=namespace,
+                    field_selector=f"metadata.name={lws_name}",
+                    timeout_seconds=cache_ready_timeout,
+                ):
+                    conditions = event["object"].get("status", {}).get("conditions", [])
                     if any(
                         c["type"] == "Available" and c["status"] == "True"
                         for c in conditions
                     ):
-                        logging.info(
-                            f"LeaderWorkerSet {lws_body['metadata']['name']} is ready"
-                        )
+                        logging.info(f"LeaderWorkerSet {lws_name} is ready")
                         break
-
-                    time.sleep(5)
-                except ApiException as e:
-                    raise e
+                else:
+                    # The stream ended without the Available condition, which
+                    # means timeout_seconds elapsed first.
+                    raise TimeoutError(
+                        f"LeaderWorkerSet {lws_name} did not become ready within "
+                        f"{cache_ready_timeout}s"
+                    )
+            finally:
+                w.stop()
 
         except ApiException as e:
             logging.error(f"Cache cluster creation failed: {e}")

--- a/pkg/initializers/dataset/cache_test.py
+++ b/pkg/initializers/dataset/cache_test.py
@@ -21,6 +21,17 @@ import pkg.initializers.utils.utils as utils
 from pkg.initializers.dataset.cache import CacheInitializer, parse_cache_storage_uri
 
 
+def make_watch(objects):
+    """Build a mock watch.Watch() whose stream yields the given LWS objects.
+
+    An empty list models the stream ending without the Available condition,
+    which is what the client does once timeout_seconds elapses.
+    """
+    mock_w = MagicMock()
+    mock_w.stream.return_value = iter([{"object": obj} for obj in objects])
+    return mock_w
+
+
 @pytest.mark.parametrize(
     ("storage_uri", "expected"),
     [
@@ -77,6 +88,7 @@ def test_parse_cache_storage_uri(storage_uri, expected):
                 "readiness_period_seconds": "10",
                 "readiness_timeout_seconds": "5",
                 "readiness_failure_threshold": "3",
+                "cache_ready_timeout_seconds": "600",
             },
         ),
         (
@@ -103,6 +115,7 @@ def test_parse_cache_storage_uri(storage_uri, expected):
                 "readiness_period_seconds": "10",
                 "readiness_timeout_seconds": "5",
                 "readiness_failure_threshold": "3",
+                "cache_ready_timeout_seconds": "600",
             },
         ),
         (
@@ -131,6 +144,7 @@ def test_parse_cache_storage_uri(storage_uri, expected):
                 "readiness_period_seconds": "10",
                 "readiness_timeout_seconds": "5",
                 "readiness_failure_threshold": "3",
+                "cache_ready_timeout_seconds": "600",
             },
         ),
     ],
@@ -253,14 +267,16 @@ def test_download_dataset(test_name, test_case):
             "status": {"conditions": [{"type": "Available", "status": "True"}]}
         }
 
-        # Set side_effect to return training job first, then ready LWS status
         mock_custom_api.get_namespaced_custom_object.side_effect = [
-            mock_training_job,  # First call for training job
-            mock_lws_ready,  # Second call for LWS status check
+            mock_training_job,  # Only call left is the TrainJob owner lookup
         ]
 
-        # Execute cache cluster creation
-        cache_initializer_instance.download_dataset()
+        # Readiness now comes from the watch stream rather than a poll.
+        with patch("pkg.initializers.dataset.cache.watch") as mock_watch:
+            mock_watch.Watch.return_value = make_watch([mock_lws_ready])
+
+            # Execute cache cluster creation
+            cache_initializer_instance.download_dataset()
 
         # Verify Kubernetes client calls were made
         mock_config.load_incluster_config.assert_called_once()
@@ -317,13 +333,124 @@ def test_download_dataset_service_already_exists():
         mock_lws_ready = {
             "status": {"conditions": [{"type": "Available", "status": "True"}]}
         }
-        mock_custom_api.get_namespaced_custom_object.side_effect = [
-            mock_training_job,
-            mock_lws_ready,
-        ]
+        mock_custom_api.get_namespaced_custom_object.side_effect = [mock_training_job]
 
-        # Must not raise.
-        cache_initializer_instance.download_dataset()
+        with patch("pkg.initializers.dataset.cache.watch") as mock_watch:
+            mock_watch.Watch.return_value = make_watch([mock_lws_ready])
+
+            # Must not raise.
+            cache_initializer_instance.download_dataset()
 
         # Must not trigger cleanup of the ServiceAccount.
         mock_core_v1.delete_namespaced_service_account.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("test_name", "events"),
+    [
+        ("stream ends with no events at all", []),
+        (
+            "stream only ever reports a non-Available condition",
+            [{"status": {"conditions": [{"type": "Available", "status": "False"}]}}],
+        ),
+        ("object has no status block", [{}]),
+    ],
+)
+def test_download_dataset_readiness_timeout(test_name, events):
+    """The watch stream ending without an Available condition means
+    timeout_seconds elapsed. That must surface as a TimeoutError rather than
+    hanging forever, which is what the old poll loop did."""
+
+    print(f"Running test: {test_name}")
+
+    cache_initializer_instance = CacheInitializer()
+
+    config = {
+        "storage_uri": "cache://test_schema/test_table",
+        "train_job_name": "timeout-job",
+        "cache_image": "test-image:latest",
+        "iam_role": "arn:aws:iam::123456789012:role/test-role",
+        "metadata_loc": "s3://test-bucket/metadata",
+        "cache_ready_timeout_seconds": "30",
+    }
+
+    with patch.object(utils, "get_config_from_env", return_value=config):
+        cache_initializer_instance.load_config()
+
+    with patch(
+        "pkg.initializers.dataset.cache.get_namespace", return_value="test-namespace"
+    ), patch("pkg.initializers.dataset.cache.config"), patch(
+        "pkg.initializers.dataset.cache.client"
+    ) as mock_client, patch(
+        "pkg.initializers.dataset.cache.watch"
+    ) as mock_watch:
+
+        mock_custom_api = MagicMock()
+        mock_client.CustomObjectsApi.return_value = mock_custom_api
+        mock_custom_api.get_namespaced_custom_object.side_effect = [
+            {
+                "apiVersion": "trainer.kubeflow.org/v1alpha1",
+                "kind": "TrainJob",
+                "metadata": {"name": "timeout-job", "uid": "test-uid"},
+            }
+        ]
+
+        mock_w = make_watch(events)
+        mock_watch.Watch.return_value = mock_w
+
+        with pytest.raises(TimeoutError, match="did not become ready within 30s"):
+            cache_initializer_instance.download_dataset()
+
+        # The watch must be closed even on the timeout path.
+        mock_w.stop.assert_called()
+
+    print("Test execution completed")
+
+
+def test_download_dataset_watch_uses_configured_timeout():
+    """The overall wait must come from cache_ready_timeout_seconds, not from
+    readiness_timeout_seconds, which is the per-probe timeout."""
+
+    cache_initializer_instance = CacheInitializer()
+
+    config = {
+        "storage_uri": "cache://test_schema/test_table",
+        "train_job_name": "timeout-config-job",
+        "cache_image": "test-image:latest",
+        "iam_role": "arn:aws:iam::123456789012:role/test-role",
+        "metadata_loc": "s3://test-bucket/metadata",
+        "readiness_timeout_seconds": "5",
+        "cache_ready_timeout_seconds": "900",
+    }
+
+    with patch.object(utils, "get_config_from_env", return_value=config):
+        cache_initializer_instance.load_config()
+
+    with patch(
+        "pkg.initializers.dataset.cache.get_namespace", return_value="test-namespace"
+    ), patch("pkg.initializers.dataset.cache.config"), patch(
+        "pkg.initializers.dataset.cache.client"
+    ) as mock_client, patch(
+        "pkg.initializers.dataset.cache.watch"
+    ) as mock_watch:
+
+        mock_custom_api = MagicMock()
+        mock_client.CustomObjectsApi.return_value = mock_custom_api
+        mock_custom_api.get_namespaced_custom_object.side_effect = [
+            {
+                "apiVersion": "trainer.kubeflow.org/v1alpha1",
+                "kind": "TrainJob",
+                "metadata": {"name": "timeout-config-job", "uid": "test-uid"},
+            }
+        ]
+
+        mock_w = make_watch(
+            [{"status": {"conditions": [{"type": "Available", "status": "True"}]}}]
+        )
+        mock_watch.Watch.return_value = mock_w
+
+        cache_initializer_instance.download_dataset()
+
+        _, kwargs = mock_w.stream.call_args
+        assert kwargs["timeout_seconds"] == 900
+        assert kwargs["field_selector"] == "metadata.name=timeout-config-job-cache"

--- a/pkg/initializers/types/types.py
+++ b/pkg/initializers/types/types.py
@@ -78,3 +78,6 @@ class CacheDatasetInitializer:
     readiness_period_seconds: str = "10"
     readiness_timeout_seconds: str = "5"
     readiness_failure_threshold: str = "3"
+    # Overall wait for the cache cluster to report Available. Distinct from
+    # readiness_timeout_seconds, which is the per-probe timeout.
+    cache_ready_timeout_seconds: str = "600"


### PR DESCRIPTION
Fixes #3927

Picks up the `# TODO:// refactor to use watch API` in the cache initializer.

The poll loop it replaces had no exit other than success:

```python
while True:
    ...
    time.sleep(5)
```

So if the LeaderWorkerSet never went `Available` — bad image, unschedulable pods, no quota — the init container just sat there. TrainJob stuck, nothing in the logs after the last message before the loop, and the only way out was deleting the TrainJob. Switching to `watch.Watch().stream(...)` gets the bounded wait for free through `timeout_seconds`, so the refactor and the hang fix are the same change.

The watch sends the current object as an ADDED event before any updates, so a cache cluster that's already up is still picked up on the first event rather than waiting for the next status write.

## The new setting

`cache_ready_timeout_seconds`, default 600.

I did look at reusing `readiness_timeout_seconds` first, but that's the per-probe timeout on the container readinessProbe (default 5s) — wrong units entirely for an overall cluster wait. Both are read in the same block now, which reads a bit confusingly, so I'm open to renaming one if you'd prefer.

## Notes

`TimeoutError` isn't an `ApiException`, so it doesn't hit the cleanup path in the outer handler and the ServiceAccount/Service/LWS are left in place. That's deliberate — they all carry ownerReferences to the TrainJob so they're garbage collected with it, and leaving them up means you can actually `kubectl describe` the thing that failed to start. Happy to change it if you'd rather it cleaned up.

Dropped the `except ApiException as e: raise e` that wrapped the loop body. It was a bare re-raise and the outer handler catches the same thing.

## Test plan

- `pytest pkg/initializers/dataset/cache_test.py` — 19 passed
- The two existing tests fed readiness through `get_namespaced_custom_object.side_effect`, so they now mock the watch stream instead. Added the timeout path (three cases: empty stream, `Available=False`, no status block) and one asserting the stream gets `cache_ready_timeout_seconds` and the right field selector.
- Checked the new tests actually fail when the code is wrong, rather than trusting the green run. Removing the `TimeoutError` breaks 3, dropping `w.stop()` breaks 3, reading the wrong timeout value breaks 1, ignoring the condition `status` breaks 1, dropping the field selector breaks 1.
- pre-commit (isort/black/flake8) passes
