### PR TITLE
feat: KEP-2839 Dynamic LLM Trainer Framework

### DIFF
--- a/proposals/2839-dynamic-llm-trainer/README.md
+++ b/proposals/2839-dynamic-llm-trainer/README.md
@@ -7,7 +7,8 @@
 | **Created**    | 2026-02-11                                                   |
 | **Reviewers**  | @andreyvelich, @astefanutti, @kramaranya                     |
 | **Supersedes** | [kubeflow/trainer#3263](https://github.com/kubeflow/trainer/pull/3263) |
-| **Relevant Issues** | [kubeflow/trainer#2839](https://github.com/kubeflow/trainer/issues/2839), [kubeflow/sdk#626](https://github.com/kubeflow/sdk/issues/626) (parked) |
+| **Transferred from** | `kubeflow/sdk` `docs/proposals/285-specialized-trainers`, which was scoped SDK-only |
+| **Relevant Issues** | [trainer#2839](https://github.com/kubeflow/trainer/issues/2839), [sdk#285](https://github.com/kubeflow/sdk/issues/285), [sdk#626](https://github.com/kubeflow/sdk/issues/626) (parked) |
 
 ## Table of Contents
 
@@ -15,65 +16,30 @@
 - [KEP-2839: Kubeflow Dynamic LLM Trainer Framework](#kep-2839-kubeflow-dynamic-llm-trainer-framework)
   - [Table of Contents](#table-of-contents)
   - [Overview](#overview)
-  - [Motivation](#motivation)
-    - [User Value](#user-value)
-    - [Personas](#personas)
-    - [Why Specialized Trainers?](#why-specialized-trainers)
-    - [Goals](#goals)
-    - [Non-Goals](#non-goals)
-  - [Current State Analysis](#current-state-analysis)
-    - [CustomTrainer](#customtrainer)
-    - [BuiltinTrainer](#builtintrainer)
-    - [TrainerClient.train()](#trainerclienttrain)
-    - [Identified Limitations](#identified-limitations)
-  - [Proposal](#proposal)
-    - [A. BaseTrainer Abstract Interface](#a-basetrainer-abstract-interface)
-    - [B. FuncTrainer — Function-Driven Base](#b-functrainer--function-driven-base)
-      - [TorchTrainer](#torchtrainer)
-      - [DeepSpeedTrainer](#deepspeedtrainer)
-      - [JAXTrainer](#jaxtrainer)
-      - [XGBoostTrainer](#xgboosttrainer)
-    - [C. ConfigTrainer — Config-Driven Base](#c-configtrainer--config-driven-base)
-      - [BuiltinTrainer](#builtintrainer)
-    - [D. RuntimeConfig](#d-runtimeconfig)
-    - [E. TrainerClient Changes](#e-trainerclient-changes)
-    - [F. Config-Driven LLM Trainers](#f-config-driven-llm-trainers)
-      - [FrameworkConfig](#frameworkconfig)
-      - [Dynamic Registration](#dynamic-registration)
-      - [TorchTuneConfig](#torchtuneconfig)
-      - [TRLConfig](#trlconfig)
-      - [Control Plane](#control-plane)
-      - [Which Framework, and Why TRL](#which-framework-and-why-trl)
-  - [Design Details](#design-details)
-    - [Runtime Auto-Discovery](#runtime-auto-discovery)
-    - [Runtime Validation](#runtime-validation)
-    - [Trainer Responsibility Boundary](#trainer-responsibility-boundary)
-    - [Framework Argument Separation](#framework-argument-separation)
-    - [Backend Integration](#backend-integration)
-    - [Type Hierarchy Diagram](#type-hierarchy-diagram)
-  - [User-Facing API Examples](#user-facing-api-examples)
-    - [Before (Current)](#before-current)
-    - [After (Proposed)](#after-proposed)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+  - [Part I: Server Side (`kubeflow/trainer`)](#part-i-server-side-kubeflowtrainer)
+    - [I.1 What the torch plugin already provides](#i1-what-the-torch-plugin-already-provides)
+    - [I.2 `PET_*` is torchrun's private interface](#i2-pet_-is-torchruns-private-interface)
+    - [I.3 Proof of concept](#i3-proof-of-concept)
+    - [I.4 Limitation: the TRL CLI and `accelerate launch`](#i4-limitation-the-trl-cli-and-accelerate-launch)
+    - [I.5 Why the plugin does not change](#i5-why-the-plugin-does-not-change)
+    - [I.6 New artifacts](#i6-new-artifacts)
+  - [Part II: Client Side (`kubeflow/sdk`)](#part-ii-client-side-kubeflowsdk)
+    - [II.1 Current limitations](#ii1-current-limitations)
+    - [II.2 `BaseTrainer`](#ii2-basetrainer)
+    - [II.3 `FuncTrainer` and the framework trainers](#ii3-functrainer-and-the-framework-trainers)
+    - [II.4 `ConfigTrainer`](#ii4-configtrainer)
+    - [II.5 `RuntimeConfig`](#ii5-runtimeconfig)
+    - [II.6 `TrainerClient` and runtime auto-discovery](#ii6-trainerclient-and-runtime-auto-discovery)
+    - [II.7 `FrameworkConfig`, the registry, and `TRLConfig`](#ii7-frameworkconfig-the-registry-and-trlconfig)
+    - [II.8 Which framework, and why TRL](#ii8-which-framework-and-why-trl)
   - [Migration and Backward Compatibility](#migration-and-backward-compatibility)
   - [Test Plan](#test-plan)
-    - [Unit Tests](#unit-tests)
-    - [Integration Tests](#integration-tests)
-    - [Backward Compatibility Tests](#backward-compatibility-tests)
   - [Implementation Plan](#implementation-plan)
   - [Graduation Criteria](#graduation-criteria)
-    - [Alpha (target: current cycle)](#alpha-target-current-cycle)
-    - [Beta](#beta)
-    - [GA](#ga)
   - [Open Questions](#open-questions)
   - [Alternatives Considered](#alternatives-considered)
-    - [1. Extend CustomTrainer with a `framework` field instead of new classes](#1-extend-customtrainer-with-a-framework-field-instead-of-new-classes)
-    - [2. Use Pydantic `BaseModel` instead of `@dataclass`](#2-use-pydantic-basemodel-instead-of-dataclass)
-    - [3. Put RuntimeConfig inside BaseTrainer instead of as a separate parameter](#3-put-runtimeconfig-inside-basetrainer-instead-of-as-a-separate-parameter)
-    - [4. Automatic runtime selection with scoring/ranking instead of strict single-match](#4-automatic-runtime-selection-with-scoringranking-instead-of-strict-single-match)
-    - [5. Flat hierarchy: all trainers inherit directly from BaseTrainer](#5-flat-hierarchy-all-trainers-inherit-directly-from-basetrainer)
-    - [6. Have specialized trainers inherit from CustomTrainer](#6-have-specialized-trainers-inherit-from-customtrainer)
-    - [7. One config class per post-training method (SFTConfig, DPOConfig, GRPOConfig)](#7-one-config-class-per-post-training-method-sftconfig-dpoconfig-grpoconfig)
-    - [8. One trainer class per framework (TRLTrainer, TorchTuneTrainer)](#8-one-trainer-class-per-framework-trltrainer-torchtunetrainer)
   - [References](#references)
 <!-- /toc -->
 
@@ -81,235 +47,337 @@
 
 ## Overview
 
-This proposal introduces two backward-compatible enhancements to the Kubeflow SDK
-(`kubeflow/sdk`) trainer subsystem:
+Kubeflow Trainer can run exactly one config-driven LLM framework: TorchTune, whose upstream
+development stopped in July 2025. This proposal makes the framework axis extensible and
+lands Hugging Face TRL as the second framework.
 
-1. **Specialized, framework-aware trainer abstractions** — A three-level type hierarchy:
-   `BaseTrainer` (common interface) → `FuncTrainer` (function-driven) and `ConfigTrainer`
-   (config-driven), with framework-specific implementations (`TorchTrainer`,
-   `DeepSpeedTrainer`, `JAXTrainer`, etc.) that automatically discover and validate the
-   correct `ClusterTrainingRuntime` using the `trainer.kubeflow.org/framework` label.
-   This fills the "missing middle" between the overly generic `CustomTrainer` and the
-   overly narrow `BuiltinTrainer`.
+The work spans two repositories.
 
-2. **`RuntimeConfig` dataclass** — A dedicated configuration object that cleanly separates
-   per-job runtime environment settings (packages, pip config, environment variables) from
-   training logic and scaling parameters. This replaces the current pattern where
-   `CustomTrainer` conflates runtime concerns with trainer concerns.
+**Server side (`kubeflow/trainer`).** A framework becomes supportable by adding a runtime
+image and a `ClusterTrainingRuntime`. The CRDs, the controller and the torch plugin are
+unchanged — no Go at all. The torch plugin already publishes the cluster topology as
+`PET_*` environment variables, and `PET_*` is torchrun's own env interface. So the TRL
+runtime launches TRL's training script **with torchrun**
+(`torchrun -m trl.scripts.sft`), and the topology flows through with no translation
+([I.2](#i2-pet_-is-torchruns-private-interface) explains why this works). The `trl` CLI is
+not used: it hands off to `accelerate launch`, which does not read `PET_*` and degrades to
+single-process training while still reporting success. That failure is documented as a
+limitation ([I.4](#i4-limitation-the-trl-cli-and-accelerate-launch)), and supporting
+accelerate is deferred to a later phase.
 
-Both changes are purely additive. Existing code using `CustomTrainer`, `BuiltinTrainer`, and
-`TrainerClient.train()` remains fully functional without modification.
+**Client side (`kubeflow/sdk`).** Two additive changes: a trainer type hierarchy
+(`BaseTrainer` → `FuncTrainer` / `ConfigTrainer`) with runtime auto-discovery by the
+`trainer.kubeflow.org/framework` label, and a `RuntimeConfig` dataclass separating per-job
+environment settings from training logic. `CustomTrainer`, `BuiltinTrainer` and
+`TrainerClient.train()` keep working unchanged.
 
----
+The contract between the two sides already exists and is narrow: the framework label, and
+the container `command` the SDK appends rendered arguments to. Each side is independently
+useful — the runtime is usable from raw YAML before any SDK change ships.
 
-## Motivation
+A proof of concept for the server side was built and run on a cluster; its results are in
+[I.3](#i3-proof-of-concept) and they changed the design.
 
-### User Value
+## Goals
 
-The Kubeflow Trainer v2 architecture (KEP-2170) introduced a powerful separation between
-the *what* (`TrainJob`) and the *how* (`TrainingRuntime` / `ClusterTrainingRuntime`). The
-SDK exposes this through `TrainerClient.train()`, which accepts a trainer and an optional
-runtime reference. However, the current SDK abstractions create a usability gap:
+**Server side**
 
-- **`CustomTrainer`** requires the user to know the runtime name, manually look it up
-  via `get_runtime()`, and pass both training arguments and runtime-environment settings
-  (packages, pip URLs, env vars) into a single flat dataclass. It provides no
-  framework-specific validation or argument handling.
+1. Ship TRL as the second in-tree config-driven framework — a `cmd/trainers/trl/` image and
+   manifests under `manifests/base/runtimes/trl/`, mirroring what TorchTune already has —
+   launched with **torchrun**, the canonical launcher the torch plugin already serves.
+2. Keep the control plane completely unchanged: no Go, no CRD change, no knowledge of TRL.
+3. Document precisely why the `trl` CLI / `accelerate launch` route is excluded from phase
+   one (it fails *silently* at world size 1), so the future accelerate discussion can start
+   from measured results.
 
-- **`BuiltinTrainer`** is restricted to a single use case (`TorchTuneConfig`) and does
-  not accept user-defined training functions.
+**Client side**
 
-For the majority of distributed training workloads — "run this PyTorch DDP function on
-N nodes" or "run this DeepSpeed training script across a cluster" — neither abstraction
-fits well.
-Users must either use the low-level `CustomTrainer` with manual runtime wiring, or
-fall back to raw YAML.
+4. Define `BaseTrainer`, plus `FuncTrainer` (function-driven) and `ConfigTrainer`
+   (config-driven), so the SDK and backends handle every trainer through one interface.
+5. Implement `TorchTrainer`, `DeepSpeedTrainer`, `JAXTrainer` and `XGBoostTrainer` with
+   runtime auto-discovery and validation by framework label.
+6. Provide an extension point for community config-driven frameworks — a `FrameworkConfig`
+   subclass in any package.
+7. Introduce `RuntimeConfig`.
+8. Keep 100% backward compatibility with `CustomTrainer`, `CustomTrainerContainer`,
+   `BuiltinTrainer` and `TrainerClient.train()`.
 
-### Personas
+## Non-Goals
 
-This proposal benefits all three personas defined in KEP-2170:
-
-| Persona | Current Pain | Proposed Improvement |
-|---|---|---|
-| **Data Scientist / ML Engineer** | Must understand runtime names and Kubernetes concepts to use `CustomTrainer` | Uses `TorchTrainer(func=my_fn)` — runtime is auto-discovered |
-| **MLOps Engineer** | Must help data scientists find the correct runtime name for their framework | Framework validation catches mismatches at submission time |
-| **Platform Admin / DevOps** | Cannot enforce that users pick the correct runtime for their framework | Trainers validate `trainer.kubeflow.org/framework` labels on runtimes |
-
-### Why Specialized Trainers?
-
-Beyond runtime auto-discovery and framework validation, specialized trainers provide
-a set of capabilities that `CustomTrainer` cannot offer:
-
-| Capability | `CustomTrainer` | Specialized Trainer (e.g., `TorchTrainer`) |
-|---|---|---|
-| **Runtime selection** | User must know and pass the runtime name | Auto-discovered from `trainer.kubeflow.org/framework` label |
-| **Framework validation** | None — mismatches fail at execution time | Validated at submission time, before `TrainJob` is created |
-| **Typed framework arguments** | Untyped `func_args` dict mixes hyperparams with framework args (`max_restarts`, `deepspeed_config`) | Dedicated typed fields with IDE autocomplete and documentation |
-| **Separation of concerns** | Runtime env (`packages_to_install`, `env`), scaling (`num_nodes`), training logic (`func`), and framework args all in one flat dataclass | Training logic in `FuncTrainer`, config in `ConfigTrainer`, runtime env in `RuntimeConfig`, scaling on `BaseTrainer` |
-| **IDE/type-checker support** | `func_args: dict` — no autocomplete or type checking | Typed fields — autocomplete, mypy, and docstrings per framework |
-| **Extensibility** | Adding framework support requires modifying `CustomTrainer` or creating ad-hoc wrappers | New framework = new subclass of `FuncTrainer` or `ConfigTrainer` |
-| **Self-documenting API** | `CustomTrainer(func=..., func_args={"max_restarts": 3})` — unclear what's a hyperparam vs. framework arg | `TorchTrainer(func=..., max_restarts=3)` — intent is clear from the type |
-
-**In summary:** Specialized trainers encode framework knowledge into the type system.
-The trainer class itself tells you what framework it targets, what arguments it accepts,
-and what runtimes it is compatible with. This shifts errors from runtime to definition
-time and makes the SDK self-documenting.
-
-### Goals
-
-1. Define a `BaseTrainer` abstract interface that all trainer implementations satisfy,
-   enabling the SDK and backends to handle any trainer polymorphically.
-2. Define two intermediate abstract classes — `FuncTrainer` for function-driven
-   trainers and `ConfigTrainer` for config-driven trainers — that provide shared
-   fields and default implementations for their respective categories.
-3. Implement framework-specific function-driven trainers (`TorchTrainer`,
-   `DeepSpeedTrainer`, `JAXTrainer`, `XGBoostTrainer`) that auto-discover runtimes
-   by the `trainer.kubeflow.org/framework` label and validate runtime compatibility.
-4. Provide a clear extension point for community-contributed config-driven frameworks
-   (e.g., `TRLConfig`; an out-of-tree framework is a `FrameworkConfig` subclass in any
-   package).
-5. Introduce a `RuntimeConfig` dataclass to cleanly separate per-job runtime environment
-   settings from training-loop and scaling configuration.
-6. Maintain 100% backward compatibility with the existing `CustomTrainer`,
-   `CustomTrainerContainer`, `BuiltinTrainer`, and `TrainerClient.train()` APIs.
-
-### Non-Goals
-
-1. **Controller/CRD changes.** This proposal is SDK-only. No changes to the Kubeflow
-   Trainer controller, `TrainJob` CRD, or `ClusterTrainingRuntime` CRD are required.
-2. **New runtime labels or conventions.** We rely on the existing
-   `trainer.kubeflow.org/framework` label already required on all runtimes.
-3. **Deprecating `CustomTrainer` or `BuiltinTrainer`.** Both remain supported.
-   Specialized trainers are an additional option, not a replacement. `ConfigTrainer`
-   is designed as the successor to `BuiltinTrainer` for config-driven trainers,
-   but the migration is deferred to a follow-up proposal.
-4. **Tier 2 trainer implementations.** This proposal defines the extension mechanism
-   and interface. Concrete Tier 2 implementations (TorchTune, Transformers, Unsloth,
-   Axolotl) will be proposed in follow-up KEPs.
-5. **Changes to the `TrainJobTemplate` dataclass.** Template support for specialized
-   trainers can be added incrementally.
+1. **Any control-plane change.** No CRD or schema change, no version bump, and no Go: the
+   server-side work is a new image and new manifests. `EnforceMLPolicy` and `Validate` are
+   both unchanged — see [I.5](#i5-why-the-plugin-does-not-change).
+2. **A new framework plugin.** TRL reuses the torch plugin via `mlPolicy.torch`; no entry
+   is added to `pkg/runtime/framework/plugins/registry.go`.
+3. **New runtime labels or conventions.** `trainer.kubeflow.org/framework` is unchanged.
+4. **Supporting `accelerate launch`.** torchrun is the only launcher in scope, and the
+   plugin's existing `mlPolicy.torch` is the only mechanism used. Accelerate's launcher, and
+   the launcher-level options only it offers, is a separate discussion together with
+   dynamic registration. See
+   [I.4](#i4-limitation-the-trl-cli-and-accelerate-launch) for why it is excluded and
+   [Open Question #7](#open-questions) for what taking it up would involve.
+5. **Deprecating `CustomTrainer` or `BuiltinTrainer`.** Both stay supported.
+6. **In-tree Axolotl, LlamaFactory or Unsloth runtimes.** Only TRL is proposed here;
+   further frameworks are follow-up work.
+7. **Changes to `TrainJobTemplate`.**
 
 ---
 
-## Current State Analysis
+## Part I: Server Side (`kubeflow/trainer`)
 
-The following is the current SDK API surface as of `kubeflow-sdk v0.1` (source:
-[`kubeflow/trainer/types/types.py`](https://github.com/kubeflow/sdk/blob/main/kubeflow/trainer/types/types.py)).
+### I.1 What the torch plugin already provides
 
-### CustomTrainer
+Any runtime declaring `mlPolicy.torch` is processed by the torch plugin
+(`pkg/runtime/framework/plugins/torch/torch.go`). Its `EnforceMLPolicy` injects into the
+trainer container:
 
-```python
-@dataclass
-class CustomTrainer:
-    func: Callable
-    func_args: Optional[dict] = None
-    image: Optional[str] = None
-    packages_to_install: Optional[list[str]] = None          # Runtime concern
-    pip_index_urls: list[str] = field(                       # Runtime concern
-        default_factory=lambda: list(constants.DEFAULT_PIP_INDEX_URLS)
-    )
-    num_nodes: Optional[int] = None                          # Scaling concern
-    resources_per_node: Optional[dict] = None                # Scaling concern
-    env: Optional[dict[str, str]] = None                     # Runtime concern
+| Env var | Value | Source |
+|---|---|---|
+| `PET_NNODES` | trainer PodSet count | `torch.go:147` |
+| `PET_NPROC_PER_NODE` | `spec.trainer.numProcPerNode`, else `"auto"`, else the CPU count when no GPU | `torch.go:121-135`, `:150` |
+| `PET_NODE_RANK` | field ref to the JobSet completion index | `torch.go:152-156` |
+| `PET_MASTER_ADDR` | `<trainjob>-node-0-0.<trainjob>` | `torch.go:161-162` |
+| `PET_MASTER_PORT` | `29500` | `torch.go:163-165` |
+
+It also opens port 29500 for the headless service, and rejects a `TrainJob` that tries to
+set any of those five variables itself.
+
+There is exactly one framework-specific branch: when `spec.trainer.command` equals
+`["tune", "run"]`, the plugin withholds `PET_MASTER_ADDR` / `PET_MASTER_PORT` and rewrites
+the command with `--rdzv_endpoint=<host>:29500` plus the recipe, config and runtime-derived
+overrides (`torch.go:175-201`). Every other command gets all five and no rewrite.
+
+So a second framework inherits a complete description of the topology for free. **The only
+question is whether its launcher reads it.**
+
+### I.2 `PET_*` is torchrun's private interface
+
+`PET_*` is not a Kubeflow convention. It is how torchrun reads its own flags from the
+environment: for every flag, torchrun also accepts a `PET_`-prefixed env var
+(`torch.distributed.argparse_util`), so `PET_NNODES` is simply `--nnodes`. That puts
+`PET_*` at a specific layer:
+
+```
+1. Torch plugin        →  sets PET_NNODES, PET_NPROC_PER_NODE, PET_NODE_RANK,
+                          PET_MASTER_ADDR, PET_MASTER_PORT
+2. Launcher (torchrun) →  reads PET_*, decides how many processes to spawn
+3. Launcher            →  spawns them, exports RANK, WORLD_SIZE, LOCAL_RANK,
+                          MASTER_ADDR, MASTER_PORT
+4. Training script     →  reads those standard variables
 ```
 
-**Issues:**
+`PET_*` is the launcher's **input**; `RANK` / `WORLD_SIZE` are its **output**. A framework
+that does not launch through torchrun never reaches step 2, so nothing produces step 3.
 
-- Mixes runtime-environment settings (`packages_to_install`, `pip_index_urls`, `env`)
-  with scaling/resource settings (`num_nodes`, `resources_per_node`) and training logic
-  (`func`, `func_args`).
-- No framework awareness. A user can pass a PyTorch training function with a
-  DeepSpeed runtime and the SDK will not catch the mismatch until the controller
-  rejects the job or, worse, it fails at execution time.
-- `func_args` is an untyped `dict` that conflates user hyperparameters with framework
-  arguments (e.g., `rdzv_endpoint`, `nnodes`) that the Trainer controller already
-  injects via environment variables.
+TRL's *CLI* is such a case: `trl sft` hands off to `accelerate launch`
+(`trl/cli/accelerate_launcher.py` resolves the training script and calls accelerate's
+`launch_command`), and **accelerate-the-launcher has no reference to `PET_` anywhere in its
+source** — it is a *peer* of torchrun that takes topology from flags.
 
-### BuiltinTrainer
+But the CLI is only a wrapper. What it wraps — `trl/scripts/sft.py` — is a **plain training
+script**: `TrlParser` argument parsing plus `SFTTrainer(...).train()`, no launcher logic,
+runnable as a module. And the accelerate *library* inside it (`PartialState`, a hard
+dependency of TRL) detects torchrun's step-3 output from the environment: `LOCAL_RANK` set →
+multi-GPU (nccl); `WORLD_SIZE > 1` on CPU → multi-CPU (gloo).
 
-```python
-@dataclass
-class BuiltinTrainer:
-    config: TorchTuneConfig
+So TRL fits the diagram directly by making torchrun the launcher of TRL's own script:
+
+```yaml
+command: [torchrun, -m, trl.scripts.sft]
 ```
 
-- Hardcoded to `TorchTuneConfig`. Cannot be extended to other config-driven frameworks
-  without modifying the class itself.
+torchrun consumes the plugin's `PET_*` natively (including `numProcPerNode: "auto"`, which
+it resolves itself), and the script's in-process accelerate reads what torchrun exports.
+No translation of variables, no translation of commands, no plugin change — the same path
+other torchrun-native frameworks in the Trainer already use, Megatron included. This is the design; the `accelerate launch`
+route is a documented limitation ([I.4](#i4-limitation-the-trl-cli-and-accelerate-launch)).
 
-### TrainerClient.train()
+### I.3 Proof of concept
 
-```python
-def train(
-    self,
-    runtime: Optional[Union[str, types.Runtime]] = None,
-    initializer: Optional[types.Initializer] = None,
-    trainer: Optional[
-        Union[types.CustomTrainer, types.CustomTrainerContainer, types.BuiltinTrainer]
-    ] = None,
-    options: Optional[list] = None,
-) -> str:
+Three runs — two on the cluster, one reproducible locally — all with the exact `PET_*`
+variables the unmodified torch plugin injects. The only difference is what consumed them.
+
+| Run | Where | Consumer of `PET_*` | Outcome |
+|---|---|---|---|
+| `probe-rendezvous` | cluster, 2 CPU nodes | bare `torchrun` | `[Gloo] Rank 1 is connected to 1 peer ranks`, then `rank=1 world_size=2 allreduce=2.0`. **Real rendezvous** from the plugin's injected env. |
+| torchrun + TRL script | Linux container, 2 simulated nodes | `torchrun -m trl.scripts.sft` — the runtime's exact command | First-step `epoch` moved from `0.05882` (1/17, single-node control) to `0.1111` (1/9): the dataset sharded across 2 ranks. **World size 2**, both launches completed. |
+| `trl-demo` | cluster, 2 CPU nodes | `trl sft` → `accelerate launch`, via a flag-translating entrypoint | Flags translated **correctly** per pod, yet `epoch` advanced `1/52002` per step instead of `2/52002`: **world size 1**. Both pods `Succeeded`, TrainJob `Complete` — a silent failure. |
+
+The probe proves the plugin→torchrun half on real infrastructure: each rank contributes
+`1.0` to a Gloo all-reduce, so a sum of `2.0` can only come from two processes that
+exchanged data. The container run proves the torchrun→TRL half with TRL's real `sft.py`,
+launched with **only** the five `PET_*` variables set — no topology flags, no CLI. The
+epoch value cannot lie: 17 examples become 9 steps/epoch only when the data is split
+across 2 workers, and a worker that failed to connect would hang rather than complete. The
+run is committed as `examples/trl/local_torchrun_proof.sh` (needs only docker) and used
+`--use_cpu`, so reproducing it — and the eventual cluster E2E — needs no GPUs.
+
+**What is not yet proven.** The two halves were verified separately: cross-pod rendezvous on
+the cluster, and the TRL script under torchrun locally. Running the TRL script across two
+real pods is the remaining step, and it is the first item of the E2E phase. Nothing in the
+two results suggests it will behave differently — the local run used the manifest's exact
+command, and the pod-to-pod path is what the probe already exercised — but it has not been
+run.
+
+`trl-demo` is the failure case, and the reason the accelerate route is excluded from phase
+one; [I.4](#i4-limitation-the-trl-cli-and-accelerate-launch) records its causes.
+
+### I.4 Limitation: the TRL CLI and `accelerate launch`
+
+The TRL CLI cannot be the runtime command. `trl-demo` failed for two causes, both in
+accelerate's launcher and both **exiting 0** — JobSet observes completion, the TrainJob
+reports `Succeeded`, and no signal reaches the control plane:
+
+1. **`--use_cpu` disables every distributed path** *(demonstrated on the cluster)*. Each
+   distributed branch in `launch_command` is guarded `... and not args.cpu`, so a CPU run
+   falls through to `simple_launcher`, which never sets `RANK` / `WORLD_SIZE`.
+2. **`--multi_gpu` is inferred only from local device count** *(from source)*. Accelerate
+   auto-enables it when `torch.cuda.device_count() > 1` in the current process — never true
+   at one GPU per pod.
+
+Both are properties of the *launcher* and vanish when torchrun launches the script: the
+container run in [I.3](#i3-proof-of-concept) used `--use_cpu` and still reached world
+size 2, because in-process accelerate reads the env torchrun had already exported.
+
+Choosing torchrun is also the pattern the Trainer already follows for other frameworks —
+Megatron runs under the torchrun launcher today — so TRL joins an established path rather
+than introducing a second one. Axolotl and LlamaFactory can both be launched by torchrun as
+well, which is a useful signal for later frameworks but not part of this proposal.
+
+**What torchrun gives up.** Most of what `accelerate launch` configures is also exposed by
+HF `TrainingArguments`, so it survives as ordinary script flags: `--deepspeed`, `--fsdp`,
+`--fsdp_config`, `--accelerator_config`, `--bf16` / `--fp16`, `--gradient_checkpointing`,
+`--torch_compile`, `--ddp_backend`. DeepSpeed and FSDP are therefore **not** lost. What is
+genuinely unavailable under torchrun:
+
+| Not available | Impact |
+|---|---|
+| `--config_file` — one accelerate YAML per job | Cosmetic here: the same settings are reachable as script flags, and a runtime manifest is already the place operators express them. |
+| `--use_megatron_lm` | The accelerate Megatron-LM plugin. Out of scope for TRL post-training. |
+| `--tpu` | No TPU support in the Trainer's torch plugin either. |
+| `--mixed_precision`, `--dynamo_backend` at launch time | Covered by `--bf16` / `--fp16` and `--torch_compile` on the script. |
+| `--mpirun_hostfile` | Only needed because accelerate cannot do multi-process CPU without MPI. torchrun does it natively over gloo, so this is a limitation torchrun *removes*. |
+
+Supporting `accelerate launch` is **out of scope here** and left to a later discussion
+([Open Question #7](#open-questions)).
+
+**In short: we do not use accelerate's launcher — torchrun launches TRL's script directly.
+accelerate is still in the image because TRL depends on it (`accelerate>=1.4.0`, and HF
+`Trainer` cannot be imported without it), but in-process it only reads the variables
+torchrun exported.** The distinction matters for review: what is excluded here is a second
+launcher, not a library.
+
+### I.5 Why the plugin does not change
+
+`EnforceMLPolicy` today supports the torchrun launcher through the `PET_*` variables, and
+that is exactly what TRL needs. Every run in [I.3](#i3-proof-of-concept) used an unmodified
+`torch.go`:
+
+- TRL under torchrun wants exactly the plugin's default behaviour — all five `PET_*`
+  injected, command untouched. The TorchTune branch exists only because `tune run` takes
+  rendezvous as a *command-line argument*; nothing analogous is needed here.
+- Which module torchrun runs (`trl.scripts.sft` vs `.dpo` vs `.grpo`) is declared in the
+  runtime manifest and shipped in the image. A TRL upgrade is an image rebuild, not a
+  controller release.
+
+`Validate` is also unchanged: with torchrun as the launcher there is no CPU-multi-node
+failure mode left to reject at admission.
+
+### I.6 New artifacts
+
+Two, mirroring what TorchTune already has. No extra script or binary in the image — the
+command is torchrun invoking TRL's training module.
+
+**1. `cmd/trainers/trl/`** — `Dockerfile` on the same PyTorch base as
+`cmd/trainers/torchtune`, installing pinned `trl` + dependencies. accelerate is among them
+— TRL requires it (`accelerate>=1.4.0`) and HF `Trainer` cannot be imported without it — but
+it is used only in-process; its launcher is never invoked. With:
+
+```dockerfile
+ENTRYPOINT ["torchrun", "-m", "trl.scripts.sft"]
 ```
 
-- The `trainer` parameter type union must be extended for each new trainer type.
-- No concept of runtime auto-discovery: if `runtime` is `None`, it defaults to
-  `torch-distributed` regardless of the trainer type.
+**2. `manifests/base/runtimes/trl/`** — one `ClusterTrainingRuntime` per base model,
+mirroring `manifests/base/runtimes/torchtune/`. Initializer replicatedJobs are identical and
+omitted here:
 
-### Identified Limitations
+```yaml
+kind: ClusterTrainingRuntime
+metadata:
+  name: trl-qwen2.5-1.5b
+  labels:
+    trainer.kubeflow.org/framework: trl   # the SDK's discovery key
+spec:
+  mlPolicy: {numNodes: 1, torch: {}}      # engages the torch plugin; PET_* injection
+  # ...
+                    - name: node
+                      image: ghcr.io/kubeflow/trainer/trl-trainer
+                      # torchrun reads PET_* natively; the trl CLI and
+                      # accelerate launch are never invoked. Other methods
+                      # swap the module: trl.scripts.dpo, trl.scripts.grpo.
+                      command: [torchrun, -m, trl.scripts.sft]
+                      args:
+                        - --model_name_or_path=/workspace/model
+                        - --dataset_name=/workspace/dataset
+                        - --output_dir=/workspace/output
+```
+
+The command is not `["tune", "run"]`, so `EnforceMLPolicy` takes its default path. The
+manifest's `sft` module is the raw-YAML default; an SDK-submitted `TrainJob` carries
+`command: [torchrun, -m]` with the method's module as the first entry of `args`
+(`TRLConfig.to_args()`, [II.7](#ii7-frameworkconfig-the-registry-and-trlconfig)), so one
+runtime serves every method.
+
+**The server side stops here** — an image and manifests, no control-plane code. One gap is
+deferred rather than dismissed: none of this lets a runtime *report* its achieved world
+size, so a silently degraded run (the `trl-demo` shape, in any framework) is still
+indistinguishable from success at the control plane. See
+[Open Question #6](#open-questions).
+
+---
+
+## Part II: Client Side (`kubeflow/sdk`)
+
+### II.1 Current limitations
+
+The SDK offers `CustomTrainer` (a flat dataclass taking `func`, `func_args`, `image`,
+`packages_to_install`, `pip_index_urls`, `num_nodes`, `resources_per_node`, `env`) and
+`BuiltinTrainer` (a single field, `config: TorchTuneConfig`).
 
 | # | Limitation | Impact |
 |---|---|---|
-| 1 | **Missing middle abstraction** | 90% of workloads fall between BuiltinTrainer (too specific) and CustomTrainer (too generic) |
-| 2 | **Mixed concerns in CustomTrainer** | Runtime config, scaling config, and training logic are tangled in one dataclass |
-| 3 | **No framework validation** | Mismatched trainer/runtime combinations fail late — at execution, not submission |
-| 4 | **No framework-specific arguments** | torch-specific args (e.g., `max-restarts`, `monitor-interval`) have no typed home |
-| 5 | **BuiltinTrainer is not extensible** | Adding a new config-driven framework requires changing the BuiltinTrainer class |
-| 6 | **Flat `func_args` dict** | User hyperparameters mix with framework arguments the controller injects |
+| 1 | **Missing middle abstraction** | Most workloads fall between `BuiltinTrainer` (too specific) and `CustomTrainer` (too generic) |
+| 2 | **Mixed concerns in `CustomTrainer`** | Runtime env, scaling and training logic tangled in one dataclass |
+| 3 | **No framework validation** | Mismatched trainer/runtime pairs fail at execution, not submission |
+| 4 | **No typed framework arguments** | `max-restarts`, `deepspeed_config` have no home but the untyped `func_args` |
+| 5 | **`BuiltinTrainer` is not extensible** | A new config-driven framework means changing the class |
+| 6 | **No runtime auto-discovery** | `runtime=None` defaults to `torch-distributed` regardless of trainer type |
 
----
+TorchTune is hardcoded at four points, and #3 is the one that blocks everything else:
 
-## Proposal
+| # | Coupling | Location |
+|---|---|---|
+| 1 | `BuiltinTrainer.config` annotated with the concrete `TorchTuneConfig` | `types.py:226-236` |
+| 2 | Framework identifier derived by reflecting on that annotation | `types.py:239-240` |
+| 3 | `trainer_type` and entrypoint selected by string-comparing the label against it | `utils.py:114-119`, `:140-158` |
+| 4 | Config-to-argument translation guarded by `isinstance(..., TorchTuneConfig)` | `utils.py:451-452` |
 
-### A. BaseTrainer Abstract Interface
+`trainer_type` is not a field on the Runtime CR; the SDK computes it as `BUILTIN_TRAINER if
+framework == TORCH_TUNE else CUSTOM_TRAINER`. A runtime labelled `trl` therefore resolves to
+`CUSTOM_TRAINER` today and `ConfigTrainer.validate_runtime()` would reject it. Until
+`get_runtime_trainer()` changes, no config-driven framework but TorchTune can run.
 
-Introduce an abstract base class that defines the contract all trainers must satisfy.
-This enables the SDK, backends, and `TrainerClient` to work with any trainer
-polymorphically through a single, stable interface.
-
-`BaseTrainer` holds common fields and methods shared by both function-driven and
-config-driven trainers. The training-mode-specific concerns (`func`/`func_args` vs.
-`config`) are pushed down to the two intermediate classes described in sections B and C.
+### II.2 `BaseTrainer`
 
 ```python
-# kubeflow/trainer/types/types.py
-
-from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
-from typing import Callable, Optional, ClassVar
-
 @dataclass(kw_only=True)
 class BaseTrainer(ABC):
-    """Abstract base class for all specialized trainer implementations.
+    """Common fields, runtime auto-discovery and framework validation.
 
-    Provides common fields for scaling and resource configuration, runtime
-    auto-discovery via the `supported_frameworks` class variable, and
-    framework validation.
-
-    Subclasses should not inherit from this directly — use `FuncTrainer`
-    for function-driven trainers or `ConfigTrainer` for config-driven trainers.
-
-    Class Attributes:
-        supported_frameworks: Framework identifiers this trainer supports.
-            Must match values of the `trainer.kubeflow.org/framework` label
-            on ClusterTrainingRuntime resources. Declared as a tuple (immutable)
-            and ordered by preference — the first entry is the preferred framework
-            for auto-discovery.
-
-    Args:
-        num_nodes: Number of nodes for distributed training.
-        resources_per_node: Resource requirements per node (cpu, memory, gpu).
-        image: Optional custom container image.
+    Subclasses use FuncTrainer or ConfigTrainer rather than inheriting directly.
+    supported_frameworks must match `trainer.kubeflow.org/framework` values, and
+    is ordered by preference — the first entry wins auto-discovery.
     """
-
     supported_frameworks: ClassVar[tuple[str, ...]]
 
     num_nodes: Optional[int] = None
@@ -317,147 +385,61 @@ class BaseTrainer(ABC):
     image: Optional[str] = None
 
     def __init_subclass__(cls, **kwargs: object) -> None:
-        super().__init_subclass__(**kwargs)
-        # `__abstractmethods__` is a `type` descriptor that does not inherit
-        # through the MRO, and ABCMeta populates it only *after*
-        # `__init_subclass__` runs — so it cannot be used to detect an abstract
-        # subclass here. Skip classes that declare abstract methods of their own,
-        # and let `abc` reject instantiation of anything still abstract.
-        if any(
-            getattr(value, "__isabstractmethod__", False)
-            for value in cls.__dict__.values()
-        ):
-            return
-        if not getattr(cls, "supported_frameworks", None):
-            raise TypeError(
-                f"{cls.__name__} must define a non-empty "
-                f"'supported_frameworks' class variable"
-            )
+        """Reject a concrete subclass that forgot to declare supported_frameworks,
+        at class-definition time. Abstract intermediates (FuncTrainer,
+        ConfigTrainer) are skipped."""
 
     def validate_runtime(self, runtime: "Runtime") -> None:
-        """Validate that the given runtime is compatible with this trainer.
-
-        The default implementation checks the runtime's framework label against
-        `supported_frameworks`. Subclasses may add additional validation.
-
-        Raises:
-            ValueError: If the runtime's framework is not in supported_frameworks.
-        """
+        """Raise ValueError if the runtime's framework is unsupported."""
         if runtime.trainer.framework not in self.supported_frameworks:
-            raise ValueError(
-                f"{type(self).__name__} supports frameworks "
-                f"{self.supported_frameworks}, but runtime '{runtime.name}' "
-                f"has framework '{runtime.trainer.framework}'"
-            )
+            raise ValueError(...)
 ```
 
-**Design decisions:**
+- `supported_frameworks` is a `ClassVar[tuple[...]]` — immutable, class-level, ordered by
+  preference. `__init_subclass__` catches a missing declaration at class-definition time.
+- `@dataclass(kw_only=True)`: `BaseTrainer`'s fields have defaults, so without it
+  `FuncTrainer.func` could not be required. Existing types keep their bare declarations —
+  their signatures are public API.
+- No shared argument-rendering method: `FuncTrainer` declares `get_framework_args()`, the
+  config-driven path renders through `config.to_args()`. A dict-shaped accessor on
+  `BaseTrainer` would duplicate `to_args()`.
 
-- `supported_frameworks` is a `ClassVar[tuple[str, ...]]` — immutable and class-level.
-  It is a property of the trainer *class*, not of individual instances. The tuple is
-  ordered by preference: the first entry is the preferred framework for auto-discovery.
-  `__init_subclass__` enforces that every concrete subclass defines a non-empty
-  `supported_frameworks`, catching missing declarations at class definition time
-  rather than at runtime. It detects abstract intermediates by inspecting
-  `cls.__dict__` for `__isabstractmethod__` rather than reading
-  `cls.__abstractmethods__`: that attribute is a `type` descriptor which does not
-  inherit through the MRO, and `ABCMeta` populates it only *after*
-  `__init_subclass__` has run, so it is always absent here. Reading it would make
-  the guard fire on `FuncTrainer` and `ConfigTrainer` themselves, which legitimately
-  do not declare `supported_frameworks`.
-- Common fields (`num_nodes`, `resources_per_node`, `image`) live on `BaseTrainer` so
-  every trainer inherits them without repetition.
-- The new hierarchy is `@dataclass(kw_only=True)`: `BaseTrainer`'s fields have defaults,
-  so without `kw_only` a subclass could not declare a required field — `FuncTrainer.func`
-  would raise `TypeError` at class-definition time. Existing types (`CustomTrainer`,
-  `BuiltinTrainer`) keep their bare declarations; their signatures are public API.
-- `BaseTrainer` declares no argument-rendering method. Each branch renders its own way:
-  `FuncTrainer` declares `get_framework_args()` (abstract), and the config-driven path
-  renders through the config's `to_args()` ([Section F](#f-config-driven-llm-trainers)).
-  Putting a shared dict-shaped accessor on `BaseTrainer` would duplicate `to_args()` on
-  the config side.
-- `validate_runtime()` has a default implementation so subclasses get validation for
-  free but can extend it.
-- Methods use `get_*` naming to clearly indicate they are accessors, not setters.
-
-### B. FuncTrainer — Function-Driven Base
-
-`FuncTrainer` is the base class for trainers where the user provides a Python training
-function. It owns the `func` and `func_args` fields and implements the corresponding
-accessors, so concrete framework trainers only need to add framework-specific fields.
+### II.3 `FuncTrainer` and the framework trainers
 
 ```python
 @dataclass(kw_only=True)
 class FuncTrainer(BaseTrainer):
-    """Base class for function-driven trainers.
+    """The user provides a training function, executed in the distributed
+    environment the runtime configures.
 
-    The user provides a training function that is serialized and executed
-    within the distributed environment configured by the runtime.
-
-    Args:
-        func: The training function. Each node executes this function.
-        func_args: Arguments passed to the training function. Should contain
-            only user hyperparameters — framework arguments like rdzv_endpoint
-            and nnodes are injected by the Kubeflow Trainer controller.
+    func_args should hold only user hyperparameters — rdzv_endpoint, nnodes and
+    the rest are injected by the controller.
     """
-
     func: Callable
     func_args: Optional[dict] = None
 
     @abstractmethod
     def get_framework_args(self) -> dict:
-        """Return framework-specific CLI/env arguments that do not overlap
-        with arguments injected by the Kubeflow Trainer controller
-        (e.g., rdzv_endpoint, nnodes are excluded)."""
-        ...
+        """Framework CLI/env arguments that do not overlap with controller-injected ones."""
 
-    def get_train_func(self) -> Callable:
-        """Return the user-provided training function."""
-        return self.func
-
-    def get_train_func_args(self) -> Optional[dict]:
-        """Return the arguments to pass to the training function."""
-        return self.func_args
+    def get_train_func(self) -> Callable: return self.func
+    def get_train_func_args(self) -> Optional[dict]: return self.func_args
 
     def validate_runtime(self, runtime: "Runtime") -> None:
-        """Validate framework and trainer_type compatibility.
-
-        FuncTrainer requires runtimes with trainer_type == CUSTOM_TRAINER.
-        """
         super().validate_runtime(runtime)
-        if runtime.trainer.trainer_type != TrainerType.CUSTOM_TRAINER:
-            raise ValueError(
-                f"{type(self).__name__} requires a runtime with "
-                f"trainer_type={TrainerType.CUSTOM_TRAINER.value}, but "
-                f"runtime '{runtime.name}' has "
-                f"trainer_type={runtime.trainer.trainer_type.value}"
-            )
+        # FuncTrainer additionally requires trainer_type == CUSTOM_TRAINER.
 ```
 
-Concrete function-driven trainers extend `FuncTrainer` and only need to define
-`supported_frameworks`, framework-specific fields, and `get_framework_args()`:
-
-#### TorchTrainer
+Concrete trainers add only `supported_frameworks`, typed fields, and
+`get_framework_args()`:
 
 ```python
 @dataclass
 class TorchTrainer(FuncTrainer):
-    """Trainer for PyTorch distributed training workloads.
-
-    Supports runtimes labeled with `trainer.kubeflow.org/framework: torch`.
-
-    Args:
-        max_restarts: Maximum number of worker group restarts before failing.
-            Maps to torchrun --max-restarts.
-        monitor_interval: Interval in seconds for the elastic agent to monitor
-            workers. Maps to torchrun --monitor-interval.
-    """
-
     supported_frameworks: ClassVar[tuple[str, ...]] = ("torch",)
 
-    # Torch-specific arguments (non-overlapping with controller-injected args)
-    max_restarts: Optional[int] = None
-    monitor_interval: Optional[float] = None
+    max_restarts: Optional[int] = None       # torchrun --max-restarts
+    monitor_interval: Optional[float] = None # torchrun --monitor-interval
 
     def get_framework_args(self) -> dict:
         args = {}
@@ -468,108 +450,20 @@ class TorchTrainer(FuncTrainer):
         return args
 ```
 
-#### DeepSpeedTrainer
+| Trainer | `supported_frameworks` | Typed fields | Notes |
+|---|---|---|---|
+| `TorchTrainer` | `("torch",)` | `max_restarts`, `monitor_interval` | |
+| `DeepSpeedTrainer` | `("deepspeed", "torch")` | `deepspeed_config`, `num_proc_per_node` | Bootstraps via torchrun or mpirun, so it accepts both runtime types; when both exist the user picks explicitly. `deepspeed_config` accepts a path or a dict (JSON-encoded). |
+| `JAXTrainer` | `("jax",)` | — | `get_framework_args()` returns `{}` |
+| `XGBoostTrainer` | `("xgboost",)` | — | `get_framework_args()` returns `{}` |
 
-```python
-@dataclass
-class DeepSpeedTrainer(FuncTrainer):
-    """Trainer for DeepSpeed distributed training workloads.
-
-    DeepSpeed can be bootstrapped via either `torchrun` or `mpirun`, so this
-    trainer supports both torch-based and MPI-based runtimes. The SDK
-    auto-discovers a compatible runtime by matching the
-    `trainer.kubeflow.org/framework` label against the supported frameworks.
-    When both runtime types are available, the user must specify the runtime
-    explicitly.
-
-    Args:
-        deepspeed_config: Path or dict for the DeepSpeed JSON configuration.
-            When provided, the config is passed to the DeepSpeed launcher
-            via the --deepspeed_config flag.
-        num_proc_per_node: Number of processes per node. Maps to
-            --num_gpus (DeepSpeed launcher) or --nproc_per_node (torchrun).
-    """
-
-    supported_frameworks: ClassVar[tuple[str, ...]] = ("deepspeed", "torch")
-
-    # DeepSpeed-specific arguments
-    deepspeed_config: Optional[Union[str, dict]] = None
-    num_proc_per_node: Optional[int] = None
-
-    def validate_runtime(self, runtime: "Runtime") -> None:
-        """Validate framework compatibility and launcher support.
-
-        In addition to the standard framework label check, DeepSpeedTrainer
-        verifies that the runtime's launcher is compatible (torchrun or mpirun).
-        """
-        super().validate_runtime(runtime)
-        # TODO: Check runtime.trainer.command for launcher compatibility
-        # once the Runtime type exposes launcher metadata.
-
-    def get_framework_args(self) -> dict:
-        args = {}
-        if self.deepspeed_config is not None:
-            if isinstance(self.deepspeed_config, dict):
-                import json
-                args["deepspeed_config"] = json.dumps(self.deepspeed_config)
-            else:
-                args["deepspeed_config"] = self.deepspeed_config
-        if self.num_proc_per_node is not None:
-            args["num-proc-per-node"] = str(self.num_proc_per_node)
-        return args
-```
-
-#### JAXTrainer
-
-```python
-@dataclass
-class JAXTrainer(FuncTrainer):
-    """Trainer for JAX distributed training workloads.
-
-    Supports runtimes labeled with `trainer.kubeflow.org/framework: jax`.
-    """
-
-    supported_frameworks: ClassVar[tuple[str, ...]] = ("jax",)
-
-    def get_framework_args(self) -> dict:
-        return {}
-```
-
-#### XGBoostTrainer
-
-```python
-@dataclass
-class XGBoostTrainer(FuncTrainer):
-    """Trainer for XGBoost distributed training workloads.
-
-    Supports runtimes labeled with `trainer.kubeflow.org/framework: xgboost`.
-    """
-
-    supported_frameworks: ClassVar[tuple[str, ...]] = ("xgboost",)
-
-    def get_framework_args(self) -> dict:
-        return {}
-```
-
-### C. ConfigTrainer — Config-Driven Base
-
-`ConfigTrainer` is the base class for trainers that are driven by a configuration
-object rather than a user-provided function. The runtime's entrypoint (e.g.,
-`tune run`, `accelerate launch`) handles execution based on the config.
-
-This replaces the current `BuiltinTrainer` pattern with an extensible, `BaseTrainer`-
-compatible design that supports runtime auto-discovery and framework validation.
+### II.4 `ConfigTrainer`
 
 ```python
 @dataclass(kw_only=True)
 class ConfigTrainer(BaseTrainer):
-    """Base class for config-driven trainers.
-
-    Config-driven trainers do not accept a user training function. Instead,
-    they carry a `FrameworkConfig` that fully describes the training job.
-    The runtime's entrypoint handles execution based on the config.
-    """
-
+    """Config-driven trainers take no training function. The config fully
+    describes the job and the runtime's entrypoint executes it."""
     config: FrameworkConfig
 
     @property
@@ -578,324 +472,170 @@ class ConfigTrainer(BaseTrainer):
         return (self.config.framework,)
 
     def validate_runtime(self, runtime: "Runtime") -> None:
-        """Validate framework and trainer_type compatibility.
-
-        ConfigTrainer requires runtimes with trainer_type == BUILTIN_TRAINER.
-        """
         super().validate_runtime(runtime)
-        if runtime.trainer.trainer_type != TrainerType.BUILTIN_TRAINER:
-            raise ValueError(
-                f"{type(self).__name__} requires a runtime with "
-                f"trainer_type={TrainerType.BUILTIN_TRAINER.value}, but "
-                f"runtime '{runtime.name}' has "
-                f"trainer_type={runtime.trainer.trainer_type.value}"
-            )
+        # ConfigTrainer additionally requires trainer_type == BUILTIN_TRAINER.
 ```
 
-`supported_frameworks` is a property here rather than the `ClassVar` that `FuncTrainer`
-subclasses declare, because a config-driven trainer's framework is a property of the
-instance's config rather than of the class.
+A property rather than a `ClassVar`, because the framework comes from the instance's
+config. The `__init_subclass__` guard does not inspect its value here — it does not need
+to, since the registry already rejects a `FrameworkConfig` that declares no framework.
 
-This is the one place the property form matters for `__init_subclass__`: the guard reads
-`getattr(cls, "supported_frameworks", None)`, which on `ConfigTrainer` returns the *property
-object* — always truthy — so the check passes without inspecting a framework value. That is
-acceptable because the value it would inspect comes from `cls.config.framework`, and the
-registry already rejects a `FrameworkConfig` that declares no framework (see
-[Dynamic Registration](#dynamic-registration)). The declaration is validated once, where it
-is made, rather than twice.
-
-`ConfigTrainer` is **not** subclassed per framework. A framework is a *config* — the
-existing `BuiltinTrainer(config=TorchTuneConfig(...))` shape, generalized so the config
-can be any framework's. [Section F](#f-config-driven-llm-trainers) specifies the config
-base class and the concrete configs; the trainer side stays one class.
-
-#### BuiltinTrainer
-
-`ConfigTrainer` is concrete — new code constructs it directly with any registered config.
-`BuiltinTrainer` stays where it is today, existing and unchanged: its public construction
-signature remains `BuiltinTrainer(config=...)`, and its `config` field widens from the
-concrete `TorchTuneConfig` to the `FrameworkConfig` base. Both entry points accept any
-framework, so a second framework is a new config class and no new trainer class:
+`ConfigTrainer` is **not** subclassed per framework. `BuiltinTrainer` stays exactly where it
+is, keeping its construction signature; only its `config` field widens from `TorchTuneConfig`
+to `FrameworkConfig`. Both entry points then accept any framework:
 
 ```python
 BuiltinTrainer(config=TorchTuneConfig(...))   # today, still valid
 ConfigTrainer(config=TRLConfig(...))          # new code, same machinery
 ```
 
-| Aspect | `BuiltinTrainer` (current) | `BuiltinTrainer` (proposed) |
+| Aspect | `BuiltinTrainer` today | proposed |
 |---|---|---|
-| Runtime discovery | None (hardcoded) | Auto-discovery via `config.framework` |
-| Framework validation | None | `validate_runtime()` |
-| RuntimeConfig support | No | Yes |
-| Extension model | Modify `BuiltinTrainer` | Add a `FrameworkConfig` subclass |
-| Config type | Hardcoded `TorchTuneConfig` | Any `FrameworkConfig` |
+| Runtime discovery | none (hardcoded) | auto via `config.framework` |
+| Framework validation | none | `validate_runtime()` |
+| `RuntimeConfig` support | no | yes |
+| Extension model | modify the class | add a `FrameworkConfig` subclass |
 
-Existing code keeps working unchanged and nothing is deprecated.
-
-### D. RuntimeConfig
-
-Extract runtime-environment settings from `CustomTrainer` into a dedicated dataclass.
-This provides a clean separation of concerns and allows runtime configuration to be
-reused across any trainer type.
+### II.5 `RuntimeConfig`
 
 ```python
 @dataclass
 class RuntimeConfig:
-    """Per-job runtime environment configuration.
+    """Per-job runtime environment, separate from training-loop and scaling config.
 
-    Separates runtime-environment concerns (what packages to install, what
-    environment variables to set) from training-loop and scaling concerns.
-
-    This is passed to `TrainerClient.train()` and applies regardless of
-    the trainer type used. It is a separate parameter on `train()` — not
-    embedded in trainers — because runtime configuration is orthogonal to
-    both trainer type and initializer. The same RuntimeConfig applies to
-    all training pods, and keeping it at the `train()` call site allows
-    users to set custom env for initializers in the future without changing
-    the trainer classes.
-
-    Args:
-        packages_to_install: Python packages to install before running the
-            training function (e.g., ["transformers>=4.40", "datasets"]).
-        pip_index_urls: PyPI index URLs. The first URL is the primary index;
-            remaining URLs are extra indexes.
-        env: Environment variables to set in all training nodes.
+    Passed to TrainerClient.train() and applied whatever the trainer type.
     """
-
     packages_to_install: Optional[list[str]] = None
     pip_index_urls: list[str] = field(
-        default_factory=lambda: list(constants.DEFAULT_PIP_INDEX_URLS)
-    )
+        default_factory=lambda: list(constants.DEFAULT_PIP_INDEX_URLS))
     env: Optional[dict[str, str]] = None
 ```
 
-**Design decisions:**
+- A `@dataclass`, consistent with the rest of the SDK; field names match `CustomTrainer`'s
+  and KFP's `PipelinesClient`. Pip options are flat rather than a nested `PipConfig`.
+- A separate `train()` parameter rather than a trainer field: the same runtime settings
+  apply whatever the trainer type, and this leaves room to apply env to initializers later
+  without touching trainer classes.
+- **Merge semantics** are field-level: a `RuntimeConfig` field overrides the corresponding
+  `CustomTrainer` field only when it is not `None`. `RuntimeConfig(env=...)` alongside
+  `CustomTrainer(packages_to_install=[...])` preserves the packages.
 
-- Uses `@dataclass` (not Pydantic `BaseModel`) to be consistent with the rest of the
-  SDK codebase.
-- Field names (`packages_to_install`, `pip_index_urls`) are consistent with the
-  existing `CustomTrainer` fields and with KFP's `PipelinesClient`.
-- Pip configuration is flattened into `RuntimeConfig` rather than nested in a separate
-  `PipConfig` type, keeping the API surface minimal. Additional pip options (e.g.,
-  `--quiet`, `--user`) can be added as fields later if needed.
-- `RuntimeConfig` is a separate `train()` parameter — not embedded in trainers —
-  because runtime configuration is orthogonal to trainer type. The same `RuntimeConfig`
-  should be usable with `CustomTrainer`, `FuncTrainer`, or `ConfigTrainer` subclasses.
-  It also allows future extension to apply env vars to initializers.
-- `RuntimeConfig` is optional — when not provided, the trainer's own fields
-  (`packages_to_install`, `env` on `CustomTrainer`) or the runtime defaults are used.
-  This preserves backward compatibility.
-- **Merge semantics:** When both `RuntimeConfig` and `CustomTrainer` fields are
-  provided, `RuntimeConfig` fields override `CustomTrainer` fields **only when the
-  `RuntimeConfig` field is not `None`**. For example, if
-  `RuntimeConfig(env={"DEBUG": "1"})` is passed alongside
-  `CustomTrainer(packages_to_install=["torch"])`, the trainer's `packages_to_install`
-  is preserved because `RuntimeConfig.packages_to_install` is `None`. This is a
-  field-level merge, not a wholesale replacement.
-
-### E. TrainerClient Changes
-
-The `TrainerClient.train()` method signature is extended to accept the new types:
+### II.6 `TrainerClient` and runtime auto-discovery
 
 ```python
-class TrainerClient:
-
-    def train(
-        self,
-        runtime: Optional[Union[str, "Runtime"]] = None,
-        initializer: Optional["Initializer"] = None,
-        trainer: Optional[
-            Union[
-                "CustomTrainer",
-                "CustomTrainerContainer",
-                "BuiltinTrainer",
-                "BaseTrainer",        # NEW: accepts any specialized trainer
-            ]
-        ] = None,
-        runtime_config: Optional["RuntimeConfig"] = None,  # NEW
-        options: Optional[list] = None,
-    ) -> str:
+def train(
+    self,
+    runtime: Optional[Union[str, "Runtime"]] = None,
+    initializer: Optional["Initializer"] = None,
+    trainer: Optional[Union[
+        "CustomTrainer", "CustomTrainerContainer", "BuiltinTrainer",
+        "BaseTrainer",                                   # NEW
+    ]] = None,
+    runtime_config: Optional["RuntimeConfig"] = None,    # NEW
+    options: Optional[list] = None,
+) -> str:
 ```
 
-When a `BaseTrainer` subclass is passed:
+`_resolve_runtime()` lives on the client, not the backend, so behaviour is identical across
+backends. Given an explicit `runtime`, it calls `trainer.validate_runtime()`. Given `None`,
+it walks `supported_frameworks` in declaration order and takes the first framework with
+matches: exactly one match is selected; zero raises listing the available runtimes; more
+than one raises listing the candidates and asking for an explicit choice.
 
-1. If `runtime` is `None`, the SDK calls `list_runtimes()` and filters by the
-   `trainer.kubeflow.org/framework` label matching the trainer's
-   `supported_frameworks`.
-2. If exactly one matching runtime is found, it is used automatically.
-3. If multiple matching runtimes are found, a `ValueError` is raised listing the
-   available options and instructing the user to specify one explicitly.
-4. If `runtime` is provided (as a name or `Runtime` object), the trainer's
-   `validate_runtime()` method is called to verify compatibility.
-5. The backend dispatches based on the trainer type: `FuncTrainer` subclasses are
-   handled via `get_train_func()` / `get_train_func_args()` / `get_framework_args()`,
-   while `ConfigTrainer` is handled via `config.command` and `config.to_args()`.
+So `DeepSpeedTrainer(("deepspeed", "torch"))` selects `torch-distributed` on a cluster with
+only that, and `deepspeed-mpi` without ambiguity on a cluster with both.
 
-When `runtime_config` is provided, its values take precedence over any
-runtime-environment fields on `CustomTrainer` (for backward compatibility, those
-fields remain on `CustomTrainer` but `RuntimeConfig` is the preferred mechanism).
+`runtime=None` behaviour is deliberately split: `CustomTrainer` and `BuiltinTrainer` keep
+defaulting to `constants.DEFAULT_TRAINING_RUNTIME`, so existing code does not change;
+`BaseTrainer` subclasses get auto-discovery.
 
-**`runtime=None` behavior by trainer type:**
+**Validation is a hard fail, not a warning**, at three levels: framework label
+(`BaseTrainer`), `trainer_type` (`FuncTrainer` / `ConfigTrainer`), and framework-specific
+overrides. A `ValueError` before the CR is created beats a job that fails minutes later in
+the controller. The SDK checks only what it can know for certain (the label and the trainer
+type); the control plane still has the final say on quotas, policy and versions.
 
-| Trainer type | `runtime=None` behavior |
-|---|---|
-| `CustomTrainer` / `BuiltinTrainer` | Defaults to `constants.DEFAULT_TRAINING_RUNTIME` ("torch-distributed"), preserving existing behavior. |
-| `BaseTrainer` subclasses (`TorchTrainer`, etc.) | Auto-discovery via `_resolve_runtime()` — finds runtimes matching `supported_frameworks`. |
-
-This distinction is intentional: existing code must not change behavior, while new
-trainer types benefit from auto-discovery. The `train()` docstring documents this
-difference explicitly.
-
-### F. Config-Driven LLM Trainers
-
-Section C keeps the trainer side to one class and puts the framework in the config. This
-section specifies the config base class, the two concrete configs — `TorchTuneConfig` and
-`TRLConfig` — and the SDK changes they require.
-
-TorchTune is currently the only config-driven framework the SDK can represent. It is
-hardcoded at four points:
-
-| # | Coupling | Location |
-|---|---|---|
-| 1 | `BuiltinTrainer.config` is annotated with the concrete `TorchTuneConfig` type | `types.py:226-236` |
-| 2 | The framework identifier is derived by reflecting on that annotation, yielding `"torchtune"`. The code's own comment reads "Change it to list: BUILTIN_CONFIGS, once we support more Builtin Trainer configs." | `types.py:239-240` |
-| 3 | `trainer_type` and the container entrypoint are both selected by string-comparing the runtime's framework label against that derived constant | `utils.py:114-119`, `:140-148` |
-| 4 | Config-to-argument translation is guarded by an `isinstance` check against `TorchTuneConfig` | `utils.py:451-452`, `:473-527` |
-
-Coupling #3 is the load-bearing one. `trainer_type` is not a field on the Runtime CR; the SDK
-computes it as `BUILTIN_TRAINER if framework == types.TORCH_TUNE else CUSTOM_TRAINER`. A
-runtime labelled `trainer.kubeflow.org/framework: trl` therefore resolves to `CUSTOM_TRAINER`
-today, and `ConfigTrainer.validate_runtime()` would reject it. Until `get_runtime_trainer()`
-changes, no config-driven trainer other than TorchTune can run.
-
-#### FrameworkConfig
-
-A config knows three things the SDK needs and nothing else knows: which framework label it
-claims, which entrypoint runs it, and how it renders itself as arguments for that entrypoint.
-These are the three couplings above, moved onto one object.
+Trainers are **plain data, not builders**. They hold the function or config, framework
+arguments, and scaling; the backend builds the `TrainJob` CR; the controller owns the
+distributed topology. So a new trainer needs no backend change, and a new backend needs no
+trainer change:
 
 ```python
-# kubeflow/trainer/types/types.py
+def _build_trainer_cr(self, runtime, trainer):
+    # num_nodes, resources_per_node, image copied across as today.
+    if isinstance(trainer, FuncTrainer):
+        trainer_cr.command = get_command_using_train_func(runtime, trainer.get_train_func(), ...)
+        trainer_cr.args = [f"--{k}={v}" for k, v in trainer.get_framework_args().items()]
+    elif isinstance(trainer, ConfigTrainer):
+        # Entrypoint comes from the runtime, exactly as today. Each config
+        # renders its own args, so there is no framework branch here.
+        trainer_cr.command = list(runtime.trainer.command)
+        trainer_cr.args = trainer.config.to_args()
+```
 
+### II.7 `FrameworkConfig`, the registry, and `TRLConfig`
+
+A config knows three things nothing else knows: the framework label it claims, the
+entrypoint that runs it, and how it renders itself as that entrypoint's arguments. Those are
+couplings #1–#4 from [II.1](#ii1-current-limitations), moved onto one object.
+
+```python
 @dataclass(kw_only=True)
 class FrameworkConfig(abc.ABC):
-    """Base class for the configuration of a config-driven LLM framework.
-
-    Concrete configs declare the framework label they claim and the container
-    entrypoint that consumes them, and render themselves as that entrypoint's
-    arguments.
-    """
-
     framework: ClassVar[str] = ""
     command: ClassVar[tuple[str, ...]] = ()
 
     @abstractmethod
     def to_args(self) -> list[str]:
         """Render this config as arguments for `command`."""
-        ...
 ```
 
-`to_args()` renders only the config's own fields. It takes no initializer: configs are plain
-dataclasses and stay that way, so nothing in `types.py` needs to know how a backend stages
-data.
+`to_args()` renders only the config's own fields and takes no initializer: configs stay
+plain dataclasses, so nothing in `types.py` needs to know how a backend stages data.
 
-#### Dynamic Registration
-
-The framework label is resolved through a registry rather than a constant. It maps a label to
-a `FrameworkConfig` subclass and serves exactly one lookup — the one `get_runtime_trainer()`
-performs — and is the extension path for out-of-tree frameworks.
+The framework label resolves through a registry rather than a constant. It serves exactly
+one lookup — `get_runtime_trainer()`'s — and is the out-of-tree extension path:
 
 ```python
 # kubeflow/trainer/types/registry.py
-
-from typing import Optional
-
 _FRAMEWORK_CONFIGS: dict[str, type["FrameworkConfig"]] = {}
 
-
-def register_framework(cls: type["FrameworkConfig"]) -> type["FrameworkConfig"]:
-    """Claim the framework label declared in `cls.framework`."""
+def register_framework(cls):
+    """Claim the framework label declared in cls.framework."""
     if not (cls.framework and cls.command):
         raise ValueError(f"{cls.__name__} must declare a framework and a command")
     _FRAMEWORK_CONFIGS[cls.framework] = cls
     return cls
 
-
 def get_framework(framework: str) -> Optional[type["FrameworkConfig"]]:
-    """Return the FrameworkConfig claiming this framework label, or None."""
     return _FRAMEWORK_CONFIGS.get(framework)
 ```
 
-Registration is an explicit decorator because that is how this ecosystem already registers
-plugins: the Trainer control plane lists every framework plugin by hand in
-`pkg/runtime/framework/plugins/registry.go`, the earlier draft of this KEP
-([trainer#3263](https://github.com/kubeflow/trainer/pull/3263)) sketched this exact shape
-(`@register_framework`), and kubeflow/sdk#310 is its PoC. The decorator takes no string
-argument — it is keyed off `cls.framework`, so there is no name to drift from the class.
-There is no entry-point or import-hook discovery: an out-of-tree config must be imported
-before it can be constructed, and importing it registers it, so the decorator is sufficient.
+An explicit decorator, matching how the control plane registers its plugins by hand in
+`plugins/registry.go` ([sdk#310](https://github.com/kubeflow/sdk/pull/310) is the PoC for
+this shape). There is no automatic discovery: a config must be imported before it can be
+constructed, and importing it registers it.
 
-#### TorchTuneConfig
-
-`TorchTuneConfig` keeps every field and its construction signature. It gains the three
-`FrameworkConfig` members:
-
-```python
-# kubeflow/trainer/types/types.py
-# Additional imports: `from kubeflow.trainer.types import torchtune`,
-# `from kubeflow.trainer.types.registry import register_framework`
-
-@register_framework
-@dataclass
-class TorchTuneConfig(FrameworkConfig):
-    """TorchTune LLM Trainer configuration. (Fields unchanged from today.)"""
-
-    framework: ClassVar[str] = "torchtune"
-    command: ClassVar[tuple[str, ...]] = ("tune", "run")
-
-    dtype: Optional[DataType] = None
-    batch_size: Optional[int] = None
-    # ... remaining fields unchanged ...
-
-    def to_args(self) -> list[str]:
-        """Preserve the existing TorchTune override rendering exactly."""
-        return torchtune.get_args_using_torchtune_config(self)
-```
-
-#### TRLConfig
+`TorchTuneConfig` keeps every field and its signature, gaining
+`framework = "torchtune"`, `command = ("tune", "run")`, and a `to_args()` delegating to the
+existing emitter.
 
 ```python
 # kubeflow/trainer/types/trl.py
 
-from dataclasses import dataclass, fields
-from enum import Enum
-from typing import ClassVar, Optional
-
-from kubeflow.trainer.types.registry import register_framework
-from kubeflow.trainer.types.types import FrameworkConfig
-
-
 class TRLMethod(Enum):
-    """Post-training method; the value is the TRL CLI subcommand."""
-
-    SFT = "sft"
-    DPO = "dpo"
-    GRPO = "grpo"
-
+    """Post-training method; the value names the TRL script module
+    (trl/scripts/<method>.py), launched as `torchrun -m trl.scripts.<method>`."""
+    SFT = "sft"; DPO = "dpo"; GRPO = "grpo"
 
 @register_framework
 @dataclass
 class TRLConfig(FrameworkConfig):
-    """Configuration for Hugging Face TRL post-training.
-
-    The runtime entrypoint is the TRL CLI, which forwards to `accelerate launch`.
-
-    Raises:
-        ValueError: If a field is set that does not apply to the selected method.
-    """
-
     framework: ClassVar[str] = "trl"
-    command: ClassVar[tuple[str, ...]] = ("trl",)
+    # torchrun launches TRL's plain training script as a module (see I.2/I.6);
+    # to_args() supplies the module name as the first positional argument, so
+    # the full argv is `torchrun -m trl.scripts.<method> --flag value ...`.
+    command: ClassVar[tuple[str, ...]] = ("torchrun", "-m")
 
     method: TRLMethod
     model_name_or_path: str
@@ -911,12 +651,11 @@ class TRLConfig(FrameworkConfig):
     lora_alpha: Optional[int] = None
     lora_target_modules: Optional[list[str]] = None
 
-    beta: Optional[float] = None                    # DPO, GRPO
-    num_generations: Optional[int] = None           # GRPO
-    reward_funcs: Optional[list[str]] = None        # GRPO
+    beta: Optional[float] = None              # DPO, GRPO
+    num_generations: Optional[int] = None     # GRPO
+    reward_funcs: Optional[list[str]] = None  # GRPO
 
-    # Fields valid only for a subset of methods. Fields absent from this map
-    # are valid for every method.
+    # Fields valid only for a subset of methods; anything absent applies to all.
     _METHOD_SCOPED_FIELDS: ClassVar[dict[str, frozenset[TRLMethod]]] = {
         "beta": frozenset({TRLMethod.DPO, TRLMethod.GRPO}),
         "num_generations": frozenset({TRLMethod.GRPO}),
@@ -924,49 +663,19 @@ class TRLConfig(FrameworkConfig):
     }
 
     def __post_init__(self) -> None:
-        self.validate()
-
-    def validate(self) -> None:
-        """Enforce method-scoped field usage.
-
-        Raises:
-            ValueError: If a field is set for a method it does not apply to, or
-                if a field the selected method requires is unset.
-        """
-        for name, methods in self._METHOD_SCOPED_FIELDS.items():
-            if getattr(self, name) is not None and self.method not in methods:
-                allowed = ", ".join(sorted(m.value for m in methods))
-                raise ValueError(
-                    f"'{name}' applies only to method={allowed}, but "
-                    f"method={self.method.value} was selected"
-                )
-        if self.method is TRLMethod.GRPO and not self.reward_funcs:
-            raise ValueError("method=grpo requires at least one entry in 'reward_funcs'")
+        self.validate()   # raises ValueError on a field set for the wrong method,
+                          # or on method=grpo without reward_funcs
 
     def to_args(self) -> list[str]:
-        """Render as `[<subcommand>, --flag, value, ...]` for the TRL CLI."""
-        args: list[str] = [self.method.value]
-        for f in fields(self):
-            if f.name == "method":
-                continue
-            value = getattr(self, f.name)
-            if value is None:
-                continue
-            if value is True:
-                args.append(f"--{f.name}")           # store_true flag
-            elif isinstance(value, list):
-                args.append(f"--{f.name}")
-                args.extend(str(item) for item in value)
-            else:
-                args += [f"--{f.name}", str(value)]
-        return args
+        """Render as [trl.scripts.<method>, --flag, value, ...]: the module name
+        first (torchrun's -m positional), then the script flags — bools become
+        store_true flags, lists expand after their flag, everything else is
+        --name value."""
 ```
 
 Users reach both through the trainer they already know:
 
 ```python
-from kubeflow.trainer import BuiltinTrainer, TrainerClient, TRLConfig, TRLMethod
-
 TrainerClient().train(
     trainer=BuiltinTrainer(
         config=TRLConfig(
@@ -981,783 +690,308 @@ TrainerClient().train(
 )
 ```
 
-**Design decisions:**
+**Design decisions**
 
 - **The framework is a config, not a trainer subclass.** A `BuiltinTrainer` holding a
-  `TRLConfig` and one holding a `TorchTuneConfig` differ in data, not in what the trainer
-  does with them: it hands the config's `command` and `to_args()` to the backend. Since the
-  trainer's behavior does not vary by framework, the framework does not need a class of its
-  own — a config class carries it. The user-facing consequence is that
-  `BuiltinTrainer(config=...)` stays the single config-driven entry point and existing code
-  is untouched. Alternative
-  [8](#8-one-trainer-class-per-framework-trltrainer-torchtunetrainer) is the rejected pole.
-- **Post-training method is a field, not a config subclass.** TRL's methods differ only in
-  which fields apply, so `method` is an enum guarded by `_METHOD_SCOPED_FIELDS`. Adding `kto`
-  is one enum member and one entry in `trl.py`; no new export, no backend change. Alternative
-  [7](#7-one-config-class-per-post-training-method-sftconfig-dpoconfig-grpoconfig) covers the
-  method-first split.
-- **`command` and `framework` are `ClassVar`s on the config, but `RuntimeTrainer` still carries
-  the resolved entrypoint.** The config *declares* them — they are properties of the framework's
-  CLI, and the config class is the only object that knows them — while
-  `RuntimeTrainer.command` remains the field every consumer reads. That field is not
-  config-driven-specific: `command[0] == "mpirun"` drives MPI detection (`utils.py:216`,
-  `:378`, `backend.py:242`), `get_runtime_packages` rewrites it to run single-process, and the
-  localprocess backend joins it into an entrypoint (`localprocess/utils.py:229`). Moving it
-  onto the config would mean special-casing all of those. Instead `get_runtime_trainer()`
-  resolves it through the registry, replacing the `framework == types.TORCH_TUNE` branch at
-  `utils.py:150-158` and deleting `constants.TORCH_TUNE_COMMAND`:
+  `TRLConfig` and one holding a `TorchTuneConfig` differ in data, not behaviour: the trainer
+  hands `command` and `to_args()` to the backend either way. So `BuiltinTrainer(config=...)`
+  stays the single config-driven entry point. (Alternative 8.)
+- **Method is a field, not a config subclass.** TRL's methods differ only in which fields
+  apply. Adding `kto` is one enum member and one map entry — no export, no backend change.
+  (Alternative 7.)
+- **`command` and `framework` are `ClassVar`s on the config, but `RuntimeTrainer.command`
+  stays the field consumers read.** That field is not config-specific:
+  `command[0] == "mpirun"` drives MPI detection, `get_runtime_packages` rewrites it for
+  single-process, and the localprocess backend joins it into an entrypoint. Moving it onto
+  the config would special-case all of those. Instead `get_runtime_trainer()` resolves it
+  through the registry, replacing the `framework == TORCH_TUNE` branch at `utils.py:150-158`
+  and deleting `constants.TORCH_TUNE_COMMAND`:
 
   ```python
   if config_cls := registry.get_framework(framework):
       trainer.set_command(config_cls.command)
   elif ml_policy.torch is not None:
       trainer.set_command(constants.TORCH_COMMAND)
-  elif ml_policy.mpi:
-      trainer.set_command(constants.MPI_COMMAND)
-  else:
-      trainer.set_command(constants.DEFAULT_COMMAND)
+  # ... mpi, default unchanged
   ```
 
-  This is the same relationship the framework label already has: the runtime CR declares it,
-  `RuntimeTrainer.framework` carries it. Adding a framework adds no lines to `utils.py`, and
-  CR construction stays uniform across both trainer types.
-- **`trainer_type` is derived from the registry.** `get_runtime_trainer()` assigns
-  `BUILTIN_TRAINER` when `get_framework(framework)` finds a registered `FrameworkConfig`
-  and `CUSTOM_TRAINER` otherwise, replacing `utils.py:114-119` and deleting
-  the reflection-derived `types.TORCH_TUNE` constant. `trainer.kubeflow.org/framework` remains
-  the sole discovery key, honoring [Non-Goal #2](#non-goals).
-- **Rendering is polymorphic, so the backend has no framework branch.** `_build_trainer_cr`'s
-  config-driven path changes one line — `trainer_cr.args = trainer.config.to_args()` — deleting
-  the `isinstance(trainer.config, TorchTuneConfig)` guard at `utils.py:451-452` (coupling #4)
-  rather than relocating it. `trainer_cr.command = list(runtime.trainer.command)` is unchanged.
-  This is the one-time backend change that makes adding a *further* framework require none.
-- **TorchTune's initializer-derived dataset override stays in the backend.** The
-  `dataset.data_files=` / `dataset.data_dir=` args are computed from the Hugging Face dataset
-  initializer (`utils.py:502-517`), which is staging knowledge the backend owns. They are
-  appended to whatever `to_args()` renders. `TRLConfig` needs nothing from the initializer:
-  `model_name_or_path` and `dataset_name` are passed through for the `trl` CLI to resolve.
-- **`TorchTuneConfig.to_args()` delegates to the existing emitter.** `get_args_from_peft_config`
-  (`utils.py:530-559`) maps `LoraConfig` onto nested `model.*` keys; a flat `key=value` walk
-  would emit `lora_rank=8` instead of `model.lora_rank=8` and produce a failing job. The
-  emitters move verbatim to `kubeflow/trainer/types/torchtune.py` — they hold no Kubernetes
-  logic, and leaving them in the backend would make `types.py` import a backend module.
-- **Registration runs at import time and is last-writer-wins.** The decorator executes when
-  the module defining the config is imported. `TRLConfig` lives in a new module, so it must
-  be exported from `kubeflow/trainer/__init__.py`; otherwise a process that never imports it
-  finds no claimant for the `trl` label and treats the runtime as function-driven. An
-  out-of-tree config claiming an in-tree label shadows it, which lets a fork replace a
-  stalled in-tree config without an upstream commit.
-- **The base class is named `FrameworkConfig`, not the earlier draft's `LLMBackend`.** `backends/`
-  in this SDK means *execution* backend (`KubernetesBackend`, `ContainerBackend`), while
-  this object is the `config=` argument — and nothing in it is LLM-specific.
-- **`LoraConfig` is not reused for TRL.** It is TorchTune-shaped — `apply_lora_to_output` and
-  `quantize_base` have no TRL analogue, and TRL's PEFT surface is `--use_peft` / `--lora_r` /
-  `--lora_alpha` / `--lora_target_modules`. Sharing it would need a lossy translation layer.
-- **Unsloth is a runtime-image concern, not a sibling config.** An Unsloth-accelerated image is
-  still labelled `trainer.kubeflow.org/framework: trl`, so it resolves to the same config
-  entry and selected with `train(runtime=...)`. No SDK field is added.
-- **Nothing is deprecated.** `BuiltinTrainer(config=TorchTuneConfig(...))` keeps its exact
-  construction signature and produces byte-identical `TrainJob` arguments. There is no
-  successor class to migrate to and no `FutureWarning`.
+  Adding a framework then adds no lines to `utils.py`.
+- **`trainer_type` comes from the registry.** `BUILTIN_TRAINER` when `get_framework()` finds
+  a registered config, `CUSTOM_TRAINER` otherwise — replacing `utils.py:114-119` and
+  deleting the `TORCH_TUNE` constant. The framework label stays the sole discovery key.
+- **Each config renders itself, so the backend has no framework branch.** One line —
+  `trainer_cr.args = trainer.config.to_args()` — deletes the `isinstance` check at
+  `utils.py:451-452` rather than relocating it. This is the one-time change that makes a
+  *further* framework require none.
+- **TorchTune's initializer-derived dataset overrides stay in the backend.** The
+  `dataset.data_files=` / `data_dir=` args are computed from the HF dataset initializer,
+  which is staging knowledge the backend owns; they are appended to whatever `to_args()`
+  renders. `TRLConfig` needs nothing from the initializer.
+- **`TorchTuneConfig.to_args()` delegates to the existing emitter.**
+  `get_args_from_peft_config` maps `LoraConfig` onto nested `model.*` keys; a flat
+  `key=value` walk would emit `lora_rank=8` instead of `model.lora_rank=8` and fail the job.
+  The emitters move verbatim to `types/torchtune.py` — they hold no Kubernetes logic, and
+  leaving them in the backend would make `types.py` import a backend module.
+- **Registration happens at import time; a later registration wins.** `TRLConfig` must be exported from
+  `kubeflow/trainer/__init__.py`, or a process that never imports it finds no claimant for
+  `trl` and treats the runtime as function-driven. Shadowing lets a fork replace a stalled
+  in-tree config without an upstream commit.
+- **Named `FrameworkConfig`, not the earlier draft's `LLMBackend`.** `backends/` here means
+  *execution* backend, and nothing about this object is LLM-specific.
+- **`LoraConfig` is not reused for TRL.** It is TorchTune-shaped — `apply_lora_to_output`
+  and `quantize_base` have no TRL analogue, and TRL's PEFT surface is `--use_peft` /
+  `--lora_r` / `--lora_alpha` / `--lora_target_modules`. Sharing it needs a lossy translation.
+- **Unsloth is a runtime-image concern.** An Unsloth-accelerated image is still labelled
+  `framework: trl`, so it resolves to the same config and is chosen with `train(runtime=...)`.
+  No SDK field.
+- **Nothing is deprecated.** `BuiltinTrainer(config=TorchTuneConfig(...))` produces
+  byte-identical `TrainJob` arguments. No successor class, no `FutureWarning`.
 
-#### Control Plane
+### II.8 Which framework, and why TRL
 
-This proposal requires no `TrainJob` CRD, `ClusterTrainingRuntime` CRD, controller, or
-plugin-registry change. A runtime is an image plus a `command` the SDK appends arguments to,
-so a framework is supportable when it is a CLI:
+| Framework | Post-training methods | Maintenance | Argument shape | torchrun path |
+|---|---|---|---|---|
+| TRL | one plain script per method under `trl/scripts/` — `sft`, `dpo`, `grpo`, `kto`, `reward`, `rloo`; PPO moved to `trl.experimental` in 0.29 ([trl#4466](https://github.com/huggingface/trl/issues/4466)) | Active (Hugging Face) | flags | native: `torchrun -m trl.scripts.<method>` |
+| TorchTune | SFT only, in the Kubeflow integration | Stopped 15 Jul 2025 ([#2883](https://github.com/meta-pytorch/torchtune/issues/2883)) | flags | via `tune run` (plugin rewrites the command) |
+| LlamaFactory | Broad, but built on HF `Trainer` and PEFT | Active | config file | wrapped: needs `FORCE_TORCHRUN=1` and renamed env |
+| Axolotl | Broad, but its GRPO is TRL's `GRPOTrainer` | Active | config file | native with `--launcher torchrun` (default is accelerate) |
+| Unsloth | None of its own; an acceleration layer | Active | n/a | n/a — not a launcher |
 
-```yaml
-# manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml — today
-kind: ClusterTrainingRuntime
-metadata:
-  labels:
-    trainer.kubeflow.org/framework: torchtune   # the SDK's discovery key
-spec: {...containers: [{image: ghcr.io/kubeflow/trainer/torchtune-trainer,
-                        command: [tune, run, ...]}]}   # TRL: [trl]
-```
-
-Per framework, the cost is three artifacts in `kubeflow/trainer`, mirroring what TorchTune
-already has: a `cmd/trainers/trl/Dockerfile` alongside `cmd/trainers/torchtune/Dockerfile`, a
-runtime manifest under `manifests/base/runtimes/trl/`, and an extension of the existing torch
-plugin. The runtime declares `mlPolicy: torch`, and the torch plugin dispatches on the
-trainer command — `torch.go:81` matches `constants.TorchTuneEntrypoint` and calls into
-`torchtune.go` for validation and command mutation. TRL follows the same pattern: a `trl.go`
-beside `torchtune.go` and a `TRLEntrypoint` constant, extending the plugin rather than
-creating a new one. All three are outside this proposal's scope; the SDK's only contract with
-them is the framework label and the `command` it appends `to_args()` onto.
-
-#### Which Framework, and Why TRL
-
-| Framework | Post-training methods | Maintenance | Entrypoint |
-|---|---|---|---|
-| TRL | `sft`, `dpo`, `grpo`, `kto`, `reward`, `rloo` on the stable CLI; PPO moved to `trl.experimental` in 0.29 ([huggingface/trl#4466](https://github.com/huggingface/trl/issues/4466)) | Actively maintained by Hugging Face | `trl <method> --flag value`; forwards to `accelerate launch` |
-| TorchTune | SFT only, in the Kubeflow integration | Active development stopped 15 July 2025 ([#2883](https://github.com/meta-pytorch/torchtune/issues/2883)) | `tune run` |
-| LlamaFactory | Broad, but built on the Hugging Face `Trainer` and PEFT | Active | `llamafactory-cli train <config.yaml>` |
-| Axolotl | Broad, but its GRPO is TRL's `GRPOTrainer` | Active | `axolotl train <config.yaml>` |
-| Unsloth | None of its own; an acceleration layer | Active | No independent CLI |
-
-TRL is selected on three grounds. Its stable CLI covers the methods the SDK cannot express at
-all today — DPO and GRPO. It is the substrate rather than a wrapper: LlamaFactory and Axolotl
-are both built on the Hugging Face `Trainer` and PEFT, so an in-tree TRL trainer adds
+TRL is selected on three grounds. Its per-method scripts cover what the SDK cannot express
+at all today — DPO and GRPO. It is the engine rather than a wrapper: LlamaFactory and
+Axolotl are both built on the HF `Trainer` and PEFT, so an in-tree TRL trainer adds
 capability where an in-tree wrapper would add a second surface over the same engine. And its
-CLI takes flags, so it renders into `TrainJob` `command` and `args` with no adapter; a
-file-first CLI (`axolotl train <config.yaml>`) would need a ConfigMap or a volume.
+scripts take flags, so `TRLConfig` renders straight into `args`; a file-first framework
+would need the SDK to stage a ConfigMap or volume first. TRL is also the cleanest fit for
+the torchrun-first pattern: its scripts are launched by torchrun directly, with no wrapper
+CLI and no environment renaming in the path.
 
-Choosing TRL first forecloses nothing: every alternative reaches the SDK out of tree as a
-`FrameworkConfig` subclass, which is why LlamaFactory is the reference out-of-tree plugin.
-GRPO-style post-training via TRL is already in flight in the Trainer
+Choosing TRL first closes no doors: every alternative reaches the SDK out of tree as a
+`FrameworkConfig` subclass, which is why LlamaFactory is the reference out-of-tree
+framework. GRPO via TRL is already in flight in the Trainer
 ([#3508](https://github.com/kubeflow/trainer/issues/3508),
-[#3718](https://github.com/kubeflow/trainer/pull/3718)); this proposal provides the SDK
-surface for that effort rather than a parallel track.
-
-**Risk:** TRL's surface is not frozen — PPO moved to `trl.experimental` in a minor release, and
-a typed dataclass mirroring TRL flags will drift. `TRLConfig` targets the CLI rather than the
-Python API, so a TRL upgrade changes the runtime image rather than the SDK type, and the
-drift is confined to the one config class that mirrors it.
-
----
-## Design Details
-
-### Runtime Auto-Discovery
-
-The auto-discovery logic lives in the `TrainerClient` (not in the backend), ensuring
-consistent behavior across all backends:
-
-```python
-def _resolve_runtime(
-    self,
-    trainer: BaseTrainer,
-    runtime: Optional[Union[str, Runtime]],
-) -> Runtime:
-    """Resolve the runtime for a specialized trainer.
-
-    If runtime is provided, validate it. If not, auto-discover by framework label.
-    """
-    if runtime is not None:
-        # Explicit runtime — validate compatibility
-        if isinstance(runtime, str):
-            runtime = self.get_runtime(runtime)
-        trainer.validate_runtime(runtime)
-        return runtime
-
-    # Auto-discover: find runtimes matching the trainer's frameworks.
-    # Iterate supported_frameworks in declaration order (most preferred first)
-    # to provide deterministic selection when exactly one runtime matches
-    # the most-preferred framework.
-    all_runtimes = self.list_runtimes()
-    matching = []
-    for framework in trainer.supported_frameworks:
-        matching = [
-            r for r in all_runtimes
-            if r.trainer.framework == framework
-        ]
-        if matching:
-            break
-
-    if len(matching) == 0:
-        raise ValueError(
-            f"No runtime found for frameworks {trainer.supported_frameworks}. "
-            f"Available runtimes: {[r.name for r in all_runtimes]}"
-        )
-    if len(matching) > 1:
-        raise ValueError(
-            f"Multiple runtimes found for framework "
-            f"'{matching[0].trainer.framework}': "
-            f"{[r.name for r in matching]}. "
-            f"Please specify the runtime explicitly."
-        )
-
-    return matching[0]
-```
-
-**Multi-runtime selection strategy:**
-
-Auto-discovery iterates `supported_frameworks` in declaration order (most preferred
-first). For each framework, it collects matching runtimes. If exactly one runtime
-matches the most-preferred framework, it is selected automatically. If multiple
-runtimes match the same framework, the SDK raises a `ValueError` listing the
-available options. If no runtimes match the most-preferred framework, discovery
-falls through to the next framework in the tuple.
-
-For example, `DeepSpeedTrainer` declares `supported_frameworks = ("deepspeed", "torch")`.
-On a cluster with only a `torch-distributed` runtime, auto-discovery falls through
-`"deepspeed"` (no match) and selects the `torch-distributed` runtime. On a cluster
-with both a `deepspeed-mpi` and a `torch-distributed` runtime, auto-discovery finds
-`deepspeed-mpi` first (matching `"deepspeed"`) and selects it without ambiguity.
-
-When multiple runtimes match the same framework, the user resolves the ambiguity by
-passing the `runtime` parameter to `train()`:
-
-```python
-# Two torch runtimes exist: "torch-distributed" and "torch-elastic"
-# Auto-discovery raises ValueError listing both options.
-
-# User resolves by specifying explicitly:
-client.train(
-    runtime="torch-elastic",
-    trainer=TorchTrainer(func=my_fn, num_nodes=4),
-)
-```
-
-This is a deliberate design choice. The `runtime` parameter on `train()` is the
-single, existing mechanism for runtime selection. Adding a `runtime_name` to
-`RuntimeConfig` or to trainer classes would conflate concerns — `RuntimeConfig` is for
-packages and environment, trainers are for training logic, and runtime selection belongs
-to the `train()` call site. See also
-[Alternative #4](#4-automatic-runtime-selection-with-scoringranking-instead-of-strict-single-match)
-for why priority-based scoring was rejected.
-
-### Runtime Validation
-
-Validation happens at three levels:
-
-1. **Framework label check** (in `BaseTrainer.validate_runtime()`): Ensures the
-   runtime's `trainer.kubeflow.org/framework` label value is in the trainer's
-   `supported_frameworks` list.
-
-2. **Trainer type check** (in `FuncTrainer.validate_runtime()` and
-   `ConfigTrainer.validate_runtime()`): Ensures the runtime's `trainer_type` matches
-   the trainer category. `FuncTrainer` requires `TrainerType.CUSTOM_TRAINER`;
-   `ConfigTrainer` requires `TrainerType.BUILTIN_TRAINER`. This catches mismatches
-   such as passing a function-driven trainer to a config-only runtime.
-
-3. **Framework-specific checks** (in concrete trainer overrides): For example,
-   `DeepSpeedTrainer` could verify that the runtime's launcher configuration
-   (torchrun vs. mpirun) is compatible with the selected runtime.
-
-**Validation strategy — SDK vs. control plane:**
-
-SDK validation raises `ValueError` at submission time, *before* the `TrainJob` CR is
-created in the cluster. This is intentionally a hard fail, not a warning, because:
-
-1. **Fast feedback.** A `ValueError` with a clear message is immediate. A warning
-   that the user ignores leads to a `TrainJob` that fails minutes later in the
-   controller or at execution time, wasting cluster resources.
-2. **Deterministic checks.** The SDK validates against concrete, known properties
-   (framework label, `trainer_type`) — not heuristics. These checks are
-   authoritative at the SDK level.
-3. **Control plane remains the final arbiter.** The controller's webhook may enforce
-   additional constraints (resource quotas, policy, version compatibility) that the
-   SDK does not know about. SDK validation is a *subset* of control-plane validation,
-   not a replacement.
-4. **Overridable.** Subclasses can override `validate_runtime()` to relax or extend
-   validation for custom use cases.
-
-In summary: the SDK fails fast on checks it *can* perform (framework, trainer_type),
-and defers to the controller for checks it *cannot* perform (quotas, policies).
-
-### Trainer Responsibility Boundary
-
-Trainers are **data objects**, not builders. They expose structured data about the
-training job; they do not construct the `TrainJob` CRD, build container entrypoints,
-or interact with the Kubernetes API. The responsibility boundary is:
-
-| Concern | Owner | Rationale |
-|---|---|---|
-| Training function / config | **Trainer** (`get_train_func()`, `config`) | Trainer knows what to run |
-| Framework-specific CLI args | **Trainer** (`get_framework_args()` / `config.to_args()`) | Trainer knows its framework's options |
-| Scaling & resources | **Trainer** (`num_nodes`, `resources_per_node`) | User sets these on the trainer |
-| Serializing function into `command` | **Backend** (`get_command_using_train_func()`) | Backend knows the serialization format |
-| Building `TrainJob` CRD / container spec | **Backend** | Backend knows the target platform (K8s, container, local) |
-| Injecting distributed args (`rdzv_endpoint`, `nnodes`, etc.) | **Controller** | Controller owns the distributed topology |
-| Enforcing policies, quotas, webhooks | **Controller** | Control plane is the final authority |
-
-This separation ensures that:
-- Adding a new trainer does **not** require changes to the backend — only a new
-  `FuncTrainer` or `ConfigTrainer` subclass.
-- Adding a new backend does **not** require changes to trainers — backends consume
-  the same `BaseTrainer` interface.
-- The controller continues to own distributed coordination args, avoiding conflicts
-  between SDK-provided and controller-injected arguments.
-
-### Framework Argument Separation
-
-The current `CustomTrainer.func_args` dict mixes user hyperparameters with framework
-arguments. The three-level hierarchy solves this structurally:
-
-| Layer | Method | Contains | Maps to in `TrainJob` CRD |
-|---|---|---|---|
-| `FuncTrainer` | `get_train_func_args()` | User hyperparameters | Embedded in serialized `trainer.command` |
-| `FuncTrainer` | `get_framework_args()` | Framework CLI args not injected by the controller | `trainer.args` |
-| `ConfigTrainer` | `config.to_args()` | Full training configuration | `trainer.args` (parsed by runtime entrypoint) |
-
-Arguments that the Kubeflow Trainer controller already injects (e.g., `rdzv_endpoint`,
-`nnodes`, `nproc_per_node`, `node_rank`) are **excluded** from `get_framework_args()`.
-The specialized trainer documentation explicitly lists which arguments it manages vs.
-which the controller manages.
-
-### Backend Integration
-
-Each backend (`KubernetesBackend`, `ContainerBackend`, `LocalProcessBackend`) must be
-updated to handle `BaseTrainer` instances. The backend reads from the trainer's
-interface methods and maps them to platform-specific constructs:
-
-```python
-# In KubernetesBackend — building the TrainJob CR:
-
-def _build_trainer_cr(self, runtime, trainer):
-    trainer_cr = TrainerV1alpha1Trainer()
-    trainer_cr.num_nodes = trainer.num_nodes
-    trainer_cr.resources_per_node = trainer.resources_per_node
-    trainer_cr.image = trainer.image
-
-    if isinstance(trainer, FuncTrainer):
-        # Serialize function into command (same as CustomTrainer today)
-        trainer_cr.command = get_command_using_train_func(
-            runtime,
-            trainer.get_train_func(),
-            trainer.get_train_func_args(),
-            runtime_config.pip_index_urls if runtime_config else None,
-            runtime_config.packages_to_install if runtime_config else None,
-        )
-        # Framework args go into trainer.args
-        framework_args = trainer.get_framework_args()
-        if framework_args:
-            trainer_cr.args = [
-                f"--{k}={v}" for k, v in framework_args.items()
-            ]
-
-    elif isinstance(trainer, ConfigTrainer):
-        # Entrypoint comes from the runtime, exactly as it does today.
-        # Only args change: to_args() is polymorphic, so no framework branch.
-        trainer_cr.command = list(runtime.trainer.command)
-        trainer_cr.args = trainer.config.to_args()
-
-    return trainer_cr
-```
-
-The `runtime_config` parameter is applied uniformly: packages are installed in the
-init container, environment variables are set on all training pods.
-
-### Type Hierarchy Diagram
-
-```
-                        BaseTrainer (ABC)
-                        ├── supported_frameworks
-                        ├── num_nodes, resources_per_node, image
-                        └── validate_runtime()
-                              │
-              ┌───────────────┴───────────────┐
-              │                               │
-        FuncTrainer (ABC)               ConfigTrainer
-        ├── func: Callable              ├── config: FrameworkConfig
-        ├── func_args: dict             └── supported_frameworks (property
-        ├── get_framework_args() [abstr]      -> config.framework)
-        ├── get_train_func()
-        └── get_train_func_args()       users construct it directly:
-              │                         ConfigTrainer(config=TRLConfig(...))
-    ┌─────────┼─────────┬──────────┐
-    │         │         │          │
-  Torch   DeepSpeed   JAX    XGBoost
-  Trainer  Trainer  Trainer  Trainer
-              │
-    (supports both "deepspeed"
-     and "torch" frameworks)
-
-
-    The framework axis lives here, not in the trainer hierarchy:
-
-                     FrameworkConfig (ABC)
-                     ├── framework (ClassVar)
-                     ├── command (ClassVar)
-                     └── to_args()  [abstract]
-                              │
-                     ┌────────┴────────┬─────────────────┐
-                     │                 │                 │
-              TorchTuneConfig      TRLConfig      (out-of-tree
-              (existing type,      (method:        subclasses)
-               unchanged fields)    TRLMethod)
-
-
-    Existing (unchanged):
-
-    BuiltinTrainer                    CustomTrainer                     CustomTrainerContainer
-    (signature unchanged;             (flat dataclass, no base class)   (image-based, no base class)
-     config widens to
-     FrameworkConfig)
-
-
-    New:
-
-    RuntimeConfig
-    (per-job env: packages, pip URLs, env vars)
-```
-
----
-
-## User-Facing API Examples
-
-### Before (Current)
-
-```python
-from kubeflow.trainer import TrainerClient, CustomTrainer
-
-# User must know the runtime name
-client = TrainerClient()
-
-# Must manually look up runtime
-runtime = client.get_runtime("torch-distributed")
-
-# Runtime config mixed into trainer
-job_id = client.train(
-    runtime=runtime,
-    trainer=CustomTrainer(
-        func=train_pytorch,
-        func_args={"lr": 1e-4, "epochs": 10},
-        packages_to_install=["transformers", "datasets"],
-        pip_index_urls=["https://pypi.org/simple"],
-        env={"NCCL_DEBUG": "INFO"},
-        num_nodes=4,
-        resources_per_node={"gpu": 1, "cpu": 3, "memory": "16Gi"},
-    ),
-)
-```
-
-### After (Proposed)
-
-```python
-from kubeflow.trainer import TrainerClient, TorchTrainer, RuntimeConfig
-
-client = TrainerClient()
-
-# Runtime is auto-discovered from trainer.kubeflow.org/framework: torch
-# Runtime environment is cleanly separated
-job_id = client.train(
-    trainer=TorchTrainer(
-        func=train_pytorch,
-        func_args={"lr": 1e-4, "epochs": 10},
-        num_nodes=4,
-        resources_per_node={"gpu": 1, "cpu": 3, "memory": "16Gi"},
-        max_restarts=3,  # Typed, torch-specific argument
-    ),
-    runtime_config=RuntimeConfig(
-        packages_to_install=["transformers", "datasets"],
-        env={"NCCL_DEBUG": "INFO"},
-    ),
-)
-```
-
-**Explicit runtime selection (when multiple runtimes exist for a framework):**
-
-```python
-job_id = client.train(
-    runtime="torch-elastic",  # Explicit selection
-    trainer=TorchTrainer(
-        func=train_pytorch,
-        func_args={"lr": 1e-4},
-        num_nodes=4,
-        resources_per_node={"gpu": 2},
-    ),
-)
-```
-
-**DeepSpeed example:**
-
-```python
-from kubeflow.trainer import DeepSpeedTrainer, RuntimeConfig
-
-job_id = client.train(
-    trainer=DeepSpeedTrainer(
-        func=train_deepspeed,
-        num_nodes=8,
-        resources_per_node={"gpu": 4, "memory": "32Gi"},
-        num_proc_per_node=4,
-        deepspeed_config={
-            "train_batch_size": 32,
-            "fp16": {"enabled": True},
-            "zero_optimization": {"stage": 2},
-        },
-    ),
-    runtime_config=RuntimeConfig(
-        packages_to_install=["deepspeed"],
-    ),
-)
-```
+[#3718](https://github.com/kubeflow/trainer/pull/3718)); this proposal provides the surface
+for that effort rather than a parallel track.
+
+**Risk:** TRL's surface is not frozen, and a typed dataclass mirroring its flags will drift.
+`TRLConfig` targets the script flags rather than the Python API, so a TRL upgrade changes
+the image rather than the SDK type, and the drift is confined to the one config class.
 
 ---
 
 ## Migration and Backward Compatibility
 
+**Server side.** Additive; no existing code path is touched.
+
 | Aspect | Impact |
 |---|---|
-| `CustomTrainer` | **No change.** Remains fully functional. `packages_to_install`, `pip_index_urls`, and `env` fields are retained. |
-| `CustomTrainerContainer` | **No change.** |
-| `BuiltinTrainer` | **No change to its construction signature.** `BuiltinTrainer(config=TorchTuneConfig(...))` keeps working and produces byte-identical `TrainJob` arguments. It becomes the concrete `ConfigTrainer` and its `config` field widens to `FrameworkConfig`, so a second framework is a new config, not a new trainer. Nothing is deprecated. |
-| `TrainerClient.train()` | **Additive only.** New `runtime_config` parameter is optional with default `None`. The `trainer` parameter type union is extended to include `BaseTrainer`. |
-| `TrainJobTemplate` | **No change in this proposal.** Future work can extend it to support `BaseTrainer` subclasses. |
-| `RuntimeConfig` vs `CustomTrainer` fields | When both `RuntimeConfig` and `CustomTrainer` fields are provided, `RuntimeConfig` takes precedence. This is documented but does not break existing code since `RuntimeConfig` defaults to `None`. |
-| Python version | No new Python version requirements. `@dataclass(kw_only=True)` needs Python 3.10, which is already the SDK's floor (`requires-python = ">=3.10"` in `pyproject.toml`). |
-| SDK public exports | New names are exported from `kubeflow.trainer` (`BaseTrainer`, `FuncTrainer`, `ConfigTrainer`, `TorchTrainer`, `DeepSpeedTrainer`, `JAXTrainer`, `XGBoostTrainer`, `RuntimeConfig`, `FrameworkConfig`, `TRLConfig`, `TRLMethod`). No existing exports are removed or renamed. |
+| CRDs | **No change.** No new or modified fields, no version bump. |
+| Torch plugin | **No change.** Neither `EnforceMLPolicy` nor `Validate` is touched; TRL falls through the default path. A unit test asserts it stays that way. |
+| Plugin registry | **No change.** TRL reuses the torch plugin via `mlPolicy.torch`. |
+| Existing TorchTune runtimes | **No change.** Same images, manifests, rendered `TrainJob`s. |
+| Default manifests | **Additive.** New runtimes under a new name prefix; nothing renamed or removed. |
 
----
+**Client side.** Additive.
+
+| Aspect | Impact |
+|---|---|
+| `CustomTrainer`, `CustomTrainerContainer` | **No change.** All fields retained. |
+| `BuiltinTrainer` | **Construction signature unchanged**; produces byte-identical `TrainJob` arguments. `config` widens to `FrameworkConfig`. Nothing deprecated. |
+| `TrainerClient.train()` | **Additive.** `runtime_config` is optional, defaulting to `None`; the `trainer` union gains `BaseTrainer`. |
+| `TrainJobTemplate` | **No change** in this proposal. |
+| Python version | No new floor. `kw_only=True` needs 3.10, already the SDK's minimum. |
+| Public exports | New names only: `BaseTrainer`, `FuncTrainer`, `ConfigTrainer`, `TorchTrainer`, `DeepSpeedTrainer`, `JAXTrainer`, `XGBoostTrainer`, `RuntimeConfig`, `FrameworkConfig`, `TRLConfig`, `TRLMethod`. Nothing removed or renamed. |
 
 ## Test Plan
 
-### Unit Tests
+**Server-side Go unit tests** (`torch_test.go`, extending the table-driven cases). Two
+cases, asserted alongside each other so the paths stay visibly distinct: a
+`[torchrun, -m, trl.scripts.sft]` command is left alone and gets all five `PET_*`,
+including the master vars the TorchTune path suppresses; a `[tune, run]` command is still
+rewritten. The first is the regression guard for
+[I.5](#i5-why-the-plugin-does-not-change) — it fails the moment anyone adds a TRL branch to
+the plugin.
 
-1. **Type hierarchy compliance**: Verify that each `FuncTrainer` subclass correctly
-   inherits `func`/`func_args` fields and that each `FrameworkConfig` subclass declares
-   `framework` and `command` and implements `to_args()`.
-2. **`validate_runtime()` — positive**: Each trainer validates a runtime with a
-   matching framework label and compatible `trainer_type`.
-3. **`validate_runtime()` — negative framework**: Each trainer raises `ValueError`
-   for a runtime with a non-matching framework label.
-4. **`validate_runtime()` — negative trainer_type**: `FuncTrainer` subclass raises
-   `ValueError` for a `BUILTIN_TRAINER` runtime; `ConfigTrainer` subclass raises
-   `ValueError` for a `CUSTOM_TRAINER` runtime.
-5. **`get_framework_args()`**: Verify that each trainer returns only non-overlapping
-   arguments (excludes controller-injected args).
-6. **`RuntimeConfig` defaults**: Verify `None` defaults and precedence over
-   `CustomTrainer` fields.
-7. **Runtime auto-discovery — single match**: Mock `list_runtimes()` to return one
-   matching runtime; verify it is selected.
-8. **Runtime auto-discovery — no match**: Mock `list_runtimes()` to return no
-   matching runtimes; verify `ValueError`.
-9. **Runtime auto-discovery — multiple matches**: Mock `list_runtimes()` to return
-   multiple matching runtimes; verify `ValueError` with runtime names in the
-   message.
+**Manifest tests** — each `manifests/base/runtimes/trl/*.yaml` carries `framework: trl`,
+`mlPolicy.torch: {}`, `command: [torchrun, -m, trl.scripts.<method>]`, and mounts
+`initializer` at `/workspace`.
 
-### Integration Tests
+**Launch-path test** — `examples/trl/local_torchrun_proof.sh` (already committed and
+passing, see [I.3](#i3-proof-of-concept)): two `torchrun -m trl.scripts.sft` launches with
+only the five `PET_*` variables set must form world size 2, asserted by the per-step
+epoch value (`0.0588` → `0.1111`); the single-node control run guards the assertion itself.
+Re-run on every `trl` version bump in `requirements.txt`.
 
-1. **End-to-end with `KubernetesBackend`**: Submit a `TorchTrainer` job against a
-   cluster with the `torch-distributed` runtime installed; verify the `TrainJob` CR
-   is created with the correct runtime reference.
-2. **End-to-end with `ContainerBackend`**: Submit a `TorchTrainer` job locally;
-   verify the container is launched with the correct entrypoint and arguments.
-3. **`RuntimeConfig` application**: Verify that packages from `RuntimeConfig` are
-   installed in the training container and env vars are set.
+**E2E** — a two-node TRL `TrainJob` reaches `Complete` **and** its logs show the two-node
+epoch increment. Asserting completion alone would have passed for the accelerate failure in
+[I.4](#i4-limitation-the-trl-cli-and-accelerate-launch); the world-size assertion is the
+part with teeth. Runs on CPU — no GPU gate needed for the launch path.
 
-### Backward Compatibility Tests
+**Client-side unit tests** — type-hierarchy compliance; `validate_runtime()` positive,
+negative framework, and negative `trainer_type`; `get_framework_args()` excludes
+controller-injected arguments; `RuntimeConfig` defaults and merge precedence; auto-discovery
+with one, zero and several matches (the last two raising, with names in the message).
 
-1. All existing `CustomTrainer` tests pass without modification.
-2. All existing `BuiltinTrainer` tests pass without modification.
-3. Existing `TrainJobTemplate` usage continues to work.
+**Client-side integration tests** — `TorchTrainer` end-to-end on the Kubernetes and
+Container backends; `RuntimeConfig` packages installed and env set. Plus the **cross-repo
+contract**: with the `trl-qwen2.5-1.5b` runtime installed,
+`BuiltinTrainer(config=TRLConfig(...))` resolves it by label, yields
+`trainer_type == BUILTIN_TRAINER`, and emits `command: [torchrun, -m]` with
+`args == config.to_args()` (module name first). This single assertion ties the two parts
+together and fails if either side changes the label or the launch shape.
 
----
+**Backward compatibility** — every existing `CustomTrainer`, `BuiltinTrainer` and
+`TrainJobTemplate` test passes unmodified.
 
 ## Implementation Plan
 
-This proposal can be implemented incrementally across multiple PRs:
+The parts are independent. Part I ships first because it is smaller and because Part II's
+integration tests need a TRL runtime to run against.
 
-**Phase 1: Core Type Hierarchy and RuntimeConfig**
-- Add `BaseTrainer`, `FuncTrainer`, `ConfigTrainer` to `kubeflow/trainer/types/types.py`
-- Add `RuntimeConfig` dataclass
-- Add `_resolve_runtime()` to `TrainerClient`
-- Extend `TrainerClient.train()` signature
-- Unit tests for the type hierarchy and RuntimeConfig
+**Server side**
 
-**Phase 2: TorchTrainer**
-- Implement `TorchTrainer` (extends `FuncTrainer`)
-- Update `KubernetesBackend`, `ContainerBackend`, `LocalProcessBackend` to handle
-  `FuncTrainer` and `ConfigTrainer` dispatch
-- Integration tests
-- Documentation and examples
+| Phase | Contents |
+|---|---|
+| S1 | `cmd/trainers/trl/` with pinned versions, the launch-path proof script, image publishing in the existing workflow |
+| S2 | `manifests/base/runtimes/trl/` + kustomization entry, manifest tests, an `examples/trl/` TrainJob |
+| S3 | The `torch_test.go` regression cases, then the two-node cluster E2E (CPU is sufficient — the launch path is device-agnostic). |
 
-**Phase 3: DeepSpeedTrainer, JAXTrainer, XGBoostTrainer**
-- Implement remaining `FuncTrainer` subclasses
-- DeepSpeedTrainer with multi-runtime support (torch and deepspeed/MPI runtimes)
-- Framework-specific validation and argument handling
-- Tests and documentation
+S1 and S2 must ship together: a manifest referencing an unpublished image is untestable, and
+an image with no manifest is unreachable.
 
-**Phase 4: Public API exports and documentation**
-- Export new classes from `kubeflow.trainer.__init__`
-- Update SDK documentation on sdk.kubeflow.org
-- Add migration guide examples
+**Client side**
 
-> **Note:** Phase 1 and Phase 2 should ship together in the same SDK release.
-> Releasing the type hierarchy without backend support would make `TorchTrainer`
-> importable but unusable, producing a confusing `ValueError` at `train()` time.
+| Phase | Contents |
+|---|---|
+| 1 | `BaseTrainer`, `FuncTrainer`, `ConfigTrainer`, `RuntimeConfig`, `_resolve_runtime()`, the `train()` signature, unit tests |
+| 2 | `TorchTrainer`; `FuncTrainer` / `ConfigTrainer` dispatch in all three backends; integration tests; docs |
+| 3 | `DeepSpeedTrainer` (multi-runtime), `JAXTrainer`, `XGBoostTrainer` |
+| 4 | Public exports, sdk.kubeflow.org documentation, migration guide |
 
----
+Phases 1 and 2 must ship in the same release: the type hierarchy without backend support
+makes `TorchTrainer` importable but unusable, failing with a confusing `ValueError`.
 
 ## Graduation Criteria
 
-### Alpha (target: current cycle)
+**Alpha** — *Server:* the `trl-trainer` image is published and at least one runtime installs
+by default; a two-node TRL job completes with `world_size == numNodes × numProcPerNode`,
+verified in E2E rather than from job status; the torch plugin is unchanged, with a test
+asserting it. *Client:* the type hierarchy and
+`RuntimeConfig` are implemented and exported; `TorchTrainer` works on all three backends;
+auto-discovery and `validate_runtime()` are functional and covered; merge semantics tested;
+all existing tests pass.
 
-- `BaseTrainer`, `FuncTrainer`, `ConfigTrainer`, and `RuntimeConfig` types are
-  implemented and exported.
-- `TorchTrainer` is implemented with full backend support (Kubernetes, Container,
-  LocalProcess).
-- Runtime auto-discovery and `validate_runtime()` are functional.
-- Unit tests cover the type hierarchy, validation (positive and negative), and
-  auto-discovery (single-match, no-match, multi-match).
-- At least one integration test exercises `TorchTrainer` end-to-end against the
-  Kubernetes backend.
-- All existing `CustomTrainer` and `BuiltinTrainer` tests continue to pass.
-- `RuntimeConfig` merge semantics are implemented and tested.
+**Beta** — `DeepSpeedTrainer`, `JAXTrainer`, `XGBoostTrainer`; `TRLConfig` alongside
+`TorchTuneConfig`, proving the extension model with no new trainer class; TRL runtimes for
+the model families TorchTune covers, with `dpo` and `grpo` exercised end-to-end, not only
+`sft`; an out-of-tree config published **paired with an out-of-tree runtime image**, proving
+both halves of the extension path (LlamaFactory is the reference — torchrun-wrapped rather
+than torchrun-native); the torchrun-first launch pattern documented on kubeflow.org as
+operator guidance for building a runtime image; SDK docs and a migration guide.
 
-### Beta
-
-- `DeepSpeedTrainer`, `JAXTrainer`, and `XGBoostTrainer` are implemented.
-- `TRLConfig` is implemented alongside `TorchTuneConfig`, proving the config-driven
-  extension model on a second framework with no new trainer class.
-- An out-of-tree config is published as a `FrameworkConfig` subclass in a separate
-  package, proving the extension path.
-- SDK documentation on sdk.kubeflow.org covers all new trainer types with examples.
-- Migration guide is published.
-
-### GA
-
-- All Tier 1 trainers are stable with no breaking changes for at least one release.
-- `BuiltinTrainer` is formally deprecated (removal deferred to a future major version).
-- `CustomTrainer` runtime-environment fields (`packages_to_install`, `pip_index_urls`,
-  `env`) are formally deprecated in favor of `RuntimeConfig`.
-- Community has contributed at least one Tier 2 `ConfigTrainer` subclass.
-
----
+**GA** — Tier 1 trainers stable for a release; `BuiltinTrainer` and `CustomTrainer`'s
+runtime-environment fields formally deprecated; at least one community `ConfigTrainer`
+subclass; a runtime can report its achieved world size to `TrainJob` status, so a silently
+degraded run is observable (Open Question #6).
 
 ## Open Questions
 
-The following design questions should be resolved before or during implementation:
-
-1. **DeepSpeed launcher detection.** `DeepSpeedTrainer` supports both `torchrun` and
-   `mpirun` launchers. How should `validate_runtime()` detect which launcher a runtime
-   uses? The `Runtime` type currently does not expose launcher metadata. Options:
-   (a) inspect `runtime.trainer.command`, (b) add a launcher label to runtimes,
-   (c) defer validation to the controller.
-
-2. **Does dynamic registration extend to the control plane?** The registry here is
-   SDK-side; the cluster must already hold a labelled runtime (image + manifest).
-   Whether "dynamic registration" should also cover provisioning that runtime needs
-   clarification with the control plane owners, and is deferred until then.
-
-3. **Observability.** When runtime auto-discovery selects a runtime, should the SDK
-   log the selected runtime name and framework at `INFO` level? This would aid
-   debugging but adds a logging dependency.
-
-4. **`resources_per_node` typing.** The current `Optional[dict]` is untyped. Should
-   this be a structured type (e.g., `ResourceRequirements` dataclass with `cpu`,
-   `memory`, `gpu` fields) to enable IDE autocomplete and validation?
-
-5. **Backend validation safety net.** Currently, `validate_runtime()` is only called
-   via `TrainerClient._resolve_runtime()`. Should backends also call
-   `validate_runtime()` as a defensive check, in case trainers are passed to backends
-   directly?
-
----
+1. **DeepSpeed launcher detection.** `DeepSpeedTrainer` supports torchrun and mpirun; the
+   `Runtime` type exposes no launcher metadata. Inspect `runtime.trainer.command`, add a
+   launcher label, or defer to the controller?
+2. **Does dynamic registration extend to the control plane?** *Partly answered.* The registry
+   is SDK-side and stays there — Part I shows a new runtime needs no control-plane
+   registration at all, only an image and a manifest. Open: whether the Trainer should
+   *provision* runtimes for frameworks it does not ship (e.g. from a catalog CR).
+3. **Observability.** Should the SDK log the auto-discovered runtime and framework at `INFO`?
+4. **`resources_per_node` typing.** Should the untyped `Optional[dict]` become a structured
+   `ResourceRequirements` dataclass?
+5. **Backend validation safety net.** Should backends call `validate_runtime()` defensively,
+   in case a trainer is passed to a backend directly?
+6. **Should a runtime report its achieved world size?** The largest gap left open, and not
+   TRL-specific. The `trl-demo` failure in
+   [I.4](#i4-limitation-the-trl-cli-and-accelerate-launch) exited 0 on both pods, so a
+   two-node job that trained two isolated copies was indistinguishable from one that trained
+   jointly. torchrun-first removes that particular cause but not the class: any image whose
+   launch degrades silently produces the same signature. A minimal mechanism: rank 0 reports
+   the world size it joined with, and the controller surfaces it as a status condition,
+   failing the job when it disagrees with `numNodes × numProcPerNode`. That is a
+   control-plane change, out of scope here — but without it, "the TrainJob succeeded" is not
+   evidence that distributed training happened.
+   [KEP-2779](../2779-trainjob-progress/README.md) already establishes a runtime→status
+   channel this could reuse.
+7. **Should accelerate get its own plugin later?** The launcher-only options in
+   [I.4](#i4-limitation-the-trl-cli-and-accelerate-launch) — an accelerate config file per
+   job, the Megatron-LM plugin, TPU — are the reasons the question will return. The
+   position from the SDK call was that a dedicated accelerate plugin is not objectionable in
+   principle — the ask was to understand the torchrun limitations first, which
+   [I.4](#i4-limitation-the-trl-cli-and-accelerate-launch) now records. It is deliberately
+   kept separate from shipping TRL, along with dynamic registration
+   (see #2): both would need their own design discussion, and neither blocks TRL.
 
 ## Alternatives Considered
 
-### 1. Extend CustomTrainer with a `framework` field instead of new classes
+| # | Alternative | Why rejected |
+|---|---|---|
+| 1 | Add a `framework` field to `CustomTrainer` instead of new classes | No home for typed framework arguments; no extension model; the class grows with every framework |
+| 2 | Pydantic `BaseModel` instead of `@dataclass` | The SDK uses dataclasses exclusively; adds a dependency for validation `__post_init__` already covers |
+| 3 | `RuntimeConfig` as a `BaseTrainer` field | The same runtime settings apply to every trainer type; as a `train()` parameter it can extend to initializers later |
+| 4 | Scoring/ranking when several runtimes match | Implicit heuristics are fragile and hard to debug; multiple runtimes per framework is deliberate platform configuration, so the user should choose. A clear error listing them beats a wrong guess |
+| 5 | Flat hierarchy, everything inherits `BaseTrainer` | Config trainers would carry `get_train_func()` returning `None`; func trainers would redeclare `func`/`func_args`; dispatch would test values instead of types |
+| 6 | Specialized trainers inherit `CustomTrainer` | Forces them to carry the runtime-env fields this proposal is separating out |
 
-Add a `framework: Optional[str]` field to `CustomTrainer` and use it for runtime
-discovery and validation.
+**7. One config class per method (`SFTConfig`, `DPOConfig`, `GRPOConfig`).** The method axis
+changes only *which fields apply*, while `to_args()`, `command` and the framework label are
+per-framework — so once a second framework supports the same method, `SFTConfig` needs a
+framework discriminator anyway. Methods are also the volatile axis: TRL moved PPO to
+`trl.experimental` in a minor release. An enum member can be added or deprecated freely; an
+exported class name cannot. The taxonomy is still captured, as `TRLMethod` and
+`_METHOD_SCOPED_FIELDS`, where regrouping is a data change rather than an API change.
 
-**Rejected because:**
-- Does not provide a place for framework-specific typed arguments (`max_restarts`,
-  `num_proc_per_node`).
-- Does not enable the Tier 2 extension model.
-- Violates the open-closed principle: the `CustomTrainer` class would need to grow
-  with each new framework.
-
-### 2. Use Pydantic `BaseModel` instead of `@dataclass`
-
-Use Pydantic for automatic validation, serialization, and schema generation.
-
-**Rejected because:**
-- The existing SDK codebase uses `@dataclass` exclusively. Introducing Pydantic
-  would add a dependency and create an inconsistency in the codebase.
-- Pydantic validation can be replicated with `__post_init__` where needed.
-
-### 3. Put RuntimeConfig inside BaseTrainer instead of as a separate parameter
-
-Make `RuntimeConfig` a field on `BaseTrainer` so that each trainer carries its own
-runtime config.
-
-**Rejected because:**
-- Runtime configuration (packages, env vars) is orthogonal to trainer type. The
-  same `RuntimeConfig` should be usable with `CustomTrainer`,
-  `CustomTrainerContainer`, or any `BaseTrainer` subclass.
-- Keeping it as a separate `train()` parameter maintains clean separation of concerns.
-- Users may want custom env for initializers too. A separate `train()` parameter
-  can be extended to apply to both trainers and initializers without changing trainer
-  classes.
-
-### 4. Automatic runtime selection with scoring/ranking instead of strict single-match
-
-When multiple runtimes match a framework, automatically pick the "best" one using a
-scoring heuristic (e.g., prefer non-deprecated, prefer more specific labels).
-
-**Rejected because:**
-- Implicit selection heuristics are fragile and hard to debug. When multiple runtimes
-  exist for the same framework, it is a deliberate platform configuration and the
-  user should explicitly choose.
-- A clear error message listing available runtimes is more useful than a possibly
-  wrong automatic selection.
-
-### 5. Flat hierarchy: all trainers inherit directly from BaseTrainer
-
-Have all concrete trainers (both function-driven and config-driven) inherit directly
-from `BaseTrainer` without the `FuncTrainer` / `ConfigTrainer` intermediate layer.
-
-**Rejected because:**
-- Config-driven trainers would carry `get_train_func()` returning `None` — semantically
-  incorrect and error-prone.
-- Function-driven trainers would each redeclare `func` and `func_args` fields —
-  unnecessary repetition.
-- Backend dispatch would rely on runtime checks (`if trainer.get_train_func() is None`)
-  instead of type checks (`isinstance(trainer, ConfigTrainer)`).
-- The intermediate classes encode the fundamental difference between the two trainer
-  modes at the type level, making the API self-documenting.
-
-### 6. Have specialized trainers inherit from CustomTrainer
-
-Make `TorchTrainer` a subclass of `CustomTrainer` instead of a new `BaseTrainer`
-hierarchy.
-
-**Rejected because:**
-- `CustomTrainer` carries runtime-environment fields (`packages_to_install`,
-  `pip_index_urls`, `env`) that specialized trainers should not expose (those belong
-  in `RuntimeConfig`).
-- Inheriting from `CustomTrainer` would force specialized trainers to carry fields
-  that violate the separation of concerns this proposal aims to achieve.
-
-### 7. One config class per post-training method (`SFTConfig`, `DPOConfig`, `GRPOConfig`)
-
-Split by method rather than by framework, mirroring TRL's own Python class names.
-
-**Rejected because:**
-- The method axis changes only data — which fields apply — while `to_args()`, `command`, and
-  the framework label are per-framework. Once a second framework supports the same method,
-  `SFTConfig` needs a framework discriminator anyway.
-- Methods are the volatile axis: TRL moved PPO to `trl.experimental` in a minor release. An
-  enum member can be added or deprecated freely; an exported class name cannot.
-- The taxonomy is still captured — as `TRLMethod` and `_METHOD_SCOPED_FIELDS` — where
-  regrouping is a data change rather than a public-API change.
-
-### 8. One trainer class per framework (`TRLTrainer`, `TorchTuneTrainer`)
-
-Give each framework its own `ConfigTrainer` subclass carrying that framework's fields
-directly, so users write `TRLTrainer(method=..., model_name_or_path=...)`.
-
-**Rejected because:**
-- The trainer does nothing different per framework: it hands the config's `command` and
-  `to_args()` to the backend. A subclass per framework encodes in the type hierarchy a
-  distinction that exists only in data.
-- It makes every framework a new exported class name — frozen public API — where the accepted
-  design makes it a config class reachable through the unchanged `BuiltinTrainer(config=...)`.
-- It forces `BuiltinTrainer` onto a deprecation path toward a `TorchTuneTrainer` successor,
-  for no behavior change. The accepted design deprecates nothing.
-
-**What it gets right:** typed per-framework fields and a flatter call
-(`TRLTrainer(...)` versus `BuiltinTrainer(config=TRLConfig(...))`). The accepted design keeps
-the typed fields — they live on the config — at the cost of one level of nesting at the call
-site.
-
----
+**8. One trainer class per framework (`TRLTrainer`, `TorchTuneTrainer`).** The trainer does
+nothing different per framework — it hands `command` and `to_args()` to the backend — so a
+subclass per framework encodes in the type hierarchy a distinction that exists only in data.
+It makes every framework a new exported class name, frozen public API, and forces
+`BuiltinTrainer` onto a deprecation path toward a `TorchTuneTrainer` successor for no
+behaviour change. *What it gets right:* typed per-framework fields and a flatter call. The
+accepted design keeps the typed fields — on the config — at the cost of one level of nesting.
 
 ## References
 
-- [KEP-2170: Kubeflow Trainer V2 API](../2170-kubeflow-trainer-v2/README.md)
-- [KEP-2401: Kubeflow LLM Trainer V2](../2401-llm-trainer-v2/README.md)
-- Tracking issue: [kubeflow/trainer#2839](https://github.com/kubeflow/trainer/issues/2839)
-- Earlier draft of this KEP, superseded by section F:
-  [proposal PR #3263](https://github.com/kubeflow/trainer/pull/3263),
+**Kubeflow**
+
+- [KEP-2170: Trainer V2 API](../2170-kubeflow-trainer-v2/README.md)
+- [KEP-2401: LLM Trainer V2](../2401-llm-trainer-v2/README.md) — the TorchTune integration
+  this generalizes; its "Complement Torch Plugin" section originated the `EnforceMLPolicy`
+  TorchTune branch
+- [KEP-2779: TrainJob progress](../2779-trainjob-progress/README.md) — the runtime→status
+  channel Open Question #6 would reuse
+- Tracking issue [trainer#2839](https://github.com/kubeflow/trainer/issues/2839); GRPO via
+  TRL in flight in [#3508](https://github.com/kubeflow/trainer/issues/3508) /
+  [#3718](https://github.com/kubeflow/trainer/pull/3718)
+- Earlier draft, superseded: [trainer#3263](https://github.com/kubeflow/trainer/pull/3263),
   [sdk#310 registry PoC](https://github.com/kubeflow/sdk/pull/310)
-- [Kubeflow SDK Repository](https://github.com/kubeflow/sdk)
-- [Kubeflow Trainer Repository](https://github.com/kubeflow/trainer)
-- [Kubeflow Community Proposal Workflow](https://github.com/kubeflow/community/blob/master/proposal-workflow.md)
-- [Runtime Guide — trainer.kubeflow.org/framework label](https://www.kubeflow.org/docs/components/trainer/operator-guides/runtime/)
-- [Kubeflow Trainer Getting Started](https://www.kubeflow.org/docs/components/trainer/getting-started/)
-- [SDK Types Source Code](https://github.com/kubeflow/sdk/blob/main/kubeflow/trainer/types/types.py)
-- [SDK TrainerClient Source Code](https://github.com/kubeflow/sdk/blob/main/kubeflow/trainer/api/trainer_client.py)
+- [Runtime guide — the framework label](https://www.kubeflow.org/docs/components/trainer/operator-guides/runtime/)
+- [SDK types](https://github.com/kubeflow/sdk/blob/main/kubeflow/trainer/types/types.py),
+  [SDK TrainerClient](https://github.com/kubeflow/sdk/blob/main/kubeflow/trainer/api/trainer_client.py)
+
+**Upstream sources cited in Part I**
+
+- `torch.distributed.argparse_util` — the `env` action deriving `PET_{DEST}`; why `PET_*` is
+  torchrun's interface and nothing else's. `torch.distributed.run` — `auto` handling and the
+  `-m` / `--module` invocation the runtime command uses.
+- `trl/scripts/sft.py` — a plain script (`TrlParser` + `SFTTrainer`, `__main__` guard, no
+  launcher logic); one sibling module per method. `trl/cli/accelerate_launcher.py` —
+  `launch_training_script` resolves `resources.files("trl.scripts")` and calls accelerate's
+  `launch_command`, which is why the CLI is accelerate-bound.
+- `accelerate.state.PartialState` — in-process env detection: `LOCAL_RANK != -1` → multi-GPU
+  (nccl); `WORLD_SIZE > 1` on CPU → multi-CPU (gloo). This is what makes the script work
+  under torchrun with no launcher flags.
+- `accelerate.commands.launch` — the *launcher* limitations recorded in I.4:
+  `launch_command`'s distributed branches are each guarded `and not args.cpu`;
+  `prepare_simple_launcher_cmd_env` sets `MASTER_ADDR` / `MASTER_PORT` but never `RANK` /
+  `WORLD_SIZE`; the `multi_gpu` auto-enable guard is keyed on
+  `torch.cuda.device_count()`.
+- [trl#4466](https://github.com/huggingface/trl/issues/4466) — PPO moved to experimental.
+  [torchtune#2883](https://github.com/meta-pytorch/torchtune/issues/2883) — development
+  halted, 15 July 2025.

--- a/proposals/2839-dynamic-llm-trainer/README.md
+++ b/proposals/2839-dynamic-llm-trainer/README.md
@@ -258,6 +258,14 @@ genuinely unavailable under torchrun:
 | `--mixed_precision`, `--dynamo_backend` at launch time | Covered by `--bf16` / `--fp16` and `--torch_compile` on the script. |
 | `--mpirun_hostfile` | Only needed because accelerate cannot do multi-process CPU without MPI. torchrun does it natively over gloo, so this is a limitation torchrun *removes*. |
 
+**Elasticity and preemption are not lost either.** For multi-GPU and DeepSpeed,
+`accelerate launch` runs torchrun itself — `import torch.distributed.run as distrib_run`,
+then `distrib_run.run(args)` — and its elastic flags (`--max_restarts`,
+`--monitor_interval`, `--rdzv_backend`, `--rdzv_conf`) are passed straight through to
+torchrun's own parser. Calling torchrun directly gives the same behaviour with one less
+layer. Elastic training is in any case not supported by the Trainer yet, for either
+launcher: `torch.go:109` carries the TODO to add it once JobSet supports elastic jobs.
+
 Supporting `accelerate launch` is **out of scope here** and left to a later discussion
 ([Open Question #7](#open-questions)).
 

--- a/proposals/2839-dynamic-llm-trainer/README.md
+++ b/proposals/2839-dynamic-llm-trainer/README.md
@@ -1,0 +1,1763 @@
+# KEP-2839: Kubeflow Dynamic LLM Trainer Framework
+
+|                |                                                              |
+| -------------- | ------------------------------------------------------------ |
+| **Authors**    | @szaher, @YassinNouh21                                       |
+| **Status**     | Draft                                                        |
+| **Created**    | 2026-02-11                                                   |
+| **Reviewers**  | @andreyvelich, @astefanutti, @kramaranya                     |
+| **Supersedes** | [kubeflow/trainer#3263](https://github.com/kubeflow/trainer/pull/3263) |
+| **Relevant Issues** | [kubeflow/trainer#2839](https://github.com/kubeflow/trainer/issues/2839), [kubeflow/sdk#626](https://github.com/kubeflow/sdk/issues/626) (parked) |
+
+## Table of Contents
+
+<!-- toc -->
+- [KEP-2839: Kubeflow Dynamic LLM Trainer Framework](#kep-2839-kubeflow-dynamic-llm-trainer-framework)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+  - [Motivation](#motivation)
+    - [User Value](#user-value)
+    - [Personas](#personas)
+    - [Why Specialized Trainers?](#why-specialized-trainers)
+    - [Goals](#goals)
+    - [Non-Goals](#non-goals)
+  - [Current State Analysis](#current-state-analysis)
+    - [CustomTrainer](#customtrainer)
+    - [BuiltinTrainer](#builtintrainer)
+    - [TrainerClient.train()](#trainerclienttrain)
+    - [Identified Limitations](#identified-limitations)
+  - [Proposal](#proposal)
+    - [A. BaseTrainer Abstract Interface](#a-basetrainer-abstract-interface)
+    - [B. FuncTrainer — Function-Driven Base](#b-functrainer--function-driven-base)
+      - [TorchTrainer](#torchtrainer)
+      - [DeepSpeedTrainer](#deepspeedtrainer)
+      - [JAXTrainer](#jaxtrainer)
+      - [XGBoostTrainer](#xgboosttrainer)
+    - [C. ConfigTrainer — Config-Driven Base](#c-configtrainer--config-driven-base)
+      - [BuiltinTrainer](#builtintrainer)
+    - [D. RuntimeConfig](#d-runtimeconfig)
+    - [E. TrainerClient Changes](#e-trainerclient-changes)
+    - [F. Config-Driven LLM Trainers](#f-config-driven-llm-trainers)
+      - [FrameworkConfig](#frameworkconfig)
+      - [Dynamic Registration](#dynamic-registration)
+      - [TorchTuneConfig](#torchtuneconfig)
+      - [TRLConfig](#trlconfig)
+      - [Control Plane](#control-plane)
+      - [Which Framework, and Why TRL](#which-framework-and-why-trl)
+  - [Design Details](#design-details)
+    - [Runtime Auto-Discovery](#runtime-auto-discovery)
+    - [Runtime Validation](#runtime-validation)
+    - [Trainer Responsibility Boundary](#trainer-responsibility-boundary)
+    - [Framework Argument Separation](#framework-argument-separation)
+    - [Backend Integration](#backend-integration)
+    - [Type Hierarchy Diagram](#type-hierarchy-diagram)
+  - [User-Facing API Examples](#user-facing-api-examples)
+    - [Before (Current)](#before-current)
+    - [After (Proposed)](#after-proposed)
+  - [Migration and Backward Compatibility](#migration-and-backward-compatibility)
+  - [Test Plan](#test-plan)
+    - [Unit Tests](#unit-tests)
+    - [Integration Tests](#integration-tests)
+    - [Backward Compatibility Tests](#backward-compatibility-tests)
+  - [Implementation Plan](#implementation-plan)
+  - [Graduation Criteria](#graduation-criteria)
+    - [Alpha (target: current cycle)](#alpha-target-current-cycle)
+    - [Beta](#beta)
+    - [GA](#ga)
+  - [Open Questions](#open-questions)
+  - [Alternatives Considered](#alternatives-considered)
+    - [1. Extend CustomTrainer with a `framework` field instead of new classes](#1-extend-customtrainer-with-a-framework-field-instead-of-new-classes)
+    - [2. Use Pydantic `BaseModel` instead of `@dataclass`](#2-use-pydantic-basemodel-instead-of-dataclass)
+    - [3. Put RuntimeConfig inside BaseTrainer instead of as a separate parameter](#3-put-runtimeconfig-inside-basetrainer-instead-of-as-a-separate-parameter)
+    - [4. Automatic runtime selection with scoring/ranking instead of strict single-match](#4-automatic-runtime-selection-with-scoringranking-instead-of-strict-single-match)
+    - [5. Flat hierarchy: all trainers inherit directly from BaseTrainer](#5-flat-hierarchy-all-trainers-inherit-directly-from-basetrainer)
+    - [6. Have specialized trainers inherit from CustomTrainer](#6-have-specialized-trainers-inherit-from-customtrainer)
+    - [7. One config class per post-training method (SFTConfig, DPOConfig, GRPOConfig)](#7-one-config-class-per-post-training-method-sftconfig-dpoconfig-grpoconfig)
+    - [8. One trainer class per framework (TRLTrainer, TorchTuneTrainer)](#8-one-trainer-class-per-framework-trltrainer-torchtunetrainer)
+  - [References](#references)
+<!-- /toc -->
+
+---
+
+## Overview
+
+This proposal introduces two backward-compatible enhancements to the Kubeflow SDK
+(`kubeflow/sdk`) trainer subsystem:
+
+1. **Specialized, framework-aware trainer abstractions** — A three-level type hierarchy:
+   `BaseTrainer` (common interface) → `FuncTrainer` (function-driven) and `ConfigTrainer`
+   (config-driven), with framework-specific implementations (`TorchTrainer`,
+   `DeepSpeedTrainer`, `JAXTrainer`, etc.) that automatically discover and validate the
+   correct `ClusterTrainingRuntime` using the `trainer.kubeflow.org/framework` label.
+   This fills the "missing middle" between the overly generic `CustomTrainer` and the
+   overly narrow `BuiltinTrainer`.
+
+2. **`RuntimeConfig` dataclass** — A dedicated configuration object that cleanly separates
+   per-job runtime environment settings (packages, pip config, environment variables) from
+   training logic and scaling parameters. This replaces the current pattern where
+   `CustomTrainer` conflates runtime concerns with trainer concerns.
+
+Both changes are purely additive. Existing code using `CustomTrainer`, `BuiltinTrainer`, and
+`TrainerClient.train()` remains fully functional without modification.
+
+---
+
+## Motivation
+
+### User Value
+
+The Kubeflow Trainer v2 architecture (KEP-2170) introduced a powerful separation between
+the *what* (`TrainJob`) and the *how* (`TrainingRuntime` / `ClusterTrainingRuntime`). The
+SDK exposes this through `TrainerClient.train()`, which accepts a trainer and an optional
+runtime reference. However, the current SDK abstractions create a usability gap:
+
+- **`CustomTrainer`** requires the user to know the runtime name, manually look it up
+  via `get_runtime()`, and pass both training arguments and runtime-environment settings
+  (packages, pip URLs, env vars) into a single flat dataclass. It provides no
+  framework-specific validation or argument handling.
+
+- **`BuiltinTrainer`** is restricted to a single use case (`TorchTuneConfig`) and does
+  not accept user-defined training functions.
+
+For the majority of distributed training workloads — "run this PyTorch DDP function on
+N nodes" or "run this DeepSpeed training script across a cluster" — neither abstraction
+fits well.
+Users must either use the low-level `CustomTrainer` with manual runtime wiring, or
+fall back to raw YAML.
+
+### Personas
+
+This proposal benefits all three personas defined in KEP-2170:
+
+| Persona | Current Pain | Proposed Improvement |
+|---|---|---|
+| **Data Scientist / ML Engineer** | Must understand runtime names and Kubernetes concepts to use `CustomTrainer` | Uses `TorchTrainer(func=my_fn)` — runtime is auto-discovered |
+| **MLOps Engineer** | Must help data scientists find the correct runtime name for their framework | Framework validation catches mismatches at submission time |
+| **Platform Admin / DevOps** | Cannot enforce that users pick the correct runtime for their framework | Trainers validate `trainer.kubeflow.org/framework` labels on runtimes |
+
+### Why Specialized Trainers?
+
+Beyond runtime auto-discovery and framework validation, specialized trainers provide
+a set of capabilities that `CustomTrainer` cannot offer:
+
+| Capability | `CustomTrainer` | Specialized Trainer (e.g., `TorchTrainer`) |
+|---|---|---|
+| **Runtime selection** | User must know and pass the runtime name | Auto-discovered from `trainer.kubeflow.org/framework` label |
+| **Framework validation** | None — mismatches fail at execution time | Validated at submission time, before `TrainJob` is created |
+| **Typed framework arguments** | Untyped `func_args` dict mixes hyperparams with framework args (`max_restarts`, `deepspeed_config`) | Dedicated typed fields with IDE autocomplete and documentation |
+| **Separation of concerns** | Runtime env (`packages_to_install`, `env`), scaling (`num_nodes`), training logic (`func`), and framework args all in one flat dataclass | Training logic in `FuncTrainer`, config in `ConfigTrainer`, runtime env in `RuntimeConfig`, scaling on `BaseTrainer` |
+| **IDE/type-checker support** | `func_args: dict` — no autocomplete or type checking | Typed fields — autocomplete, mypy, and docstrings per framework |
+| **Extensibility** | Adding framework support requires modifying `CustomTrainer` or creating ad-hoc wrappers | New framework = new subclass of `FuncTrainer` or `ConfigTrainer` |
+| **Self-documenting API** | `CustomTrainer(func=..., func_args={"max_restarts": 3})` — unclear what's a hyperparam vs. framework arg | `TorchTrainer(func=..., max_restarts=3)` — intent is clear from the type |
+
+**In summary:** Specialized trainers encode framework knowledge into the type system.
+The trainer class itself tells you what framework it targets, what arguments it accepts,
+and what runtimes it is compatible with. This shifts errors from runtime to definition
+time and makes the SDK self-documenting.
+
+### Goals
+
+1. Define a `BaseTrainer` abstract interface that all trainer implementations satisfy,
+   enabling the SDK and backends to handle any trainer polymorphically.
+2. Define two intermediate abstract classes — `FuncTrainer` for function-driven
+   trainers and `ConfigTrainer` for config-driven trainers — that provide shared
+   fields and default implementations for their respective categories.
+3. Implement framework-specific function-driven trainers (`TorchTrainer`,
+   `DeepSpeedTrainer`, `JAXTrainer`, `XGBoostTrainer`) that auto-discover runtimes
+   by the `trainer.kubeflow.org/framework` label and validate runtime compatibility.
+4. Provide a clear extension point for community-contributed config-driven frameworks
+   (e.g., `TRLConfig`; an out-of-tree framework is a `FrameworkConfig` subclass in any
+   package).
+5. Introduce a `RuntimeConfig` dataclass to cleanly separate per-job runtime environment
+   settings from training-loop and scaling configuration.
+6. Maintain 100% backward compatibility with the existing `CustomTrainer`,
+   `CustomTrainerContainer`, `BuiltinTrainer`, and `TrainerClient.train()` APIs.
+
+### Non-Goals
+
+1. **Controller/CRD changes.** This proposal is SDK-only. No changes to the Kubeflow
+   Trainer controller, `TrainJob` CRD, or `ClusterTrainingRuntime` CRD are required.
+2. **New runtime labels or conventions.** We rely on the existing
+   `trainer.kubeflow.org/framework` label already required on all runtimes.
+3. **Deprecating `CustomTrainer` or `BuiltinTrainer`.** Both remain supported.
+   Specialized trainers are an additional option, not a replacement. `ConfigTrainer`
+   is designed as the successor to `BuiltinTrainer` for config-driven trainers,
+   but the migration is deferred to a follow-up proposal.
+4. **Tier 2 trainer implementations.** This proposal defines the extension mechanism
+   and interface. Concrete Tier 2 implementations (TorchTune, Transformers, Unsloth,
+   Axolotl) will be proposed in follow-up KEPs.
+5. **Changes to the `TrainJobTemplate` dataclass.** Template support for specialized
+   trainers can be added incrementally.
+
+---
+
+## Current State Analysis
+
+The following is the current SDK API surface as of `kubeflow-sdk v0.1` (source:
+[`kubeflow/trainer/types/types.py`](https://github.com/kubeflow/sdk/blob/main/kubeflow/trainer/types/types.py)).
+
+### CustomTrainer
+
+```python
+@dataclass
+class CustomTrainer:
+    func: Callable
+    func_args: Optional[dict] = None
+    image: Optional[str] = None
+    packages_to_install: Optional[list[str]] = None          # Runtime concern
+    pip_index_urls: list[str] = field(                       # Runtime concern
+        default_factory=lambda: list(constants.DEFAULT_PIP_INDEX_URLS)
+    )
+    num_nodes: Optional[int] = None                          # Scaling concern
+    resources_per_node: Optional[dict] = None                # Scaling concern
+    env: Optional[dict[str, str]] = None                     # Runtime concern
+```
+
+**Issues:**
+
+- Mixes runtime-environment settings (`packages_to_install`, `pip_index_urls`, `env`)
+  with scaling/resource settings (`num_nodes`, `resources_per_node`) and training logic
+  (`func`, `func_args`).
+- No framework awareness. A user can pass a PyTorch training function with a
+  DeepSpeed runtime and the SDK will not catch the mismatch until the controller
+  rejects the job or, worse, it fails at execution time.
+- `func_args` is an untyped `dict` that conflates user hyperparameters with framework
+  arguments (e.g., `rdzv_endpoint`, `nnodes`) that the Trainer controller already
+  injects via environment variables.
+
+### BuiltinTrainer
+
+```python
+@dataclass
+class BuiltinTrainer:
+    config: TorchTuneConfig
+```
+
+- Hardcoded to `TorchTuneConfig`. Cannot be extended to other config-driven frameworks
+  without modifying the class itself.
+
+### TrainerClient.train()
+
+```python
+def train(
+    self,
+    runtime: Optional[Union[str, types.Runtime]] = None,
+    initializer: Optional[types.Initializer] = None,
+    trainer: Optional[
+        Union[types.CustomTrainer, types.CustomTrainerContainer, types.BuiltinTrainer]
+    ] = None,
+    options: Optional[list] = None,
+) -> str:
+```
+
+- The `trainer` parameter type union must be extended for each new trainer type.
+- No concept of runtime auto-discovery: if `runtime` is `None`, it defaults to
+  `torch-distributed` regardless of the trainer type.
+
+### Identified Limitations
+
+| # | Limitation | Impact |
+|---|---|---|
+| 1 | **Missing middle abstraction** | 90% of workloads fall between BuiltinTrainer (too specific) and CustomTrainer (too generic) |
+| 2 | **Mixed concerns in CustomTrainer** | Runtime config, scaling config, and training logic are tangled in one dataclass |
+| 3 | **No framework validation** | Mismatched trainer/runtime combinations fail late — at execution, not submission |
+| 4 | **No framework-specific arguments** | torch-specific args (e.g., `max-restarts`, `monitor-interval`) have no typed home |
+| 5 | **BuiltinTrainer is not extensible** | Adding a new config-driven framework requires changing the BuiltinTrainer class |
+| 6 | **Flat `func_args` dict** | User hyperparameters mix with framework arguments the controller injects |
+
+---
+
+## Proposal
+
+### A. BaseTrainer Abstract Interface
+
+Introduce an abstract base class that defines the contract all trainers must satisfy.
+This enables the SDK, backends, and `TrainerClient` to work with any trainer
+polymorphically through a single, stable interface.
+
+`BaseTrainer` holds common fields and methods shared by both function-driven and
+config-driven trainers. The training-mode-specific concerns (`func`/`func_args` vs.
+`config`) are pushed down to the two intermediate classes described in sections B and C.
+
+```python
+# kubeflow/trainer/types/types.py
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Callable, Optional, ClassVar
+
+@dataclass(kw_only=True)
+class BaseTrainer(ABC):
+    """Abstract base class for all specialized trainer implementations.
+
+    Provides common fields for scaling and resource configuration, runtime
+    auto-discovery via the `supported_frameworks` class variable, and
+    framework validation.
+
+    Subclasses should not inherit from this directly — use `FuncTrainer`
+    for function-driven trainers or `ConfigTrainer` for config-driven trainers.
+
+    Class Attributes:
+        supported_frameworks: Framework identifiers this trainer supports.
+            Must match values of the `trainer.kubeflow.org/framework` label
+            on ClusterTrainingRuntime resources. Declared as a tuple (immutable)
+            and ordered by preference — the first entry is the preferred framework
+            for auto-discovery.
+
+    Args:
+        num_nodes: Number of nodes for distributed training.
+        resources_per_node: Resource requirements per node (cpu, memory, gpu).
+        image: Optional custom container image.
+    """
+
+    supported_frameworks: ClassVar[tuple[str, ...]]
+
+    num_nodes: Optional[int] = None
+    resources_per_node: Optional[dict] = None
+    image: Optional[str] = None
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        # `__abstractmethods__` is a `type` descriptor that does not inherit
+        # through the MRO, and ABCMeta populates it only *after*
+        # `__init_subclass__` runs — so it cannot be used to detect an abstract
+        # subclass here. Skip classes that declare abstract methods of their own,
+        # and let `abc` reject instantiation of anything still abstract.
+        if any(
+            getattr(value, "__isabstractmethod__", False)
+            for value in cls.__dict__.values()
+        ):
+            return
+        if not getattr(cls, "supported_frameworks", None):
+            raise TypeError(
+                f"{cls.__name__} must define a non-empty "
+                f"'supported_frameworks' class variable"
+            )
+
+    def validate_runtime(self, runtime: "Runtime") -> None:
+        """Validate that the given runtime is compatible with this trainer.
+
+        The default implementation checks the runtime's framework label against
+        `supported_frameworks`. Subclasses may add additional validation.
+
+        Raises:
+            ValueError: If the runtime's framework is not in supported_frameworks.
+        """
+        if runtime.trainer.framework not in self.supported_frameworks:
+            raise ValueError(
+                f"{type(self).__name__} supports frameworks "
+                f"{self.supported_frameworks}, but runtime '{runtime.name}' "
+                f"has framework '{runtime.trainer.framework}'"
+            )
+```
+
+**Design decisions:**
+
+- `supported_frameworks` is a `ClassVar[tuple[str, ...]]` — immutable and class-level.
+  It is a property of the trainer *class*, not of individual instances. The tuple is
+  ordered by preference: the first entry is the preferred framework for auto-discovery.
+  `__init_subclass__` enforces that every concrete subclass defines a non-empty
+  `supported_frameworks`, catching missing declarations at class definition time
+  rather than at runtime. It detects abstract intermediates by inspecting
+  `cls.__dict__` for `__isabstractmethod__` rather than reading
+  `cls.__abstractmethods__`: that attribute is a `type` descriptor which does not
+  inherit through the MRO, and `ABCMeta` populates it only *after*
+  `__init_subclass__` has run, so it is always absent here. Reading it would make
+  the guard fire on `FuncTrainer` and `ConfigTrainer` themselves, which legitimately
+  do not declare `supported_frameworks`.
+- Common fields (`num_nodes`, `resources_per_node`, `image`) live on `BaseTrainer` so
+  every trainer inherits them without repetition.
+- The new hierarchy is `@dataclass(kw_only=True)`: `BaseTrainer`'s fields have defaults,
+  so without `kw_only` a subclass could not declare a required field — `FuncTrainer.func`
+  would raise `TypeError` at class-definition time. Existing types (`CustomTrainer`,
+  `BuiltinTrainer`) keep their bare declarations; their signatures are public API.
+- `BaseTrainer` declares no argument-rendering method. Each branch renders its own way:
+  `FuncTrainer` declares `get_framework_args()` (abstract), and the config-driven path
+  renders through the config's `to_args()` ([Section F](#f-config-driven-llm-trainers)).
+  Putting a shared dict-shaped accessor on `BaseTrainer` would duplicate `to_args()` on
+  the config side.
+- `validate_runtime()` has a default implementation so subclasses get validation for
+  free but can extend it.
+- Methods use `get_*` naming to clearly indicate they are accessors, not setters.
+
+### B. FuncTrainer — Function-Driven Base
+
+`FuncTrainer` is the base class for trainers where the user provides a Python training
+function. It owns the `func` and `func_args` fields and implements the corresponding
+accessors, so concrete framework trainers only need to add framework-specific fields.
+
+```python
+@dataclass(kw_only=True)
+class FuncTrainer(BaseTrainer):
+    """Base class for function-driven trainers.
+
+    The user provides a training function that is serialized and executed
+    within the distributed environment configured by the runtime.
+
+    Args:
+        func: The training function. Each node executes this function.
+        func_args: Arguments passed to the training function. Should contain
+            only user hyperparameters — framework arguments like rdzv_endpoint
+            and nnodes are injected by the Kubeflow Trainer controller.
+    """
+
+    func: Callable
+    func_args: Optional[dict] = None
+
+    @abstractmethod
+    def get_framework_args(self) -> dict:
+        """Return framework-specific CLI/env arguments that do not overlap
+        with arguments injected by the Kubeflow Trainer controller
+        (e.g., rdzv_endpoint, nnodes are excluded)."""
+        ...
+
+    def get_train_func(self) -> Callable:
+        """Return the user-provided training function."""
+        return self.func
+
+    def get_train_func_args(self) -> Optional[dict]:
+        """Return the arguments to pass to the training function."""
+        return self.func_args
+
+    def validate_runtime(self, runtime: "Runtime") -> None:
+        """Validate framework and trainer_type compatibility.
+
+        FuncTrainer requires runtimes with trainer_type == CUSTOM_TRAINER.
+        """
+        super().validate_runtime(runtime)
+        if runtime.trainer.trainer_type != TrainerType.CUSTOM_TRAINER:
+            raise ValueError(
+                f"{type(self).__name__} requires a runtime with "
+                f"trainer_type={TrainerType.CUSTOM_TRAINER.value}, but "
+                f"runtime '{runtime.name}' has "
+                f"trainer_type={runtime.trainer.trainer_type.value}"
+            )
+```
+
+Concrete function-driven trainers extend `FuncTrainer` and only need to define
+`supported_frameworks`, framework-specific fields, and `get_framework_args()`:
+
+#### TorchTrainer
+
+```python
+@dataclass
+class TorchTrainer(FuncTrainer):
+    """Trainer for PyTorch distributed training workloads.
+
+    Supports runtimes labeled with `trainer.kubeflow.org/framework: torch`.
+
+    Args:
+        max_restarts: Maximum number of worker group restarts before failing.
+            Maps to torchrun --max-restarts.
+        monitor_interval: Interval in seconds for the elastic agent to monitor
+            workers. Maps to torchrun --monitor-interval.
+    """
+
+    supported_frameworks: ClassVar[tuple[str, ...]] = ("torch",)
+
+    # Torch-specific arguments (non-overlapping with controller-injected args)
+    max_restarts: Optional[int] = None
+    monitor_interval: Optional[float] = None
+
+    def get_framework_args(self) -> dict:
+        args = {}
+        if self.max_restarts is not None:
+            args["max-restarts"] = str(self.max_restarts)
+        if self.monitor_interval is not None:
+            args["monitor-interval"] = str(self.monitor_interval)
+        return args
+```
+
+#### DeepSpeedTrainer
+
+```python
+@dataclass
+class DeepSpeedTrainer(FuncTrainer):
+    """Trainer for DeepSpeed distributed training workloads.
+
+    DeepSpeed can be bootstrapped via either `torchrun` or `mpirun`, so this
+    trainer supports both torch-based and MPI-based runtimes. The SDK
+    auto-discovers a compatible runtime by matching the
+    `trainer.kubeflow.org/framework` label against the supported frameworks.
+    When both runtime types are available, the user must specify the runtime
+    explicitly.
+
+    Args:
+        deepspeed_config: Path or dict for the DeepSpeed JSON configuration.
+            When provided, the config is passed to the DeepSpeed launcher
+            via the --deepspeed_config flag.
+        num_proc_per_node: Number of processes per node. Maps to
+            --num_gpus (DeepSpeed launcher) or --nproc_per_node (torchrun).
+    """
+
+    supported_frameworks: ClassVar[tuple[str, ...]] = ("deepspeed", "torch")
+
+    # DeepSpeed-specific arguments
+    deepspeed_config: Optional[Union[str, dict]] = None
+    num_proc_per_node: Optional[int] = None
+
+    def validate_runtime(self, runtime: "Runtime") -> None:
+        """Validate framework compatibility and launcher support.
+
+        In addition to the standard framework label check, DeepSpeedTrainer
+        verifies that the runtime's launcher is compatible (torchrun or mpirun).
+        """
+        super().validate_runtime(runtime)
+        # TODO: Check runtime.trainer.command for launcher compatibility
+        # once the Runtime type exposes launcher metadata.
+
+    def get_framework_args(self) -> dict:
+        args = {}
+        if self.deepspeed_config is not None:
+            if isinstance(self.deepspeed_config, dict):
+                import json
+                args["deepspeed_config"] = json.dumps(self.deepspeed_config)
+            else:
+                args["deepspeed_config"] = self.deepspeed_config
+        if self.num_proc_per_node is not None:
+            args["num-proc-per-node"] = str(self.num_proc_per_node)
+        return args
+```
+
+#### JAXTrainer
+
+```python
+@dataclass
+class JAXTrainer(FuncTrainer):
+    """Trainer for JAX distributed training workloads.
+
+    Supports runtimes labeled with `trainer.kubeflow.org/framework: jax`.
+    """
+
+    supported_frameworks: ClassVar[tuple[str, ...]] = ("jax",)
+
+    def get_framework_args(self) -> dict:
+        return {}
+```
+
+#### XGBoostTrainer
+
+```python
+@dataclass
+class XGBoostTrainer(FuncTrainer):
+    """Trainer for XGBoost distributed training workloads.
+
+    Supports runtimes labeled with `trainer.kubeflow.org/framework: xgboost`.
+    """
+
+    supported_frameworks: ClassVar[tuple[str, ...]] = ("xgboost",)
+
+    def get_framework_args(self) -> dict:
+        return {}
+```
+
+### C. ConfigTrainer — Config-Driven Base
+
+`ConfigTrainer` is the base class for trainers that are driven by a configuration
+object rather than a user-provided function. The runtime's entrypoint (e.g.,
+`tune run`, `accelerate launch`) handles execution based on the config.
+
+This replaces the current `BuiltinTrainer` pattern with an extensible, `BaseTrainer`-
+compatible design that supports runtime auto-discovery and framework validation.
+
+```python
+@dataclass(kw_only=True)
+class ConfigTrainer(BaseTrainer):
+    """Base class for config-driven trainers.
+
+    Config-driven trainers do not accept a user training function. Instead,
+    they carry a `FrameworkConfig` that fully describes the training job.
+    The runtime's entrypoint handles execution based on the config.
+    """
+
+    config: FrameworkConfig
+
+    @property
+    def supported_frameworks(self) -> tuple[str, ...]:
+        """The framework is carried by the config, not fixed per class."""
+        return (self.config.framework,)
+
+    def validate_runtime(self, runtime: "Runtime") -> None:
+        """Validate framework and trainer_type compatibility.
+
+        ConfigTrainer requires runtimes with trainer_type == BUILTIN_TRAINER.
+        """
+        super().validate_runtime(runtime)
+        if runtime.trainer.trainer_type != TrainerType.BUILTIN_TRAINER:
+            raise ValueError(
+                f"{type(self).__name__} requires a runtime with "
+                f"trainer_type={TrainerType.BUILTIN_TRAINER.value}, but "
+                f"runtime '{runtime.name}' has "
+                f"trainer_type={runtime.trainer.trainer_type.value}"
+            )
+```
+
+`supported_frameworks` is a property here rather than the `ClassVar` that `FuncTrainer`
+subclasses declare, because a config-driven trainer's framework is a property of the
+instance's config rather than of the class.
+
+This is the one place the property form matters for `__init_subclass__`: the guard reads
+`getattr(cls, "supported_frameworks", None)`, which on `ConfigTrainer` returns the *property
+object* — always truthy — so the check passes without inspecting a framework value. That is
+acceptable because the value it would inspect comes from `cls.config.framework`, and the
+registry already rejects a `FrameworkConfig` that declares no framework (see
+[Dynamic Registration](#dynamic-registration)). The declaration is validated once, where it
+is made, rather than twice.
+
+`ConfigTrainer` is **not** subclassed per framework. A framework is a *config* — the
+existing `BuiltinTrainer(config=TorchTuneConfig(...))` shape, generalized so the config
+can be any framework's. [Section F](#f-config-driven-llm-trainers) specifies the config
+base class and the concrete configs; the trainer side stays one class.
+
+#### BuiltinTrainer
+
+`ConfigTrainer` is concrete — new code constructs it directly with any registered config.
+`BuiltinTrainer` stays where it is today, existing and unchanged: its public construction
+signature remains `BuiltinTrainer(config=...)`, and its `config` field widens from the
+concrete `TorchTuneConfig` to the `FrameworkConfig` base. Both entry points accept any
+framework, so a second framework is a new config class and no new trainer class:
+
+```python
+BuiltinTrainer(config=TorchTuneConfig(...))   # today, still valid
+ConfigTrainer(config=TRLConfig(...))          # new code, same machinery
+```
+
+| Aspect | `BuiltinTrainer` (current) | `BuiltinTrainer` (proposed) |
+|---|---|---|
+| Runtime discovery | None (hardcoded) | Auto-discovery via `config.framework` |
+| Framework validation | None | `validate_runtime()` |
+| RuntimeConfig support | No | Yes |
+| Extension model | Modify `BuiltinTrainer` | Add a `FrameworkConfig` subclass |
+| Config type | Hardcoded `TorchTuneConfig` | Any `FrameworkConfig` |
+
+Existing code keeps working unchanged and nothing is deprecated.
+
+### D. RuntimeConfig
+
+Extract runtime-environment settings from `CustomTrainer` into a dedicated dataclass.
+This provides a clean separation of concerns and allows runtime configuration to be
+reused across any trainer type.
+
+```python
+@dataclass
+class RuntimeConfig:
+    """Per-job runtime environment configuration.
+
+    Separates runtime-environment concerns (what packages to install, what
+    environment variables to set) from training-loop and scaling concerns.
+
+    This is passed to `TrainerClient.train()` and applies regardless of
+    the trainer type used. It is a separate parameter on `train()` — not
+    embedded in trainers — because runtime configuration is orthogonal to
+    both trainer type and initializer. The same RuntimeConfig applies to
+    all training pods, and keeping it at the `train()` call site allows
+    users to set custom env for initializers in the future without changing
+    the trainer classes.
+
+    Args:
+        packages_to_install: Python packages to install before running the
+            training function (e.g., ["transformers>=4.40", "datasets"]).
+        pip_index_urls: PyPI index URLs. The first URL is the primary index;
+            remaining URLs are extra indexes.
+        env: Environment variables to set in all training nodes.
+    """
+
+    packages_to_install: Optional[list[str]] = None
+    pip_index_urls: list[str] = field(
+        default_factory=lambda: list(constants.DEFAULT_PIP_INDEX_URLS)
+    )
+    env: Optional[dict[str, str]] = None
+```
+
+**Design decisions:**
+
+- Uses `@dataclass` (not Pydantic `BaseModel`) to be consistent with the rest of the
+  SDK codebase.
+- Field names (`packages_to_install`, `pip_index_urls`) are consistent with the
+  existing `CustomTrainer` fields and with KFP's `PipelinesClient`.
+- Pip configuration is flattened into `RuntimeConfig` rather than nested in a separate
+  `PipConfig` type, keeping the API surface minimal. Additional pip options (e.g.,
+  `--quiet`, `--user`) can be added as fields later if needed.
+- `RuntimeConfig` is a separate `train()` parameter — not embedded in trainers —
+  because runtime configuration is orthogonal to trainer type. The same `RuntimeConfig`
+  should be usable with `CustomTrainer`, `FuncTrainer`, or `ConfigTrainer` subclasses.
+  It also allows future extension to apply env vars to initializers.
+- `RuntimeConfig` is optional — when not provided, the trainer's own fields
+  (`packages_to_install`, `env` on `CustomTrainer`) or the runtime defaults are used.
+  This preserves backward compatibility.
+- **Merge semantics:** When both `RuntimeConfig` and `CustomTrainer` fields are
+  provided, `RuntimeConfig` fields override `CustomTrainer` fields **only when the
+  `RuntimeConfig` field is not `None`**. For example, if
+  `RuntimeConfig(env={"DEBUG": "1"})` is passed alongside
+  `CustomTrainer(packages_to_install=["torch"])`, the trainer's `packages_to_install`
+  is preserved because `RuntimeConfig.packages_to_install` is `None`. This is a
+  field-level merge, not a wholesale replacement.
+
+### E. TrainerClient Changes
+
+The `TrainerClient.train()` method signature is extended to accept the new types:
+
+```python
+class TrainerClient:
+
+    def train(
+        self,
+        runtime: Optional[Union[str, "Runtime"]] = None,
+        initializer: Optional["Initializer"] = None,
+        trainer: Optional[
+            Union[
+                "CustomTrainer",
+                "CustomTrainerContainer",
+                "BuiltinTrainer",
+                "BaseTrainer",        # NEW: accepts any specialized trainer
+            ]
+        ] = None,
+        runtime_config: Optional["RuntimeConfig"] = None,  # NEW
+        options: Optional[list] = None,
+    ) -> str:
+```
+
+When a `BaseTrainer` subclass is passed:
+
+1. If `runtime` is `None`, the SDK calls `list_runtimes()` and filters by the
+   `trainer.kubeflow.org/framework` label matching the trainer's
+   `supported_frameworks`.
+2. If exactly one matching runtime is found, it is used automatically.
+3. If multiple matching runtimes are found, a `ValueError` is raised listing the
+   available options and instructing the user to specify one explicitly.
+4. If `runtime` is provided (as a name or `Runtime` object), the trainer's
+   `validate_runtime()` method is called to verify compatibility.
+5. The backend dispatches based on the trainer type: `FuncTrainer` subclasses are
+   handled via `get_train_func()` / `get_train_func_args()` / `get_framework_args()`,
+   while `ConfigTrainer` is handled via `config.command` and `config.to_args()`.
+
+When `runtime_config` is provided, its values take precedence over any
+runtime-environment fields on `CustomTrainer` (for backward compatibility, those
+fields remain on `CustomTrainer` but `RuntimeConfig` is the preferred mechanism).
+
+**`runtime=None` behavior by trainer type:**
+
+| Trainer type | `runtime=None` behavior |
+|---|---|
+| `CustomTrainer` / `BuiltinTrainer` | Defaults to `constants.DEFAULT_TRAINING_RUNTIME` ("torch-distributed"), preserving existing behavior. |
+| `BaseTrainer` subclasses (`TorchTrainer`, etc.) | Auto-discovery via `_resolve_runtime()` — finds runtimes matching `supported_frameworks`. |
+
+This distinction is intentional: existing code must not change behavior, while new
+trainer types benefit from auto-discovery. The `train()` docstring documents this
+difference explicitly.
+
+### F. Config-Driven LLM Trainers
+
+Section C keeps the trainer side to one class and puts the framework in the config. This
+section specifies the config base class, the two concrete configs — `TorchTuneConfig` and
+`TRLConfig` — and the SDK changes they require.
+
+TorchTune is currently the only config-driven framework the SDK can represent. It is
+hardcoded at four points:
+
+| # | Coupling | Location |
+|---|---|---|
+| 1 | `BuiltinTrainer.config` is annotated with the concrete `TorchTuneConfig` type | `types.py:226-236` |
+| 2 | The framework identifier is derived by reflecting on that annotation, yielding `"torchtune"`. The code's own comment reads "Change it to list: BUILTIN_CONFIGS, once we support more Builtin Trainer configs." | `types.py:239-240` |
+| 3 | `trainer_type` and the container entrypoint are both selected by string-comparing the runtime's framework label against that derived constant | `utils.py:114-119`, `:140-148` |
+| 4 | Config-to-argument translation is guarded by an `isinstance` check against `TorchTuneConfig` | `utils.py:451-452`, `:473-527` |
+
+Coupling #3 is the load-bearing one. `trainer_type` is not a field on the Runtime CR; the SDK
+computes it as `BUILTIN_TRAINER if framework == types.TORCH_TUNE else CUSTOM_TRAINER`. A
+runtime labelled `trainer.kubeflow.org/framework: trl` therefore resolves to `CUSTOM_TRAINER`
+today, and `ConfigTrainer.validate_runtime()` would reject it. Until `get_runtime_trainer()`
+changes, no config-driven trainer other than TorchTune can run.
+
+#### FrameworkConfig
+
+A config knows three things the SDK needs and nothing else knows: which framework label it
+claims, which entrypoint runs it, and how it renders itself as arguments for that entrypoint.
+These are the three couplings above, moved onto one object.
+
+```python
+# kubeflow/trainer/types/types.py
+
+@dataclass(kw_only=True)
+class FrameworkConfig(abc.ABC):
+    """Base class for the configuration of a config-driven LLM framework.
+
+    Concrete configs declare the framework label they claim and the container
+    entrypoint that consumes them, and render themselves as that entrypoint's
+    arguments.
+    """
+
+    framework: ClassVar[str] = ""
+    command: ClassVar[tuple[str, ...]] = ()
+
+    @abstractmethod
+    def to_args(self) -> list[str]:
+        """Render this config as arguments for `command`."""
+        ...
+```
+
+`to_args()` renders only the config's own fields. It takes no initializer: configs are plain
+dataclasses and stay that way, so nothing in `types.py` needs to know how a backend stages
+data.
+
+#### Dynamic Registration
+
+The framework label is resolved through a registry rather than a constant. It maps a label to
+a `FrameworkConfig` subclass and serves exactly one lookup — the one `get_runtime_trainer()`
+performs — and is the extension path for out-of-tree frameworks.
+
+```python
+# kubeflow/trainer/types/registry.py
+
+from typing import Optional
+
+_FRAMEWORK_CONFIGS: dict[str, type["FrameworkConfig"]] = {}
+
+
+def register_framework(cls: type["FrameworkConfig"]) -> type["FrameworkConfig"]:
+    """Claim the framework label declared in `cls.framework`."""
+    if not (cls.framework and cls.command):
+        raise ValueError(f"{cls.__name__} must declare a framework and a command")
+    _FRAMEWORK_CONFIGS[cls.framework] = cls
+    return cls
+
+
+def get_framework(framework: str) -> Optional[type["FrameworkConfig"]]:
+    """Return the FrameworkConfig claiming this framework label, or None."""
+    return _FRAMEWORK_CONFIGS.get(framework)
+```
+
+Registration is an explicit decorator because that is how this ecosystem already registers
+plugins: the Trainer control plane lists every framework plugin by hand in
+`pkg/runtime/framework/plugins/registry.go`, the earlier draft of this KEP
+([trainer#3263](https://github.com/kubeflow/trainer/pull/3263)) sketched this exact shape
+(`@register_framework`), and kubeflow/sdk#310 is its PoC. The decorator takes no string
+argument — it is keyed off `cls.framework`, so there is no name to drift from the class.
+There is no entry-point or import-hook discovery: an out-of-tree config must be imported
+before it can be constructed, and importing it registers it, so the decorator is sufficient.
+
+#### TorchTuneConfig
+
+`TorchTuneConfig` keeps every field and its construction signature. It gains the three
+`FrameworkConfig` members:
+
+```python
+# kubeflow/trainer/types/types.py
+# Additional imports: `from kubeflow.trainer.types import torchtune`,
+# `from kubeflow.trainer.types.registry import register_framework`
+
+@register_framework
+@dataclass
+class TorchTuneConfig(FrameworkConfig):
+    """TorchTune LLM Trainer configuration. (Fields unchanged from today.)"""
+
+    framework: ClassVar[str] = "torchtune"
+    command: ClassVar[tuple[str, ...]] = ("tune", "run")
+
+    dtype: Optional[DataType] = None
+    batch_size: Optional[int] = None
+    # ... remaining fields unchanged ...
+
+    def to_args(self) -> list[str]:
+        """Preserve the existing TorchTune override rendering exactly."""
+        return torchtune.get_args_using_torchtune_config(self)
+```
+
+#### TRLConfig
+
+```python
+# kubeflow/trainer/types/trl.py
+
+from dataclasses import dataclass, fields
+from enum import Enum
+from typing import ClassVar, Optional
+
+from kubeflow.trainer.types.registry import register_framework
+from kubeflow.trainer.types.types import FrameworkConfig
+
+
+class TRLMethod(Enum):
+    """Post-training method; the value is the TRL CLI subcommand."""
+
+    SFT = "sft"
+    DPO = "dpo"
+    GRPO = "grpo"
+
+
+@register_framework
+@dataclass
+class TRLConfig(FrameworkConfig):
+    """Configuration for Hugging Face TRL post-training.
+
+    The runtime entrypoint is the TRL CLI, which forwards to `accelerate launch`.
+
+    Raises:
+        ValueError: If a field is set that does not apply to the selected method.
+    """
+
+    framework: ClassVar[str] = "trl"
+    command: ClassVar[tuple[str, ...]] = ("trl",)
+
+    method: TRLMethod
+    model_name_or_path: str
+    dataset_name: str
+
+    learning_rate: Optional[float] = None
+    num_train_epochs: Optional[int] = None
+    per_device_train_batch_size: Optional[int] = None
+    bf16: Optional[bool] = None
+
+    use_peft: Optional[bool] = None
+    lora_r: Optional[int] = None
+    lora_alpha: Optional[int] = None
+    lora_target_modules: Optional[list[str]] = None
+
+    beta: Optional[float] = None                    # DPO, GRPO
+    num_generations: Optional[int] = None           # GRPO
+    reward_funcs: Optional[list[str]] = None        # GRPO
+
+    # Fields valid only for a subset of methods. Fields absent from this map
+    # are valid for every method.
+    _METHOD_SCOPED_FIELDS: ClassVar[dict[str, frozenset[TRLMethod]]] = {
+        "beta": frozenset({TRLMethod.DPO, TRLMethod.GRPO}),
+        "num_generations": frozenset({TRLMethod.GRPO}),
+        "reward_funcs": frozenset({TRLMethod.GRPO}),
+    }
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    def validate(self) -> None:
+        """Enforce method-scoped field usage.
+
+        Raises:
+            ValueError: If a field is set for a method it does not apply to, or
+                if a field the selected method requires is unset.
+        """
+        for name, methods in self._METHOD_SCOPED_FIELDS.items():
+            if getattr(self, name) is not None and self.method not in methods:
+                allowed = ", ".join(sorted(m.value for m in methods))
+                raise ValueError(
+                    f"'{name}' applies only to method={allowed}, but "
+                    f"method={self.method.value} was selected"
+                )
+        if self.method is TRLMethod.GRPO and not self.reward_funcs:
+            raise ValueError("method=grpo requires at least one entry in 'reward_funcs'")
+
+    def to_args(self) -> list[str]:
+        """Render as `[<subcommand>, --flag, value, ...]` for the TRL CLI."""
+        args: list[str] = [self.method.value]
+        for f in fields(self):
+            if f.name == "method":
+                continue
+            value = getattr(self, f.name)
+            if value is None:
+                continue
+            if value is True:
+                args.append(f"--{f.name}")           # store_true flag
+            elif isinstance(value, list):
+                args.append(f"--{f.name}")
+                args.extend(str(item) for item in value)
+            else:
+                args += [f"--{f.name}", str(value)]
+        return args
+```
+
+Users reach both through the trainer they already know:
+
+```python
+from kubeflow.trainer import BuiltinTrainer, TrainerClient, TRLConfig, TRLMethod
+
+TrainerClient().train(
+    trainer=BuiltinTrainer(
+        config=TRLConfig(
+            method=TRLMethod.DPO,
+            model_name_or_path="Qwen/Qwen2.5-0.5B",
+            dataset_name="trl-lib/ultrafeedback_binarized",
+            beta=0.1,
+        ),
+        num_nodes=2,
+        resources_per_node={"gpu": 1},
+    ),
+)
+```
+
+**Design decisions:**
+
+- **The framework is a config, not a trainer subclass.** A `BuiltinTrainer` holding a
+  `TRLConfig` and one holding a `TorchTuneConfig` differ in data, not in what the trainer
+  does with them: it hands the config's `command` and `to_args()` to the backend. Since the
+  trainer's behavior does not vary by framework, the framework does not need a class of its
+  own — a config class carries it. The user-facing consequence is that
+  `BuiltinTrainer(config=...)` stays the single config-driven entry point and existing code
+  is untouched. Alternative
+  [8](#8-one-trainer-class-per-framework-trltrainer-torchtunetrainer) is the rejected pole.
+- **Post-training method is a field, not a config subclass.** TRL's methods differ only in
+  which fields apply, so `method` is an enum guarded by `_METHOD_SCOPED_FIELDS`. Adding `kto`
+  is one enum member and one entry in `trl.py`; no new export, no backend change. Alternative
+  [7](#7-one-config-class-per-post-training-method-sftconfig-dpoconfig-grpoconfig) covers the
+  method-first split.
+- **`command` and `framework` are `ClassVar`s on the config, but `RuntimeTrainer` still carries
+  the resolved entrypoint.** The config *declares* them — they are properties of the framework's
+  CLI, and the config class is the only object that knows them — while
+  `RuntimeTrainer.command` remains the field every consumer reads. That field is not
+  config-driven-specific: `command[0] == "mpirun"` drives MPI detection (`utils.py:216`,
+  `:378`, `backend.py:242`), `get_runtime_packages` rewrites it to run single-process, and the
+  localprocess backend joins it into an entrypoint (`localprocess/utils.py:229`). Moving it
+  onto the config would mean special-casing all of those. Instead `get_runtime_trainer()`
+  resolves it through the registry, replacing the `framework == types.TORCH_TUNE` branch at
+  `utils.py:150-158` and deleting `constants.TORCH_TUNE_COMMAND`:
+
+  ```python
+  if config_cls := registry.get_framework(framework):
+      trainer.set_command(config_cls.command)
+  elif ml_policy.torch is not None:
+      trainer.set_command(constants.TORCH_COMMAND)
+  elif ml_policy.mpi:
+      trainer.set_command(constants.MPI_COMMAND)
+  else:
+      trainer.set_command(constants.DEFAULT_COMMAND)
+  ```
+
+  This is the same relationship the framework label already has: the runtime CR declares it,
+  `RuntimeTrainer.framework` carries it. Adding a framework adds no lines to `utils.py`, and
+  CR construction stays uniform across both trainer types.
+- **`trainer_type` is derived from the registry.** `get_runtime_trainer()` assigns
+  `BUILTIN_TRAINER` when `get_framework(framework)` finds a registered `FrameworkConfig`
+  and `CUSTOM_TRAINER` otherwise, replacing `utils.py:114-119` and deleting
+  the reflection-derived `types.TORCH_TUNE` constant. `trainer.kubeflow.org/framework` remains
+  the sole discovery key, honoring [Non-Goal #2](#non-goals).
+- **Rendering is polymorphic, so the backend has no framework branch.** `_build_trainer_cr`'s
+  config-driven path changes one line — `trainer_cr.args = trainer.config.to_args()` — deleting
+  the `isinstance(trainer.config, TorchTuneConfig)` guard at `utils.py:451-452` (coupling #4)
+  rather than relocating it. `trainer_cr.command = list(runtime.trainer.command)` is unchanged.
+  This is the one-time backend change that makes adding a *further* framework require none.
+- **TorchTune's initializer-derived dataset override stays in the backend.** The
+  `dataset.data_files=` / `dataset.data_dir=` args are computed from the Hugging Face dataset
+  initializer (`utils.py:502-517`), which is staging knowledge the backend owns. They are
+  appended to whatever `to_args()` renders. `TRLConfig` needs nothing from the initializer:
+  `model_name_or_path` and `dataset_name` are passed through for the `trl` CLI to resolve.
+- **`TorchTuneConfig.to_args()` delegates to the existing emitter.** `get_args_from_peft_config`
+  (`utils.py:530-559`) maps `LoraConfig` onto nested `model.*` keys; a flat `key=value` walk
+  would emit `lora_rank=8` instead of `model.lora_rank=8` and produce a failing job. The
+  emitters move verbatim to `kubeflow/trainer/types/torchtune.py` — they hold no Kubernetes
+  logic, and leaving them in the backend would make `types.py` import a backend module.
+- **Registration runs at import time and is last-writer-wins.** The decorator executes when
+  the module defining the config is imported. `TRLConfig` lives in a new module, so it must
+  be exported from `kubeflow/trainer/__init__.py`; otherwise a process that never imports it
+  finds no claimant for the `trl` label and treats the runtime as function-driven. An
+  out-of-tree config claiming an in-tree label shadows it, which lets a fork replace a
+  stalled in-tree config without an upstream commit.
+- **The base class is named `FrameworkConfig`, not the earlier draft's `LLMBackend`.** `backends/`
+  in this SDK means *execution* backend (`KubernetesBackend`, `ContainerBackend`), while
+  this object is the `config=` argument — and nothing in it is LLM-specific.
+- **`LoraConfig` is not reused for TRL.** It is TorchTune-shaped — `apply_lora_to_output` and
+  `quantize_base` have no TRL analogue, and TRL's PEFT surface is `--use_peft` / `--lora_r` /
+  `--lora_alpha` / `--lora_target_modules`. Sharing it would need a lossy translation layer.
+- **Unsloth is a runtime-image concern, not a sibling config.** An Unsloth-accelerated image is
+  still labelled `trainer.kubeflow.org/framework: trl`, so it resolves to the same config
+  entry and selected with `train(runtime=...)`. No SDK field is added.
+- **Nothing is deprecated.** `BuiltinTrainer(config=TorchTuneConfig(...))` keeps its exact
+  construction signature and produces byte-identical `TrainJob` arguments. There is no
+  successor class to migrate to and no `FutureWarning`.
+
+#### Control Plane
+
+This proposal requires no `TrainJob` CRD, `ClusterTrainingRuntime` CRD, controller, or
+plugin-registry change. A runtime is an image plus a `command` the SDK appends arguments to,
+so a framework is supportable when it is a CLI:
+
+```yaml
+# manifests/base/runtimes/torchtune/llama3_2/llama3_2_1B.yaml — today
+kind: ClusterTrainingRuntime
+metadata:
+  labels:
+    trainer.kubeflow.org/framework: torchtune   # the SDK's discovery key
+spec: {...containers: [{image: ghcr.io/kubeflow/trainer/torchtune-trainer,
+                        command: [tune, run, ...]}]}   # TRL: [trl]
+```
+
+Per framework, the cost is three artifacts in `kubeflow/trainer`, mirroring what TorchTune
+already has: a `cmd/trainers/trl/Dockerfile` alongside `cmd/trainers/torchtune/Dockerfile`, a
+runtime manifest under `manifests/base/runtimes/trl/`, and an extension of the existing torch
+plugin. The runtime declares `mlPolicy: torch`, and the torch plugin dispatches on the
+trainer command — `torch.go:81` matches `constants.TorchTuneEntrypoint` and calls into
+`torchtune.go` for validation and command mutation. TRL follows the same pattern: a `trl.go`
+beside `torchtune.go` and a `TRLEntrypoint` constant, extending the plugin rather than
+creating a new one. All three are outside this proposal's scope; the SDK's only contract with
+them is the framework label and the `command` it appends `to_args()` onto.
+
+#### Which Framework, and Why TRL
+
+| Framework | Post-training methods | Maintenance | Entrypoint |
+|---|---|---|---|
+| TRL | `sft`, `dpo`, `grpo`, `kto`, `reward`, `rloo` on the stable CLI; PPO moved to `trl.experimental` in 0.29 ([huggingface/trl#4466](https://github.com/huggingface/trl/issues/4466)) | Actively maintained by Hugging Face | `trl <method> --flag value`; forwards to `accelerate launch` |
+| TorchTune | SFT only, in the Kubeflow integration | Active development stopped 15 July 2025 ([#2883](https://github.com/meta-pytorch/torchtune/issues/2883)) | `tune run` |
+| LlamaFactory | Broad, but built on the Hugging Face `Trainer` and PEFT | Active | `llamafactory-cli train <config.yaml>` |
+| Axolotl | Broad, but its GRPO is TRL's `GRPOTrainer` | Active | `axolotl train <config.yaml>` |
+| Unsloth | None of its own; an acceleration layer | Active | No independent CLI |
+
+TRL is selected on three grounds. Its stable CLI covers the methods the SDK cannot express at
+all today — DPO and GRPO. It is the substrate rather than a wrapper: LlamaFactory and Axolotl
+are both built on the Hugging Face `Trainer` and PEFT, so an in-tree TRL trainer adds
+capability where an in-tree wrapper would add a second surface over the same engine. And its
+CLI takes flags, so it renders into `TrainJob` `command` and `args` with no adapter; a
+file-first CLI (`axolotl train <config.yaml>`) would need a ConfigMap or a volume.
+
+Choosing TRL first forecloses nothing: every alternative reaches the SDK out of tree as a
+`FrameworkConfig` subclass, which is why LlamaFactory is the reference out-of-tree plugin.
+GRPO-style post-training via TRL is already in flight in the Trainer
+([#3508](https://github.com/kubeflow/trainer/issues/3508),
+[#3718](https://github.com/kubeflow/trainer/pull/3718)); this proposal provides the SDK
+surface for that effort rather than a parallel track.
+
+**Risk:** TRL's surface is not frozen — PPO moved to `trl.experimental` in a minor release, and
+a typed dataclass mirroring TRL flags will drift. `TRLConfig` targets the CLI rather than the
+Python API, so a TRL upgrade changes the runtime image rather than the SDK type, and the
+drift is confined to the one config class that mirrors it.
+
+---
+## Design Details
+
+### Runtime Auto-Discovery
+
+The auto-discovery logic lives in the `TrainerClient` (not in the backend), ensuring
+consistent behavior across all backends:
+
+```python
+def _resolve_runtime(
+    self,
+    trainer: BaseTrainer,
+    runtime: Optional[Union[str, Runtime]],
+) -> Runtime:
+    """Resolve the runtime for a specialized trainer.
+
+    If runtime is provided, validate it. If not, auto-discover by framework label.
+    """
+    if runtime is not None:
+        # Explicit runtime — validate compatibility
+        if isinstance(runtime, str):
+            runtime = self.get_runtime(runtime)
+        trainer.validate_runtime(runtime)
+        return runtime
+
+    # Auto-discover: find runtimes matching the trainer's frameworks.
+    # Iterate supported_frameworks in declaration order (most preferred first)
+    # to provide deterministic selection when exactly one runtime matches
+    # the most-preferred framework.
+    all_runtimes = self.list_runtimes()
+    matching = []
+    for framework in trainer.supported_frameworks:
+        matching = [
+            r for r in all_runtimes
+            if r.trainer.framework == framework
+        ]
+        if matching:
+            break
+
+    if len(matching) == 0:
+        raise ValueError(
+            f"No runtime found for frameworks {trainer.supported_frameworks}. "
+            f"Available runtimes: {[r.name for r in all_runtimes]}"
+        )
+    if len(matching) > 1:
+        raise ValueError(
+            f"Multiple runtimes found for framework "
+            f"'{matching[0].trainer.framework}': "
+            f"{[r.name for r in matching]}. "
+            f"Please specify the runtime explicitly."
+        )
+
+    return matching[0]
+```
+
+**Multi-runtime selection strategy:**
+
+Auto-discovery iterates `supported_frameworks` in declaration order (most preferred
+first). For each framework, it collects matching runtimes. If exactly one runtime
+matches the most-preferred framework, it is selected automatically. If multiple
+runtimes match the same framework, the SDK raises a `ValueError` listing the
+available options. If no runtimes match the most-preferred framework, discovery
+falls through to the next framework in the tuple.
+
+For example, `DeepSpeedTrainer` declares `supported_frameworks = ("deepspeed", "torch")`.
+On a cluster with only a `torch-distributed` runtime, auto-discovery falls through
+`"deepspeed"` (no match) and selects the `torch-distributed` runtime. On a cluster
+with both a `deepspeed-mpi` and a `torch-distributed` runtime, auto-discovery finds
+`deepspeed-mpi` first (matching `"deepspeed"`) and selects it without ambiguity.
+
+When multiple runtimes match the same framework, the user resolves the ambiguity by
+passing the `runtime` parameter to `train()`:
+
+```python
+# Two torch runtimes exist: "torch-distributed" and "torch-elastic"
+# Auto-discovery raises ValueError listing both options.
+
+# User resolves by specifying explicitly:
+client.train(
+    runtime="torch-elastic",
+    trainer=TorchTrainer(func=my_fn, num_nodes=4),
+)
+```
+
+This is a deliberate design choice. The `runtime` parameter on `train()` is the
+single, existing mechanism for runtime selection. Adding a `runtime_name` to
+`RuntimeConfig` or to trainer classes would conflate concerns — `RuntimeConfig` is for
+packages and environment, trainers are for training logic, and runtime selection belongs
+to the `train()` call site. See also
+[Alternative #4](#4-automatic-runtime-selection-with-scoringranking-instead-of-strict-single-match)
+for why priority-based scoring was rejected.
+
+### Runtime Validation
+
+Validation happens at three levels:
+
+1. **Framework label check** (in `BaseTrainer.validate_runtime()`): Ensures the
+   runtime's `trainer.kubeflow.org/framework` label value is in the trainer's
+   `supported_frameworks` list.
+
+2. **Trainer type check** (in `FuncTrainer.validate_runtime()` and
+   `ConfigTrainer.validate_runtime()`): Ensures the runtime's `trainer_type` matches
+   the trainer category. `FuncTrainer` requires `TrainerType.CUSTOM_TRAINER`;
+   `ConfigTrainer` requires `TrainerType.BUILTIN_TRAINER`. This catches mismatches
+   such as passing a function-driven trainer to a config-only runtime.
+
+3. **Framework-specific checks** (in concrete trainer overrides): For example,
+   `DeepSpeedTrainer` could verify that the runtime's launcher configuration
+   (torchrun vs. mpirun) is compatible with the selected runtime.
+
+**Validation strategy — SDK vs. control plane:**
+
+SDK validation raises `ValueError` at submission time, *before* the `TrainJob` CR is
+created in the cluster. This is intentionally a hard fail, not a warning, because:
+
+1. **Fast feedback.** A `ValueError` with a clear message is immediate. A warning
+   that the user ignores leads to a `TrainJob` that fails minutes later in the
+   controller or at execution time, wasting cluster resources.
+2. **Deterministic checks.** The SDK validates against concrete, known properties
+   (framework label, `trainer_type`) — not heuristics. These checks are
+   authoritative at the SDK level.
+3. **Control plane remains the final arbiter.** The controller's webhook may enforce
+   additional constraints (resource quotas, policy, version compatibility) that the
+   SDK does not know about. SDK validation is a *subset* of control-plane validation,
+   not a replacement.
+4. **Overridable.** Subclasses can override `validate_runtime()` to relax or extend
+   validation for custom use cases.
+
+In summary: the SDK fails fast on checks it *can* perform (framework, trainer_type),
+and defers to the controller for checks it *cannot* perform (quotas, policies).
+
+### Trainer Responsibility Boundary
+
+Trainers are **data objects**, not builders. They expose structured data about the
+training job; they do not construct the `TrainJob` CRD, build container entrypoints,
+or interact with the Kubernetes API. The responsibility boundary is:
+
+| Concern | Owner | Rationale |
+|---|---|---|
+| Training function / config | **Trainer** (`get_train_func()`, `config`) | Trainer knows what to run |
+| Framework-specific CLI args | **Trainer** (`get_framework_args()` / `config.to_args()`) | Trainer knows its framework's options |
+| Scaling & resources | **Trainer** (`num_nodes`, `resources_per_node`) | User sets these on the trainer |
+| Serializing function into `command` | **Backend** (`get_command_using_train_func()`) | Backend knows the serialization format |
+| Building `TrainJob` CRD / container spec | **Backend** | Backend knows the target platform (K8s, container, local) |
+| Injecting distributed args (`rdzv_endpoint`, `nnodes`, etc.) | **Controller** | Controller owns the distributed topology |
+| Enforcing policies, quotas, webhooks | **Controller** | Control plane is the final authority |
+
+This separation ensures that:
+- Adding a new trainer does **not** require changes to the backend — only a new
+  `FuncTrainer` or `ConfigTrainer` subclass.
+- Adding a new backend does **not** require changes to trainers — backends consume
+  the same `BaseTrainer` interface.
+- The controller continues to own distributed coordination args, avoiding conflicts
+  between SDK-provided and controller-injected arguments.
+
+### Framework Argument Separation
+
+The current `CustomTrainer.func_args` dict mixes user hyperparameters with framework
+arguments. The three-level hierarchy solves this structurally:
+
+| Layer | Method | Contains | Maps to in `TrainJob` CRD |
+|---|---|---|---|
+| `FuncTrainer` | `get_train_func_args()` | User hyperparameters | Embedded in serialized `trainer.command` |
+| `FuncTrainer` | `get_framework_args()` | Framework CLI args not injected by the controller | `trainer.args` |
+| `ConfigTrainer` | `config.to_args()` | Full training configuration | `trainer.args` (parsed by runtime entrypoint) |
+
+Arguments that the Kubeflow Trainer controller already injects (e.g., `rdzv_endpoint`,
+`nnodes`, `nproc_per_node`, `node_rank`) are **excluded** from `get_framework_args()`.
+The specialized trainer documentation explicitly lists which arguments it manages vs.
+which the controller manages.
+
+### Backend Integration
+
+Each backend (`KubernetesBackend`, `ContainerBackend`, `LocalProcessBackend`) must be
+updated to handle `BaseTrainer` instances. The backend reads from the trainer's
+interface methods and maps them to platform-specific constructs:
+
+```python
+# In KubernetesBackend — building the TrainJob CR:
+
+def _build_trainer_cr(self, runtime, trainer):
+    trainer_cr = TrainerV1alpha1Trainer()
+    trainer_cr.num_nodes = trainer.num_nodes
+    trainer_cr.resources_per_node = trainer.resources_per_node
+    trainer_cr.image = trainer.image
+
+    if isinstance(trainer, FuncTrainer):
+        # Serialize function into command (same as CustomTrainer today)
+        trainer_cr.command = get_command_using_train_func(
+            runtime,
+            trainer.get_train_func(),
+            trainer.get_train_func_args(),
+            runtime_config.pip_index_urls if runtime_config else None,
+            runtime_config.packages_to_install if runtime_config else None,
+        )
+        # Framework args go into trainer.args
+        framework_args = trainer.get_framework_args()
+        if framework_args:
+            trainer_cr.args = [
+                f"--{k}={v}" for k, v in framework_args.items()
+            ]
+
+    elif isinstance(trainer, ConfigTrainer):
+        # Entrypoint comes from the runtime, exactly as it does today.
+        # Only args change: to_args() is polymorphic, so no framework branch.
+        trainer_cr.command = list(runtime.trainer.command)
+        trainer_cr.args = trainer.config.to_args()
+
+    return trainer_cr
+```
+
+The `runtime_config` parameter is applied uniformly: packages are installed in the
+init container, environment variables are set on all training pods.
+
+### Type Hierarchy Diagram
+
+```
+                        BaseTrainer (ABC)
+                        ├── supported_frameworks
+                        ├── num_nodes, resources_per_node, image
+                        └── validate_runtime()
+                              │
+              ┌───────────────┴───────────────┐
+              │                               │
+        FuncTrainer (ABC)               ConfigTrainer
+        ├── func: Callable              ├── config: FrameworkConfig
+        ├── func_args: dict             └── supported_frameworks (property
+        ├── get_framework_args() [abstr]      -> config.framework)
+        ├── get_train_func()
+        └── get_train_func_args()       users construct it directly:
+              │                         ConfigTrainer(config=TRLConfig(...))
+    ┌─────────┼─────────┬──────────┐
+    │         │         │          │
+  Torch   DeepSpeed   JAX    XGBoost
+  Trainer  Trainer  Trainer  Trainer
+              │
+    (supports both "deepspeed"
+     and "torch" frameworks)
+
+
+    The framework axis lives here, not in the trainer hierarchy:
+
+                     FrameworkConfig (ABC)
+                     ├── framework (ClassVar)
+                     ├── command (ClassVar)
+                     └── to_args()  [abstract]
+                              │
+                     ┌────────┴────────┬─────────────────┐
+                     │                 │                 │
+              TorchTuneConfig      TRLConfig      (out-of-tree
+              (existing type,      (method:        subclasses)
+               unchanged fields)    TRLMethod)
+
+
+    Existing (unchanged):
+
+    BuiltinTrainer                    CustomTrainer                     CustomTrainerContainer
+    (signature unchanged;             (flat dataclass, no base class)   (image-based, no base class)
+     config widens to
+     FrameworkConfig)
+
+
+    New:
+
+    RuntimeConfig
+    (per-job env: packages, pip URLs, env vars)
+```
+
+---
+
+## User-Facing API Examples
+
+### Before (Current)
+
+```python
+from kubeflow.trainer import TrainerClient, CustomTrainer
+
+# User must know the runtime name
+client = TrainerClient()
+
+# Must manually look up runtime
+runtime = client.get_runtime("torch-distributed")
+
+# Runtime config mixed into trainer
+job_id = client.train(
+    runtime=runtime,
+    trainer=CustomTrainer(
+        func=train_pytorch,
+        func_args={"lr": 1e-4, "epochs": 10},
+        packages_to_install=["transformers", "datasets"],
+        pip_index_urls=["https://pypi.org/simple"],
+        env={"NCCL_DEBUG": "INFO"},
+        num_nodes=4,
+        resources_per_node={"gpu": 1, "cpu": 3, "memory": "16Gi"},
+    ),
+)
+```
+
+### After (Proposed)
+
+```python
+from kubeflow.trainer import TrainerClient, TorchTrainer, RuntimeConfig
+
+client = TrainerClient()
+
+# Runtime is auto-discovered from trainer.kubeflow.org/framework: torch
+# Runtime environment is cleanly separated
+job_id = client.train(
+    trainer=TorchTrainer(
+        func=train_pytorch,
+        func_args={"lr": 1e-4, "epochs": 10},
+        num_nodes=4,
+        resources_per_node={"gpu": 1, "cpu": 3, "memory": "16Gi"},
+        max_restarts=3,  # Typed, torch-specific argument
+    ),
+    runtime_config=RuntimeConfig(
+        packages_to_install=["transformers", "datasets"],
+        env={"NCCL_DEBUG": "INFO"},
+    ),
+)
+```
+
+**Explicit runtime selection (when multiple runtimes exist for a framework):**
+
+```python
+job_id = client.train(
+    runtime="torch-elastic",  # Explicit selection
+    trainer=TorchTrainer(
+        func=train_pytorch,
+        func_args={"lr": 1e-4},
+        num_nodes=4,
+        resources_per_node={"gpu": 2},
+    ),
+)
+```
+
+**DeepSpeed example:**
+
+```python
+from kubeflow.trainer import DeepSpeedTrainer, RuntimeConfig
+
+job_id = client.train(
+    trainer=DeepSpeedTrainer(
+        func=train_deepspeed,
+        num_nodes=8,
+        resources_per_node={"gpu": 4, "memory": "32Gi"},
+        num_proc_per_node=4,
+        deepspeed_config={
+            "train_batch_size": 32,
+            "fp16": {"enabled": True},
+            "zero_optimization": {"stage": 2},
+        },
+    ),
+    runtime_config=RuntimeConfig(
+        packages_to_install=["deepspeed"],
+    ),
+)
+```
+
+---
+
+## Migration and Backward Compatibility
+
+| Aspect | Impact |
+|---|---|
+| `CustomTrainer` | **No change.** Remains fully functional. `packages_to_install`, `pip_index_urls`, and `env` fields are retained. |
+| `CustomTrainerContainer` | **No change.** |
+| `BuiltinTrainer` | **No change to its construction signature.** `BuiltinTrainer(config=TorchTuneConfig(...))` keeps working and produces byte-identical `TrainJob` arguments. It becomes the concrete `ConfigTrainer` and its `config` field widens to `FrameworkConfig`, so a second framework is a new config, not a new trainer. Nothing is deprecated. |
+| `TrainerClient.train()` | **Additive only.** New `runtime_config` parameter is optional with default `None`. The `trainer` parameter type union is extended to include `BaseTrainer`. |
+| `TrainJobTemplate` | **No change in this proposal.** Future work can extend it to support `BaseTrainer` subclasses. |
+| `RuntimeConfig` vs `CustomTrainer` fields | When both `RuntimeConfig` and `CustomTrainer` fields are provided, `RuntimeConfig` takes precedence. This is documented but does not break existing code since `RuntimeConfig` defaults to `None`. |
+| Python version | No new Python version requirements. `@dataclass(kw_only=True)` needs Python 3.10, which is already the SDK's floor (`requires-python = ">=3.10"` in `pyproject.toml`). |
+| SDK public exports | New names are exported from `kubeflow.trainer` (`BaseTrainer`, `FuncTrainer`, `ConfigTrainer`, `TorchTrainer`, `DeepSpeedTrainer`, `JAXTrainer`, `XGBoostTrainer`, `RuntimeConfig`, `FrameworkConfig`, `TRLConfig`, `TRLMethod`). No existing exports are removed or renamed. |
+
+---
+
+## Test Plan
+
+### Unit Tests
+
+1. **Type hierarchy compliance**: Verify that each `FuncTrainer` subclass correctly
+   inherits `func`/`func_args` fields and that each `FrameworkConfig` subclass declares
+   `framework` and `command` and implements `to_args()`.
+2. **`validate_runtime()` — positive**: Each trainer validates a runtime with a
+   matching framework label and compatible `trainer_type`.
+3. **`validate_runtime()` — negative framework**: Each trainer raises `ValueError`
+   for a runtime with a non-matching framework label.
+4. **`validate_runtime()` — negative trainer_type**: `FuncTrainer` subclass raises
+   `ValueError` for a `BUILTIN_TRAINER` runtime; `ConfigTrainer` subclass raises
+   `ValueError` for a `CUSTOM_TRAINER` runtime.
+5. **`get_framework_args()`**: Verify that each trainer returns only non-overlapping
+   arguments (excludes controller-injected args).
+6. **`RuntimeConfig` defaults**: Verify `None` defaults and precedence over
+   `CustomTrainer` fields.
+7. **Runtime auto-discovery — single match**: Mock `list_runtimes()` to return one
+   matching runtime; verify it is selected.
+8. **Runtime auto-discovery — no match**: Mock `list_runtimes()` to return no
+   matching runtimes; verify `ValueError`.
+9. **Runtime auto-discovery — multiple matches**: Mock `list_runtimes()` to return
+   multiple matching runtimes; verify `ValueError` with runtime names in the
+   message.
+
+### Integration Tests
+
+1. **End-to-end with `KubernetesBackend`**: Submit a `TorchTrainer` job against a
+   cluster with the `torch-distributed` runtime installed; verify the `TrainJob` CR
+   is created with the correct runtime reference.
+2. **End-to-end with `ContainerBackend`**: Submit a `TorchTrainer` job locally;
+   verify the container is launched with the correct entrypoint and arguments.
+3. **`RuntimeConfig` application**: Verify that packages from `RuntimeConfig` are
+   installed in the training container and env vars are set.
+
+### Backward Compatibility Tests
+
+1. All existing `CustomTrainer` tests pass without modification.
+2. All existing `BuiltinTrainer` tests pass without modification.
+3. Existing `TrainJobTemplate` usage continues to work.
+
+---
+
+## Implementation Plan
+
+This proposal can be implemented incrementally across multiple PRs:
+
+**Phase 1: Core Type Hierarchy and RuntimeConfig**
+- Add `BaseTrainer`, `FuncTrainer`, `ConfigTrainer` to `kubeflow/trainer/types/types.py`
+- Add `RuntimeConfig` dataclass
+- Add `_resolve_runtime()` to `TrainerClient`
+- Extend `TrainerClient.train()` signature
+- Unit tests for the type hierarchy and RuntimeConfig
+
+**Phase 2: TorchTrainer**
+- Implement `TorchTrainer` (extends `FuncTrainer`)
+- Update `KubernetesBackend`, `ContainerBackend`, `LocalProcessBackend` to handle
+  `FuncTrainer` and `ConfigTrainer` dispatch
+- Integration tests
+- Documentation and examples
+
+**Phase 3: DeepSpeedTrainer, JAXTrainer, XGBoostTrainer**
+- Implement remaining `FuncTrainer` subclasses
+- DeepSpeedTrainer with multi-runtime support (torch and deepspeed/MPI runtimes)
+- Framework-specific validation and argument handling
+- Tests and documentation
+
+**Phase 4: Public API exports and documentation**
+- Export new classes from `kubeflow.trainer.__init__`
+- Update SDK documentation on sdk.kubeflow.org
+- Add migration guide examples
+
+> **Note:** Phase 1 and Phase 2 should ship together in the same SDK release.
+> Releasing the type hierarchy without backend support would make `TorchTrainer`
+> importable but unusable, producing a confusing `ValueError` at `train()` time.
+
+---
+
+## Graduation Criteria
+
+### Alpha (target: current cycle)
+
+- `BaseTrainer`, `FuncTrainer`, `ConfigTrainer`, and `RuntimeConfig` types are
+  implemented and exported.
+- `TorchTrainer` is implemented with full backend support (Kubernetes, Container,
+  LocalProcess).
+- Runtime auto-discovery and `validate_runtime()` are functional.
+- Unit tests cover the type hierarchy, validation (positive and negative), and
+  auto-discovery (single-match, no-match, multi-match).
+- At least one integration test exercises `TorchTrainer` end-to-end against the
+  Kubernetes backend.
+- All existing `CustomTrainer` and `BuiltinTrainer` tests continue to pass.
+- `RuntimeConfig` merge semantics are implemented and tested.
+
+### Beta
+
+- `DeepSpeedTrainer`, `JAXTrainer`, and `XGBoostTrainer` are implemented.
+- `TRLConfig` is implemented alongside `TorchTuneConfig`, proving the config-driven
+  extension model on a second framework with no new trainer class.
+- An out-of-tree config is published as a `FrameworkConfig` subclass in a separate
+  package, proving the extension path.
+- SDK documentation on sdk.kubeflow.org covers all new trainer types with examples.
+- Migration guide is published.
+
+### GA
+
+- All Tier 1 trainers are stable with no breaking changes for at least one release.
+- `BuiltinTrainer` is formally deprecated (removal deferred to a future major version).
+- `CustomTrainer` runtime-environment fields (`packages_to_install`, `pip_index_urls`,
+  `env`) are formally deprecated in favor of `RuntimeConfig`.
+- Community has contributed at least one Tier 2 `ConfigTrainer` subclass.
+
+---
+
+## Open Questions
+
+The following design questions should be resolved before or during implementation:
+
+1. **DeepSpeed launcher detection.** `DeepSpeedTrainer` supports both `torchrun` and
+   `mpirun` launchers. How should `validate_runtime()` detect which launcher a runtime
+   uses? The `Runtime` type currently does not expose launcher metadata. Options:
+   (a) inspect `runtime.trainer.command`, (b) add a launcher label to runtimes,
+   (c) defer validation to the controller.
+
+2. **Does dynamic registration extend to the control plane?** The registry here is
+   SDK-side; the cluster must already hold a labelled runtime (image + manifest).
+   Whether "dynamic registration" should also cover provisioning that runtime needs
+   clarification with the control plane owners, and is deferred until then.
+
+3. **Observability.** When runtime auto-discovery selects a runtime, should the SDK
+   log the selected runtime name and framework at `INFO` level? This would aid
+   debugging but adds a logging dependency.
+
+4. **`resources_per_node` typing.** The current `Optional[dict]` is untyped. Should
+   this be a structured type (e.g., `ResourceRequirements` dataclass with `cpu`,
+   `memory`, `gpu` fields) to enable IDE autocomplete and validation?
+
+5. **Backend validation safety net.** Currently, `validate_runtime()` is only called
+   via `TrainerClient._resolve_runtime()`. Should backends also call
+   `validate_runtime()` as a defensive check, in case trainers are passed to backends
+   directly?
+
+---
+
+## Alternatives Considered
+
+### 1. Extend CustomTrainer with a `framework` field instead of new classes
+
+Add a `framework: Optional[str]` field to `CustomTrainer` and use it for runtime
+discovery and validation.
+
+**Rejected because:**
+- Does not provide a place for framework-specific typed arguments (`max_restarts`,
+  `num_proc_per_node`).
+- Does not enable the Tier 2 extension model.
+- Violates the open-closed principle: the `CustomTrainer` class would need to grow
+  with each new framework.
+
+### 2. Use Pydantic `BaseModel` instead of `@dataclass`
+
+Use Pydantic for automatic validation, serialization, and schema generation.
+
+**Rejected because:**
+- The existing SDK codebase uses `@dataclass` exclusively. Introducing Pydantic
+  would add a dependency and create an inconsistency in the codebase.
+- Pydantic validation can be replicated with `__post_init__` where needed.
+
+### 3. Put RuntimeConfig inside BaseTrainer instead of as a separate parameter
+
+Make `RuntimeConfig` a field on `BaseTrainer` so that each trainer carries its own
+runtime config.
+
+**Rejected because:**
+- Runtime configuration (packages, env vars) is orthogonal to trainer type. The
+  same `RuntimeConfig` should be usable with `CustomTrainer`,
+  `CustomTrainerContainer`, or any `BaseTrainer` subclass.
+- Keeping it as a separate `train()` parameter maintains clean separation of concerns.
+- Users may want custom env for initializers too. A separate `train()` parameter
+  can be extended to apply to both trainers and initializers without changing trainer
+  classes.
+
+### 4. Automatic runtime selection with scoring/ranking instead of strict single-match
+
+When multiple runtimes match a framework, automatically pick the "best" one using a
+scoring heuristic (e.g., prefer non-deprecated, prefer more specific labels).
+
+**Rejected because:**
+- Implicit selection heuristics are fragile and hard to debug. When multiple runtimes
+  exist for the same framework, it is a deliberate platform configuration and the
+  user should explicitly choose.
+- A clear error message listing available runtimes is more useful than a possibly
+  wrong automatic selection.
+
+### 5. Flat hierarchy: all trainers inherit directly from BaseTrainer
+
+Have all concrete trainers (both function-driven and config-driven) inherit directly
+from `BaseTrainer` without the `FuncTrainer` / `ConfigTrainer` intermediate layer.
+
+**Rejected because:**
+- Config-driven trainers would carry `get_train_func()` returning `None` — semantically
+  incorrect and error-prone.
+- Function-driven trainers would each redeclare `func` and `func_args` fields —
+  unnecessary repetition.
+- Backend dispatch would rely on runtime checks (`if trainer.get_train_func() is None`)
+  instead of type checks (`isinstance(trainer, ConfigTrainer)`).
+- The intermediate classes encode the fundamental difference between the two trainer
+  modes at the type level, making the API self-documenting.
+
+### 6. Have specialized trainers inherit from CustomTrainer
+
+Make `TorchTrainer` a subclass of `CustomTrainer` instead of a new `BaseTrainer`
+hierarchy.
+
+**Rejected because:**
+- `CustomTrainer` carries runtime-environment fields (`packages_to_install`,
+  `pip_index_urls`, `env`) that specialized trainers should not expose (those belong
+  in `RuntimeConfig`).
+- Inheriting from `CustomTrainer` would force specialized trainers to carry fields
+  that violate the separation of concerns this proposal aims to achieve.
+
+### 7. One config class per post-training method (`SFTConfig`, `DPOConfig`, `GRPOConfig`)
+
+Split by method rather than by framework, mirroring TRL's own Python class names.
+
+**Rejected because:**
+- The method axis changes only data — which fields apply — while `to_args()`, `command`, and
+  the framework label are per-framework. Once a second framework supports the same method,
+  `SFTConfig` needs a framework discriminator anyway.
+- Methods are the volatile axis: TRL moved PPO to `trl.experimental` in a minor release. An
+  enum member can be added or deprecated freely; an exported class name cannot.
+- The taxonomy is still captured — as `TRLMethod` and `_METHOD_SCOPED_FIELDS` — where
+  regrouping is a data change rather than a public-API change.
+
+### 8. One trainer class per framework (`TRLTrainer`, `TorchTuneTrainer`)
+
+Give each framework its own `ConfigTrainer` subclass carrying that framework's fields
+directly, so users write `TRLTrainer(method=..., model_name_or_path=...)`.
+
+**Rejected because:**
+- The trainer does nothing different per framework: it hands the config's `command` and
+  `to_args()` to the backend. A subclass per framework encodes in the type hierarchy a
+  distinction that exists only in data.
+- It makes every framework a new exported class name — frozen public API — where the accepted
+  design makes it a config class reachable through the unchanged `BuiltinTrainer(config=...)`.
+- It forces `BuiltinTrainer` onto a deprecation path toward a `TorchTuneTrainer` successor,
+  for no behavior change. The accepted design deprecates nothing.
+
+**What it gets right:** typed per-framework fields and a flatter call
+(`TRLTrainer(...)` versus `BuiltinTrainer(config=TRLConfig(...))`). The accepted design keeps
+the typed fields — they live on the config — at the cost of one level of nesting at the call
+site.
+
+---
+
+## References
+
+- [KEP-2170: Kubeflow Trainer V2 API](../2170-kubeflow-trainer-v2/README.md)
+- [KEP-2401: Kubeflow LLM Trainer V2](../2401-llm-trainer-v2/README.md)
+- Tracking issue: [kubeflow/trainer#2839](https://github.com/kubeflow/trainer/issues/2839)
+- Earlier draft of this KEP, superseded by section F:
+  [proposal PR #3263](https://github.com/kubeflow/trainer/pull/3263),
+  [sdk#310 registry PoC](https://github.com/kubeflow/sdk/pull/310)
+- [Kubeflow SDK Repository](https://github.com/kubeflow/sdk)
+- [Kubeflow Trainer Repository](https://github.com/kubeflow/trainer)
+- [Kubeflow Community Proposal Workflow](https://github.com/kubeflow/community/blob/master/proposal-workflow.md)
+- [Runtime Guide — trainer.kubeflow.org/framework label](https://www.kubeflow.org/docs/components/trainer/operator-guides/runtime/)
+- [Kubeflow Trainer Getting Started](https://www.kubeflow.org/docs/components/trainer/getting-started/)
+- [SDK Types Source Code](https://github.com/kubeflow/sdk/blob/main/kubeflow/trainer/types/types.py)
+- [SDK TrainerClient Source Code](https://github.com/kubeflow/sdk/blob/main/kubeflow/trainer/api/trainer_client.py)

--- a/proposals/2839-dynamic-llm-trainer/README.md
+++ b/proposals/2839-dynamic-llm-trainer/README.md
@@ -23,7 +23,7 @@
     - [I.2 `PET_*` is torchrun's private interface](#i2-pet_-is-torchruns-private-interface)
     - [I.3 Proof of concept](#i3-proof-of-concept)
     - [I.4 Limitation: the TRL CLI and `accelerate launch`](#i4-limitation-the-trl-cli-and-accelerate-launch)
-    - [I.5 Why the plugin does not change](#i5-why-the-plugin-does-not-change)
+    - [I.5 What changes in the plugin](#i5-what-changes-in-the-plugin)
     - [I.6 New artifacts](#i6-new-artifacts)
   - [Part II: Client Side (`kubeflow/sdk`)](#part-ii-client-side-kubeflowsdk)
     - [II.1 Current limitations](#ii1-current-limitations)
@@ -106,7 +106,7 @@ A proof of concept for the server side was built and run on a cluster; its resul
 
 1. **Any control-plane change.** No CRD or schema change, no version bump, and no Go: the
    server-side work is a new image and new manifests. `EnforceMLPolicy` and `Validate` are
-   both unchanged — see [I.5](#i5-why-the-plugin-does-not-change).
+   both unchanged — see [I.5](#i5-what-changes-in-the-plugin).
 2. **A new framework plugin.** TRL reuses the torch plugin via `mlPolicy.torch`; no entry
    is added to `pkg/runtime/framework/plugins/registry.go`.
 3. **New runtime labels or conventions.** `trainer.kubeflow.org/framework` is unchanged.
@@ -275,21 +275,24 @@ accelerate is still in the image because TRL depends on it (`accelerate>=1.4.0`,
 torchrun exported.** The distinction matters for review: what is excluded here is a second
 launcher, not a library.
 
-### I.5 Why the plugin does not change
+### I.5 What changes in the plugin
 
-`EnforceMLPolicy` today supports the torchrun launcher through the `PET_*` variables, and
-that is exactly what TRL needs. Every run in [I.3](#i3-proof-of-concept) used an unmodified
-`torch.go`:
+Nothing. `EnforceMLPolicy` today supports the torchrun launcher through the `PET_*`
+variables, and that is what TRL needs — every run in [I.3](#i3-proof-of-concept) used an
+unmodified `torch.go`. `Validate` is unchanged too.
 
-- TRL under torchrun wants exactly the plugin's default behaviour — all five `PET_*`
-  injected, command untouched. The TorchTune branch exists only because `tune run` takes
-  rendezvous as a *command-line argument*; nothing analogous is needed here.
-- Which module torchrun runs (`trl.scripts.sft` vs `.dpo` vs `.grpo`) is declared in the
-  runtime manifest and shipped in the image. A TRL upgrade is an image rebuild, not a
-  controller release.
+The difference from TorchTune is where the training arguments are built:
 
-`Validate` is also unchanged: with torchrun as the launcher there is no CPU-multi-node
-failure mode left to reject at admission.
+| | TorchTune | TRL |
+|---|---|---|
+| Launcher | `tune run` | `torchrun` |
+| Rendezvous | a command-line argument, so the plugin rewrites the command (`torch.go:175-201`) | environment, so the command is left alone |
+| Who builds the arguments | the plugin, in Go: `torchtune.go` picks the recipe, adds `--config`, and appends the path overrides read from the runtime | the SDK, in Python: `TRLConfig.to_args()`, passed through unchanged as `args` |
+| Go needed | the existing branch | none |
+
+So supporting TRL adds no logic to the controller. Which module torchrun runs
+(`trl.scripts.sft` vs `.dpo` vs `.grpo`) is declared in the runtime manifest and shipped in
+the image, so a TRL upgrade is an image rebuild rather than a controller release.
 
 ### I.6 New artifacts
 
@@ -817,7 +820,7 @@ cases, asserted alongside each other so the paths stay visibly distinct: a
 `[torchrun, -m, trl.scripts.sft]` command is left alone and gets all five `PET_*`,
 including the master vars the TorchTune path suppresses; a `[tune, run]` command is still
 rewritten. The first is the regression guard for
-[I.5](#i5-why-the-plugin-does-not-change) — it fails the moment anyone adds a TRL branch to
+[I.5](#i5-what-changes-in-the-plugin) — it fails the moment anyone adds a TRL branch to
 the plugin.
 
 **Manifest tests** — each `manifests/base/runtimes/trl/*.yaml` carries `framework: trl`,

--- a/proposals/2839-dynamic-llm-trainer/README.md
+++ b/proposals/2839-dynamic-llm-trainer/README.md
@@ -458,11 +458,20 @@ class FrameworkConfig(abc.ABC):
 
     @abstractmethod
     def to_args(self) -> list[str]:
-        """Render this config as arguments for `command`."""
+        """Render this config's own fields as arguments for `command`."""
+
+    def to_initializer_args(self, initializer: Optional["Initializer"]) -> list[str]:
+        """Render the flags that point the framework at what the Initializer
+        staged under /workspace. Default: none."""
+        return []
 ```
 
-`to_args()` renders only the config's own fields and takes no initializer: configs stay plain
-dataclasses, so nothing in `types.py` needs to know how a backend stages data.
+Two methods because the two inputs differ. `to_args()` is the config's own fields.
+`to_initializer_args()` exists because the model and dataset flags still belong to the framework
+even though the `Initializer` owns the download: TRL needs `--model_name_or_path` and
+`--dataset_name`, TorchTune needs `dataset.data_files=`, and only the config knows its own
+spelling. The staged paths are SDK constants (`constants.MODEL_PATH`, `DATASET_PATH`), so the
+config never imports a backend.
 
 The framework label resolves through a registry rather than a constant. It serves exactly one
 lookup — `get_runtime_trainer()`'s — and is the out-of-tree extension path:
@@ -488,7 +497,8 @@ shape). There is no automatic discovery: a config must be imported before it can
 constructed, and importing it registers it.
 
 `TorchTuneConfig` keeps every field and its signature, gaining `framework = "torchtune"`,
-`command = ("tune", "run")`, and a `to_args()` delegating to the existing emitter.
+`command = ("tune", "run")`, a `to_args()` delegating to the existing emitter, and a
+`to_initializer_args()` carrying the `dataset.data_files=` / `data_dir=` overrides it emits today.
 
 #### `TRLConfig` and the per-method configs
 
@@ -578,6 +588,11 @@ class TRLConfig(FrameworkConfig):
             + self.method.to_args()
             + self._extra_args()
         )
+
+    def to_initializer_args(self, initializer) -> list[str]:
+        """--model_name_or_path=/workspace/model and
+        --dataset_name=/workspace/dataset/<subpath>, using the same subpath
+        helper as TorchTuneConfig. Absent initializer: raises ValueError."""
 ```
 
 ##### Why the shared fields sit on the outer config
@@ -609,10 +624,10 @@ SDK release. It is rendered last, so it can also override anything above it.
 
 From `train(initializer=...)`, and nowhere else — exactly as for TorchTune, whose config has no
 model or dataset fields either. The SDK writes the `Initializer` into `TrainJob.spec.initializer`
-as it does today, the runtime's initializer jobs download into `/workspace`, and the backend
-appends `--model_name_or_path=/workspace/model` and `--dataset_name=/workspace/dataset/<subpath>`
-after `to_args()`. The subpath derivation already exists for TorchTune's `dataset.data_files=`
-override and becomes a shared helper rather than a second copy.
+as it does today, the runtime's initializer jobs download into `/workspace`, and
+`TRLConfig.to_initializer_args()` renders `--model_name_or_path=/workspace/model` and
+`--dataset_name=/workspace/dataset/<subpath>`. The subpath derivation already exists for
+TorchTune's `dataset.data_files=` override and becomes a shared helper rather than a second copy.
 
 Three reasons for having no string fields on the config:
 
@@ -730,8 +745,8 @@ Three call sites change, and each one *loses* a branch:
   `TORCH_TUNE` constant. The framework label stays the sole discovery key.
 
 - **The backend has no framework branch.** One line —
-  `trainer_cr.args = trainer.config.to_args()` — deletes the `isinstance` check at
-  `utils.py:465` rather than relocating it. `command` still comes from the runtime, exactly
+  `trainer_cr.args = config.to_args() + config.to_initializer_args(initializer)` — deletes
+  the `isinstance` check at `utils.py:465` rather than relocating it. `command` still comes from the runtime, exactly
   as today.
 
 `RuntimeTrainer.command` stays the field consumers read. It is not config-specific:
@@ -744,10 +759,11 @@ the one-time change this KEP is buying.
 
 Two details preserved from the TorchTune path:
 
-- **Initializer-derived path arguments stay in the backend.** The `dataset.data_files=` /
-  `data_dir=` overrides for TorchTune and the `--model_name_or_path` / `--dataset_name` paths for
-  TRL are both staging knowledge the backend owns; they are appended to whatever `to_args()`
-  renders, through one shared subpath helper.
+- **Initializer-derived path arguments move onto the config.** TorchTune's `dataset.data_files=`
+  / `data_dir=` overrides, computed today inside the backend from the HF dataset initializer,
+  become `TorchTuneConfig.to_initializer_args()`; TRL's `--model_name_or_path` /
+  `--dataset_name` are `TRLConfig.to_initializer_args()`. Both use one shared subpath helper,
+  and the backend stops knowing either spelling.
 - **`TorchTuneConfig.to_args()` delegates to the existing emitter.** `get_args_from_peft_config`
   maps `LoraConfig` onto nested `model.*` keys; a flat `key=value` walk would emit `lora_rank=8`
   instead of `model.lora_rank=8` and fail the job. The emitters move verbatim to
@@ -798,7 +814,7 @@ config and is chosen with `train(runtime=...)` — no SDK field.
 |---|---|
 | `CustomTrainer`, `CustomTrainerContainer` | **No change.** All fields retained. |
 | `BuiltinTrainer` | **Construction signature unchanged**; produces byte-identical `TrainJob` arguments for TorchTune. `config` widens to `FrameworkConfig`. Nothing deprecated. |
-| `TorchTuneConfig` | **No change** to fields or signature; gains two `ClassVar`s and `to_args()`. |
+| `TorchTuneConfig` | **No change** to fields or signature; gains two `ClassVar`s, `to_args()` and `to_initializer_args()`. |
 | `TrainerClient.train()` | **No change** to the signature. |
 | `TrainJobTemplate` | **No change.** |
 | Python version | No new floor. `kw_only=True` needs 3.10, already the SDK's minimum. |
@@ -831,8 +847,10 @@ Client side:
 - `to_args()` for each of `TRLSFTConfig`, `TRLDPOConfig`, `TRLGRPOConfig`: the module name is
   the first element; bools render as store_true flags; lists expand after their flag.
 - Passing a method-specific parameter to the wrong method config raises `TypeError`.
-- A `TRLConfig` submitted without an `Initializer` raises `ValueError`; with one, the rendered
-  args carry the `/workspace` model and dataset paths.
+- `TRLConfig.to_initializer_args()` raises `ValueError` without an `Initializer`; with one it
+  yields the `/workspace` model and dataset paths.
+- `TorchTuneConfig.to_initializer_args()` matches the `dataset.data_files=` / `data_dir=` output
+  of the current backend code byte for byte.
 - `num_nodes` and `resources_per_node` never appear in `to_args()` output; `extra_args` renders
   last.
 - `register_framework` rejects a config declaring no framework or no command.
@@ -845,7 +863,7 @@ Client side:
 
 - With the `trl-distributed` runtime installed, `BuiltinTrainer(config=TRLConfig(...))` resolves
   it by label, yields `trainer_type == BUILTIN_TRAINER`, and emits `command: [torchrun, -m]`
-  with `args == config.to_args()` (module name first). This is the **cross-repo contract**: it
+  with `args == config.to_args() + config.to_initializer_args(initializer)` (module name first). This is the **cross-repo contract**: it
   fails if either side changes the label or the launch shape.
 - `BuiltinTrainer(config=TorchTuneConfig(...))` produces byte-identical `TrainJob` arguments to
   the current implementation.

--- a/proposals/2839-dynamic-llm-trainer/README.md
+++ b/proposals/2839-dynamic-llm-trainer/README.md
@@ -114,7 +114,7 @@ the first framework to join it.
 As a platform admin, I install the Trainer and get a `trl-distributed`
 `ClusterTrainingRuntime` alongside the TorchTune runtimes. I did not have to build an image or
 write a plugin, and I can verify the runtime is correct by submitting a raw-YAML `TrainJob`
-against it before anyone uses the SDK.
+with `spec.initializer` set against it before anyone uses the SDK.
 
 #### Story 2: Data scientist runs supervised fine-tuning
 
@@ -124,17 +124,21 @@ As a data scientist, I fine-tune a model with TRL from the SDK using the same
 ```python
 TrainerClient().train(
     runtime=TrainerClient().get_runtime("trl-distributed"),
+    initializer=Initializer(
+        model=HuggingFaceModelInitializer(storage_uri="hf://Qwen/Qwen2.5-0.5B"),
+        dataset=HuggingFaceDatasetInitializer(storage_uri="hf://trl-lib/Capybara"),
+    ),
     trainer=BuiltinTrainer(
         config=TRLConfig(
             method=TRLSFTConfig(packing=True),
-            model_name_or_path="Qwen/Qwen2.5-0.5B",
-            dataset_name="trl-lib/Capybara",
             learning_rate=2e-5,
             num_nodes=2,
         ),
     ),
 )
 ```
+
+The model and dataset are given exactly as for TorchTune, through the `Initializer`.
 
 #### Story 3: Data scientist runs GRPO
 
@@ -163,7 +167,7 @@ TrainerClient().train(
 )
 ```
 
-The model and dataset come from the `Initializer` here, so the config names neither.
+The config carries only TRL flags; where the model and dataset come from is unchanged.
 
 #### Story 4: Community adds a framework out of tree
 
@@ -368,7 +372,8 @@ installing pinned `trl` + dependencies. accelerate is among them — TRL require
 in-process; its launcher is never invoked.
 
 **2. `manifests/base/runtimes/trl/`** — a **single** `ClusterTrainingRuntime`, `trl-distributed`.
-Initializer replicatedJobs are identical to the TorchTune runtimes and omitted here:
+It keeps the same two initializer replicatedJobs as the TorchTune runtimes, but pins no
+`STORAGE_URI`; the TrainJob supplies both. They are omitted here:
 
 ```yaml
 kind: ClusterTrainingRuntime
@@ -543,10 +548,8 @@ class TRLConfig(FrameworkConfig):
 
     method: TRLMethodConfig                         # the typed slot
 
-    # Normally supplied by the Initializer; set these only without one.
-    model_name_or_path: Optional[str] = None
-    dataset_name: Optional[str] = None
-
+    # No model or dataset fields: both come from train(initializer=...),
+    # exactly as for TorchTuneConfig.
     learning_rate: Optional[float] = None
     num_train_epochs: Optional[int] = None
     per_device_train_batch_size: Optional[int] = None
@@ -591,8 +594,7 @@ The split is also lopsided, which is what makes it worth making once: **161 flag
 against 11 to 79 that are method-specific, GRPO being the 79. Under a per-method design those
 161 would be re-frozen in every exported constructor.
 
-`model_name_or_path` and `dataset_name` come from `ModelConfig` and `ScriptArguments`, which are
-also method-independent, so they belong outside too. Both are `Optional`: see
+The model and dataset are not fields at all; see
 [Where the model and dataset come from](#where-the-model-and-dataset-come-from).
 
 `num_nodes` and `resources_per_node` are not TRL flags at all — they are Kubeflow placement
@@ -605,16 +607,26 @@ SDK release. It is rendered last, so it can also override anything above it.
 
 ##### Where the model and dataset come from
 
-TorchTune takes both from the runtime plus the `Initializer` and has no model or dataset fields
-on its config at all. TRL's scripts need `--model_name_or_path` and `--dataset_name` as flags, so
-naming them on the config would create a second source with no stated precedence.
+From `train(initializer=...)`, and nowhere else — exactly as for TorchTune, whose config has no
+model or dataset fields either. The SDK writes the `Initializer` into `TrainJob.spec.initializer`
+as it does today, the runtime's initializer jobs download into `/workspace`, and the backend
+appends `--model_name_or_path=/workspace/model` and `--dataset_name=/workspace/dataset/<subpath>`
+after `to_args()`. The subpath derivation already exists for TorchTune's `dataset.data_files=`
+override and becomes a shared helper rather than a second copy.
 
-The rule: **the `Initializer` wins, and the config fields are the no-initializer path.** When an
-`Initializer` is present the backend appends `--model_name_or_path=/workspace/model` and
-`--dataset_name=/workspace/dataset` — the same "staging knowledge the backend owns" rule the KEP
-already applies to TorchTune's `dataset.data_files=` overrides, and the same
-`constants.MODEL_PATH` / `DATASET_PATH` the SDK already defines. Setting both an `Initializer`
-and the matching config field is a `ValueError` at submit rather than a silent precedence rule.
+Three reasons for having no string fields on the config:
+
+- **One habit for both frameworks.** A TorchTune user already knows how to give TRL a model.
+- **A string is ambiguous.** `Qwen/Qwen2.5-0.5B` is a hub id, `/mnt/data/model` is a folder,
+  `s3://bucket/model` needs credentials. The SDK would have to guess. `Initializer` already knows,
+  and already covers S3, the data cache, and secrets for gated models.
+- **No tie-break rule.** Two ways to name a model need a rule for when both are set. One way
+  does not.
+
+A `TRLConfig` submitted without an `Initializer` is a `ValueError` in the SDK, since the
+runtime's initializer jobs would otherwise start with no `STORAGE_URI` and fail late. A shortcut
+such as `Initializer.from_hf(model=..., dataset=...)` can come later and would help TorchTune
+users equally; it is not part of this KEP.
 
 #### Choosing the config shape
 
@@ -732,10 +744,10 @@ the one-time change this KEP is buying.
 
 Two details preserved from the TorchTune path:
 
-- **TorchTune's initializer-derived dataset overrides stay in the backend.** The
-  `dataset.data_files=` / `data_dir=` args are computed from the HF dataset initializer, which
-  is staging knowledge the backend owns; they are appended to whatever `to_args()` renders.
-  `TRLConfig` needs nothing from the initializer.
+- **Initializer-derived path arguments stay in the backend.** The `dataset.data_files=` /
+  `data_dir=` overrides for TorchTune and the `--model_name_or_path` / `--dataset_name` paths for
+  TRL are both staging knowledge the backend owns; they are appended to whatever `to_args()`
+  renders, through one shared subpath helper.
 - **`TorchTuneConfig.to_args()` delegates to the existing emitter.** `get_args_from_peft_config`
   maps `LoraConfig` onto nested `model.*` keys; a flat `key=value` walk would emit `lora_rank=8`
   instead of `model.lora_rank=8` and fail the job. The emitters move verbatim to
@@ -819,8 +831,8 @@ Client side:
 - `to_args()` for each of `TRLSFTConfig`, `TRLDPOConfig`, `TRLGRPOConfig`: the module name is
   the first element; bools render as store_true flags; lists expand after their flag.
 - Passing a method-specific parameter to the wrong method config raises `TypeError`.
-- Setting both an `Initializer` and `model_name_or_path` (or `dataset_name`) raises `ValueError`
-  at submit; with an `Initializer` alone the rendered args carry the `/workspace` paths.
+- A `TRLConfig` submitted without an `Initializer` raises `ValueError`; with one, the rendered
+  args carry the `/workspace` model and dataset paths.
 - `num_nodes` and `resources_per_node` never appear in `to_args()` output; `extra_args` renders
   last.
 - `register_framework` rejects a config declaring no framework or no command.
@@ -952,6 +964,8 @@ TRL reachable from Python.
   [`01b96f3`](https://github.com/YassinNouh21/trainer/tree/01b96f38608467d96acfc01c7500d49ebeca5d6f)); torchrun confirmed as the
   launcher and the `accelerate launch` route recorded as a limitation.
 - **2026-08-30**: config-shape options compared in a [design note](https://claude.ai/code/artifact/29468417-11ca-42d8-a8d2-b23c0939a14c); the typed slot chosen.
+- **2026-09-09**: model and dataset come from `Initializer` only, as for TorchTune; no string
+  fields on `TRLConfig`.
 - **2026-09-02**: reviewed on the Kubeflow Trainer community call. The client-side design here
   supersedes the parallel SDK proposal in
   [sdk#627](https://github.com/kubeflow/sdk/pull/627), which covered the same ground. Agreed: restructure to the

--- a/proposals/2839-dynamic-llm-trainer/README.md
+++ b/proposals/2839-dynamic-llm-trainer/README.md
@@ -3,7 +3,7 @@
 Authors:
 
 - Yassin Nouh - [@YassinNouh21](https://github.com/YassinNouh21)
-- Shady Zaher - [@szaher](https://github.com/szaher)
+- Saad Zaher - [@szaher](https://github.com/szaher)
 
 Creation date: 2026-02-11
 
@@ -130,8 +130,8 @@ TrainerClient().train(
             model_name_or_path="Qwen/Qwen2.5-0.5B",
             dataset_name="trl-lib/Capybara",
             learning_rate=2e-5,
+            num_nodes=2,
         ),
-        num_nodes=2,
     ),
 )
 ```
@@ -144,6 +144,10 @@ before the job is submitted, not a flag TRL silently ignores at runtime:
 
 ```python
 TrainerClient().train(
+    initializer=Initializer(
+        model=HuggingFaceModelInitializer(storage_uri="hf://Qwen/Qwen2.5-0.5B"),
+        dataset=HuggingFaceDatasetInitializer(storage_uri="hf://trl-lib/tldr"),
+    ),
     trainer=BuiltinTrainer(
         config=TRLConfig(
             method=TRLGRPOConfig(
@@ -151,15 +155,15 @@ TrainerClient().train(
                 num_generations=8,
                 reward_funcs=["think_format_reward"],
             ),
-            model_name_or_path="Qwen/Qwen2.5-0.5B",
-            dataset_name="trl-lib/tldr",
             learning_rate=1e-6,
+            num_nodes=2,
+            resources_per_node={"gpu": 1},
         ),
-        num_nodes=2,
-        resources_per_node={"gpu": 1},
     ),
 )
 ```
+
+The model and dataset come from the `Initializer` here, so the config names neither.
 
 #### Story 4: Community adds a framework out of tree
 
@@ -190,8 +194,9 @@ this — see [What torchrun gives up](#what-torchrun-gives-up).
 | Risk | Mitigation |
 |---|---|
 | **A silently degraded run looks like success.** The `trl-demo` failure exited 0 on both pods, so a two-node job that trained two isolated copies was indistinguishable from one that trained jointly. torchrun-first removes that particular cause, not the class. | The E2E test asserts the achieved world size from the logs, not just `Complete`. Closing the class needs a runtime→status channel, which is out of scope here — see [Open Questions](#open-questions). |
-| **TRL's surface is not frozen**, and typed configs mirroring its flags will drift. TRL moved PPO to `trl.experimental` in a minor release. | The configs target the *script flags*, not the Python API, so a TRL upgrade changes the image rather than the SDK types, and drift is confined to the per-method config classes. The launch-path proof re-runs on every `trl` version bump. |
+| **TRL's surface is not frozen**, and typed configs mirroring its flags will drift. TRL moved PPO to `trl.experimental` and then dropped it from the package altogether. | The configs target the *script flags*, not the Python API, so a TRL upgrade changes the image rather than the SDK types, and drift is confined to the per-method config classes. The launch-path proof re-runs on every `trl` version bump. |
 | **TRL ignores unknown flags.** `trl/scripts/*.py` parse with `fail_with_unknown_args=False`, so a misapplied flag is dropped rather than rejected. | The typed per-method configs make a wrong-method parameter a construction-time `TypeError` in the SDK, before the TrainJob is created. This is the primary reason for the config shape in [Choosing the config shape](#choosing-the-config-shape). |
+| **`extra_args` reopens the silent-ignore hole** for anything passed through it, since those flags are not typed and TRL will not reject them. | Accepted by design: it is the escape hatch for the 161 shared flags, documented as unvalidated. Everything the KEP types is still checked at construction. |
 | **A framework registered twice** (in-tree and out-of-tree) claims the same label. | Registration is explicit and import-ordered; a later registration wins, which is what lets a fork shadow a stalled in-tree config. Documented, not silent. |
 
 ## Design Details
@@ -216,8 +221,9 @@ trainer container:
 | `PET_MASTER_ADDR` | `<trainjob>-node-0-0.<trainjob>` | `torch.go:161-162` |
 | `PET_MASTER_PORT` | `29500` | `torch.go:163-165` |
 
-It also opens port 29500 for the headless service, and rejects a `TrainJob` that tries to set
-any of those five variables itself.
+It also opens port 29500 for the headless service, and `Validate` rejects a `TrainJob` that tries
+to set any of those five variables itself (`torch.go:67-77`, against
+`constants.TorchRunReservedEnvNames`).
 
 There is exactly one framework-specific branch: when `spec.trainer.command` equals
 `["tune", "run"]`, the plugin withholds `PET_MASTER_ADDR` / `PET_MASTER_PORT` and rewrites the
@@ -270,59 +276,51 @@ torchrun-native frameworks in the Trainer already use, Megatron included.
 
 #### Proof of concept
 
-Three runs — two on the cluster, one reproducible locally — all with the exact `PET_*`
-variables the unmodified torch plugin injects. The only difference is what consumed them.
+Three runs, all with the exact `PET_*` variables the unmodified torch plugin injects. The only
+difference is what consumed them.
 
-| Run | Where | Consumer of `PET_*` | Outcome |
-|---|---|---|---|
-| `probe-rendezvous` | cluster, 2 CPU nodes | bare `torchrun` | `[Gloo] Rank 1 is connected to 1 peer ranks`, then `rank=1 world_size=2 allreduce=2.0`. **Real rendezvous** from the plugin's injected env. |
-| torchrun + TRL script | Linux container, 2 simulated nodes | `torchrun -m trl.scripts.sft` — the runtime's exact command | First-step `epoch` moved from `0.05882` (1/17, single-node control) to `0.1111` (1/9): the dataset sharded across 2 ranks. **World size 2**, both launches completed. |
-| `trl-demo` | cluster, 2 CPU nodes | `trl sft` → `accelerate launch`, via a flag-translating entrypoint | Flags translated **correctly** per pod, yet `epoch` advanced `1/52002` per step instead of `2/52002`: **world size 1**. Both pods `Succeeded`, TrainJob `Complete` — a silent failure. |
+- **Cluster, bare torchrun.** Two CPU pods reached `world_size=2` with a Gloo all-reduce summing
+  to `2.0` — real rendezvous from the plugin's injected env, so the plugin→torchrun half holds on
+  real infrastructure.
+- **Container, `torchrun -m trl.scripts.sft`** — the runtime's exact command, with only the five
+  `PET_*` set and no topology flags. The first-step `epoch` moved from `0.05882` (1/17, single-node
+  control) to `0.1111` (1/9), so the dataset sharded across 2 ranks: **world size 2**.
+- **Cluster, `trl sft` → `accelerate launch`.** Flags translated correctly per pod, yet the run
+  stayed at **world size 1** while both pods reported `Succeeded` and the TrainJob `Complete` — the
+  silent failure that rules the CLI out.
 
-The probe proves the plugin→torchrun half on real infrastructure: each rank contributes `1.0`
-to a Gloo all-reduce, so a sum of `2.0` can only come from two processes that exchanged data.
-The container run proves the torchrun→TRL half with TRL's real `sft.py`, launched with **only**
-the five `PET_*` variables set — no topology flags, no CLI. The epoch value cannot lie: 17
-examples become 9 steps/epoch only when the data is split across 2 workers, and a worker that
-failed to connect would hang rather than complete. The run is committed as
-`examples/trl/local_torchrun_proof.sh` (needs only docker) and used `--use_cpu`, so reproducing
-it — and the eventual cluster E2E — needs no GPUs.
+Full write-up, the reproduction script (docker only, `--use_cpu`, no GPUs) and the draft image and
+manifests: [`examples/trl/README.md` on the PoC branch](https://github.com/YassinNouh21/trainer/blob/01b96f38608467d96acfc01c7500d49ebeca5d6f/examples/trl/README.md).
 
-**What is not yet proven.** The two halves were verified separately: cross-pod rendezvous on
-the cluster, and the TRL script under torchrun locally. Running the TRL script across two real
-pods is the remaining step, and it is the first item of the E2E phase. Nothing in the two
-results suggests it will behave differently — the local run used the manifest's exact command,
-and the pod-to-pod path is what the probe already exercised — but it has not been run.
+**What is not yet proven.** The two halves were verified separately — cross-pod rendezvous on the
+cluster, and the TRL script under torchrun in a container. Running the TRL script across two real
+pods is the remaining step and the first item of the E2E phase.
 
 #### Limitation: the TRL CLI and `accelerate launch`
 
-The TRL CLI cannot be the runtime command. `trl-demo` failed for two causes, both in
-accelerate's launcher and both **exiting 0** — JobSet observes completion, the TrainJob reports
-`Succeeded`, and no signal reaches the control plane:
+The TRL CLI cannot be the runtime command. The `accelerate launch` run failed for two causes,
+both in accelerate's launcher and both **exiting 0**, so JobSet observes completion, the TrainJob
+reports `Succeeded`, and no signal reaches the control plane:
 
-1. **`--use_cpu` disables every distributed path** *(demonstrated on the cluster)*. Each
-   distributed branch in `launch_command` is guarded `... and not args.cpu`, so a CPU run falls
-   through to `simple_launcher`, which never sets `RANK` / `WORLD_SIZE`.
-2. **`--multi_gpu` is inferred only from local device count** *(from source)*. Accelerate
-   auto-enables it when `torch.cuda.device_count() > 1` in the current process — never true at
-   one GPU per pod.
+1. **`--use_cpu` disables every distributed path**, so a CPU run falls through to the simple
+   launcher, which never sets `RANK` / `WORLD_SIZE`. Demonstrated on the cluster.
+2. **Multi-GPU is inferred from the local device count** in the current process, which is never
+   above one at one GPU per pod.
 
-Both are properties of the *launcher* and vanish when torchrun launches the script: the
-container run in [Proof of concept](#proof-of-concept) used `--use_cpu` and still reached world
-size 2, because in-process accelerate reads the env torchrun had already exported.
+Both are properties of the *launcher* and vanish when torchrun launches the script: the container
+run above used `--use_cpu` and still reached world size 2, because in-process accelerate reads the
+env torchrun had already exported. The source-level detail is in the
+[PoC write-up](https://github.com/YassinNouh21/trainer/blob/01b96f38608467d96acfc01c7500d49ebeca5d6f/examples/trl/README.md).
 
-Choosing torchrun is also the pattern the Trainer already follows for other frameworks —
-Megatron runs under the torchrun launcher today — so TRL joins an established path rather than
-introducing a second one. Axolotl and LlamaFactory can both be launched by torchrun as well,
-which is a useful signal for later frameworks but not part of this proposal.
+Choosing torchrun is also the pattern the Trainer already follows — Megatron runs under the
+torchrun launcher today — so TRL joins an established path rather than introducing a second one.
 
 ##### What torchrun gives up
 
 Most of what `accelerate launch` configures is also exposed by HF `TrainingArguments`, so it
-survives as ordinary script flags: `--deepspeed`, `--fsdp`, `--fsdp_config`,
-`--accelerator_config`, `--bf16` / `--fp16`, `--gradient_checkpointing`, `--torch_compile`,
-`--ddp_backend`. DeepSpeed and FSDP are therefore **not** lost. What is genuinely unavailable
-under torchrun:
+survives as ordinary script flags: `--deepspeed`, `--fsdp`, `--fsdp_config`, `--bf16` / `--fp16`,
+`--gradient_checkpointing`, `--torch_compile`, `--ddp_backend`. DeepSpeed and FSDP are therefore
+**not** lost. What is genuinely unavailable under torchrun:
 
 | Not available | Impact |
 |---|---|
@@ -332,16 +330,15 @@ under torchrun:
 | `--mixed_precision`, `--dynamo_backend` at launch time | Covered by `--bf16` / `--fp16` and `--torch_compile` on the script. |
 | `--mpirun_hostfile` | Only needed because accelerate cannot do multi-process CPU without MPI. torchrun does it natively over gloo, so this is a limitation torchrun *removes*. |
 
-**Elasticity and preemption are not lost either.** For multi-GPU and DeepSpeed,
-`accelerate launch` runs torchrun itself — `import torch.distributed.run as distrib_run`, then
-`distrib_run.run(args)` — and its elastic flags (`--max_restarts`, `--monitor_interval`,
-`--rdzv_backend`, `--rdzv_conf`) are passed straight through to torchrun's own parser. Calling
-torchrun directly gives the same behaviour with one less layer.
+Elasticity is not lost either: for multi-GPU and DeepSpeed, `accelerate launch` runs torchrun
+itself and passes its elastic flags straight through, so calling torchrun directly gives the same
+behaviour with one less layer. Elastic training is in any case unsupported by the Trainer for
+either launcher (`torch.go:109`).
 
 **In short: we do not use accelerate's launcher — torchrun launches TRL's script directly.**
-accelerate is still in the image because TRL depends on it (`accelerate>=1.4.0`, and HF
-`Trainer` cannot be imported without it), but in-process it only reads the variables torchrun
-exported. What is excluded here is a second launcher, not a library.
+accelerate is still in the image because TRL depends on it (`accelerate>=1.4.0`, and HF `Trainer`
+cannot be imported without it), but in-process it only reads the variables torchrun exported. What
+is excluded here is a second launcher, not a library.
 
 #### What changes in the plugin
 
@@ -431,10 +428,10 @@ points:
 
 | # | Coupling | Location |
 |---|---|---|
-| 1 | `BuiltinTrainer.config` annotated with the concrete `TorchTuneConfig` | `types.py:226-236` |
-| 2 | Framework identifier derived by reflecting on that annotation | `types.py:239-240` |
-| 3 | `trainer_type` and entrypoint selected by string-comparing the label against it | `utils.py:114-119`, `:140-158` |
-| 4 | Config-to-argument translation guarded by `isinstance(..., TorchTuneConfig)` | `utils.py:451-452` |
+| 1 | `BuiltinTrainer.config` annotated with the concrete `TorchTuneConfig` | `types.py:241` |
+| 2 | Framework identifier derived by reflecting on that annotation (`BuiltinTrainer.__annotations__["config"].__name__`) | `types.py:245` |
+| 3 | `trainer_type` and entrypoint selected by string-comparing the label against it | `utils.py:125-129`, `:152-159` |
+| 4 | Config-to-argument translation guarded by `isinstance(..., TorchTuneConfig)` | `utils.py:465` |
 
 Coupling #3 is the one that blocks everything else. `trainer_type` is not a field on the
 Runtime CR; the SDK computes it as `BUILTIN_TRAINER if framework == TORCH_TUNE else
@@ -530,6 +527,8 @@ class TRLGRPOConfig(TRLMethodConfig):
     loss_type: Optional[Literal[
         "grpo", "dr_grpo", "dapo", "bnpo", "cispo", "sapo", "luspo", "vespo"]] = None
     num_generations: Optional[int] = None
+    # Upstream reward_funcs lives on GRPOScriptArguments, not GRPOConfig;
+    # merged here on purpose so one object covers the method's whole surface.
     reward_funcs: Optional[list[str]] = None
 
 
@@ -544,8 +543,9 @@ class TRLConfig(FrameworkConfig):
 
     method: TRLMethodConfig                         # the typed slot
 
-    model_name_or_path: str
-    dataset_name: str
+    # Normally supplied by the Initializer; set these only without one.
+    model_name_or_path: Optional[str] = None
+    dataset_name: Optional[str] = None
 
     learning_rate: Optional[float] = None
     num_train_epochs: Optional[int] = None
@@ -557,14 +557,23 @@ class TRLConfig(FrameworkConfig):
     lora_alpha: Optional[int] = None
     lora_target_modules: Optional[list[str]] = None
 
+    # Kubeflow placement, never rendered as flags. Mirrors TorchTuneConfig.
+    num_nodes: Optional[int] = None
+    resources_per_node: Optional[dict] = None
+
+    # Escape hatch for the shared TRL flags this class does not type.
+    extra_args: Optional[dict[str, str]] = None
+
     def to_args(self) -> list[str]:
         """[trl.scripts.<module>, --flag, value, ...]: the module name first
-        (torchrun's -m positional), then shared flags, then the method's own.
-        Bools become store_true flags, lists expand after their flag."""
+        (torchrun's -m positional), then shared flags, the method's own, then
+        extra_args. Bools become store_true flags, lists expand after their
+        flag. num_nodes and resources_per_node are never rendered."""
         return (
             [f"trl.scripts.{self.method.module}"]
             + self._shared_args()
             + self.method.to_args()
+            + self._extra_args()
         )
 ```
 
@@ -577,21 +586,50 @@ arguments, please refer to the `TrainingArguments` documentation." Splitting alo
 seam means each field is declared once, and the split matches upstream rather than inventing
 one.
 
-`model_name_or_path` and `dataset_name` come from `ModelConfig` and `ScriptArguments`, which
-are also method-independent, so they belong outside too.
+The split is also lopsided, which is what makes it worth making once: **161 flags are shared**
+(`TrainingArguments` 133, `ModelConfig` 19, `ScriptArguments` 6, `DatasetMixtureConfig` 3),
+against 11 to 79 that are method-specific, GRPO being the 79. Under a per-method design those
+161 would be re-frozen in every exported constructor.
+
+`model_name_or_path` and `dataset_name` come from `ModelConfig` and `ScriptArguments`, which are
+also method-independent, so they belong outside too. Both are `Optional`: see
+[Where the model and dataset come from](#where-the-model-and-dataset-come-from).
+
+`num_nodes` and `resources_per_node` are not TRL flags at all — they are Kubeflow placement
+knobs, and they sit here because `TorchTuneConfig` already carries them and `BuiltinTrainer` has
+no fields of its own. `to_args()` never renders them.
+
+`extra_args` is the escape hatch for the shared flags this class does not type. 161 is too many
+to enumerate, and a user who needs `--gradient_accumulation_steps` should not have to wait for an
+SDK release. It is rendered last, so it can also override anything above it.
+
+##### Where the model and dataset come from
+
+TorchTune takes both from the runtime plus the `Initializer` and has no model or dataset fields
+on its config at all. TRL's scripts need `--model_name_or_path` and `--dataset_name` as flags, so
+naming them on the config would create a second source with no stated precedence.
+
+The rule: **the `Initializer` wins, and the config fields are the no-initializer path.** When an
+`Initializer` is present the backend appends `--model_name_or_path=/workspace/model` and
+`--dataset_name=/workspace/dataset` — the same "staging knowledge the backend owns" rule the KEP
+already applies to TorchTune's `dataset.data_files=` overrides, and the same
+`constants.MODEL_PATH` / `DATASET_PATH` the SDK already defines. Setting both an `Initializer`
+and the matching config field is a `ValueError` at submit rather than a silent precedence rule.
 
 #### Choosing the config shape
 
-Three shapes were considered. The one above is B.
+Four shapes were considered. The one above is C. The full comparison, with the upstream field
+counts behind it, is in the [design note](https://claude.ai/code/artifact/29468417-11ca-42d8-a8d2-b23c0939a14c).
 
-| | **A. Flat + method enum** | **B. Typed slot** (chosen) | **C. Top-level per-method configs** |
-|---|---|---|---|
-| Call | `TRLConfig(method=TRLMethod.GRPO, beta=0.04)` | `TRLConfig(method=TRLGRPOConfig(beta=0.04), ...)` | `BuiltinTrainer(config=TRLGRPOConfig(...))` |
-| Wrong-method parameter | accepted, then **silently dropped by TRL** | `TypeError` at construction | `TypeError` at construction |
-| Conflicting field types | **cannot be typed** — see below | each declared once, correctly | each declared once, correctly |
-| Shared fields | declared once | declared once | **duplicated** per class, or need a shared base |
-| Registry | one config per framework ✓ | one config per framework ✓ | **N configs claim one label** — needs a registry redesign |
-| Adding a method | one enum member + one map entry | one dataclass | one dataclass + a new export + registry change |
+| | **A. Flat + method enum** | **B. Per-method configs** | **C. Typed slot** (chosen) | **D. C + shared model/dataset specs** |
+|---|---|---|---|---|
+| Call | `TRLConfig(method=TRLMethod.GRPO, beta=0.04)` | `BuiltinTrainer(config=TRLGRPOConfig(...))` | `TRLConfig(method=TRLGRPOConfig(...), ...)` | four nested objects |
+| Objects per job | 1 | 1 | 2 | 4 |
+| Wrong-method parameter | accepted, then **silently dropped by TRL** | `TypeError` at construction | `TypeError` at construction | as C |
+| Conflicting field types | **cannot be typed** | each declared once, correctly | each declared once, correctly | as C |
+| The 161 shared flags | one signature | **re-frozen in every export** | one signature | one signature |
+| Registry | one config per framework ✓ | **N configs claim one label** | one config per framework ✓ | one config per framework ✓ |
+| Adding a method | one enum member + one map entry | one dataclass + a new export + registry change | one dataclass | one dataclass |
 
 **Why A cannot be typed.** The same parameter name has a different type and different valid
 values per method, verified against TRL's config sources:
@@ -600,6 +638,7 @@ values per method, verified against TRL's config sources:
 |---|---|---|---|
 | `loss_type` | `str \| None`; `'nll'`, `'dft'`, `'chunked_nll'` | `list[str]`, default `["sigmoid"]`; 15 values, combinable | `str`, default `"dapo"`; `'grpo'`, `'dr_grpo'`, `'dapo'`, `'bnpo'`, `'cispo'`, … |
 | `beta` | — | `float = 0.1`, deviation from the **reference model** | `float = 0.0`, **KL coefficient** |
+| `shuffle_dataset` | `bool = False` | — | `bool \| None = True` |
 
 A flat dataclass must pick one annotation for `loss_type`, so it is either wrong for two
 methods or degraded to `Any`. And `beta` is one name for two different quantities with
@@ -608,18 +647,25 @@ different defaults, which no annotation can disambiguate.
 **Why the type error matters here specifically.** TRL's scripts call
 `parser.parse_args_and_config(fail_with_unknown_args=False)`, so an argument that does not
 belong to the method being run is **ignored, not rejected**. A user who sets `num_generations`
-on an SFT job gets a successful run that silently ignored it. Shape A pushes that detection to
-nowhere; shape B turns it into a `TypeError` before the TrainJob is created.
+on an SFT job gets a successful run that silently ignored it. Shape A pushes that detection
+nowhere; the typed slot turns it into a `TypeError` before the TrainJob is created.
 
 The current draft's `_METHOD_SCOPED_FIELDS` map was an attempt to recover this at runtime. It
 has to be maintained either way, so expressing it as subclasses removes a hand-maintained map
 rather than adding one.
 
-**Why not C.** It reads best at the call site, but the registry is keyed one config per
-framework label, and three classes claiming `trl` would need it redesigned to represent one
-framework's internal methods. Shared fields would also be duplicated across the three classes
-or hoisted into a shared base — at which point the base *is* shape B's outer config, without
-the single entry point.
+**Why not B.** It reads best at the call site and is closest to TRL's own shape, but the registry
+is keyed one config per framework label, and three classes claiming `trl` would need it redesigned
+to represent one framework's internal methods. The 161 shared flags would also be copied into
+every public signature, so adding one shared field would touch three frozen constructors, then
+six, then eighteen — or they get hoisted into a shared base, at which point the base *is* the
+outer config, without the single entry point.
+
+**Why not D.** Grouping the shared fields further into model, dataset and training specs is
+tempting, but the surface is shared only as a concept: TRL wants `--dataset_name`, LlamaFactory
+wants `--dataset`, and TorchTune wants Hydra overrides like `model.lora_rank=16` and could not use
+the block at all. It also costs four objects per job for one framework, and it is a one-way door —
+moving fields into `config.model` later is a breaking change.
 
 **Precedent.** The typed slot is the ordinary shape for "one of N variants, plus shared
 settings": Keras `compile(optimizer=...)` takes an `Optimizer` instance with the shared
@@ -638,6 +684,10 @@ DPO / GRPO axis — TRL's README calls them "fine-tuning methods" reached "via t
 matches how sibling KEPs name a variant slot after the concept
 (KEP-3562's `algorithm=RandomSearch()`).
 
+The classes are `TRLSFTConfig` rather than `SFTConfig` for two more reasons: it matches the
+existing `TorchTuneConfig` naming, and it avoids shadowing `from trl import SFTTrainer` in the
+same notebook. It also lets `LlamaFactorySFTConfig` land later without asymmetry.
+
 #### Wiring it up
 
 `BuiltinTrainer` stays exactly where it is and keeps its construction signature; only its
@@ -652,7 +702,7 @@ BuiltinTrainer(config=TRLConfig(...))         # new, same machinery
 Three call sites change, and each one *loses* a branch:
 
 - **`get_runtime_trainer()` resolves the command through the registry**, replacing the
-  `framework == TORCH_TUNE` branch at `utils.py:150-158` and deleting
+  `framework == TORCH_TUNE` branch at `utils.py:152-159` and deleting
   `constants.TORCH_TUNE_COMMAND`:
 
   ```python
@@ -664,12 +714,12 @@ Three call sites change, and each one *loses* a branch:
   ```
 
 - **`trainer_type` comes from the registry**: `BUILTIN_TRAINER` when `get_framework()` finds a
-  registered config, `CUSTOM_TRAINER` otherwise — replacing `utils.py:114-119` and deleting the
+  registered config, `CUSTOM_TRAINER` otherwise — replacing `utils.py:125-129` and deleting the
   `TORCH_TUNE` constant. The framework label stays the sole discovery key.
 
 - **The backend has no framework branch.** One line —
   `trainer_cr.args = trainer.config.to_args()` — deletes the `isinstance` check at
-  `utils.py:451-452` rather than relocating it. `command` still comes from the runtime, exactly
+  `utils.py:465` rather than relocating it. `command` still comes from the runtime, exactly
   as today.
 
 `RuntimeTrainer.command` stays the field consumers read. It is not config-specific:
@@ -700,7 +750,7 @@ Two details preserved from the TorchTune path:
 
 | Framework | Post-training methods | Maintenance | Argument shape | torchrun path |
 |---|---|---|---|---|
-| TRL | one plain script per method under `trl/scripts/` — `sft`, `dpo`, `grpo`, `kto`, `reward`, `rloo`; PPO moved to `trl.experimental` in 0.29 ([trl#4466](https://github.com/huggingface/trl/issues/4466)) | Active (Hugging Face) | flags | native: `torchrun -m trl.scripts.<method>` |
+| TRL | one plain script per method under `trl/scripts/` — `sft`, `dpo`, `grpo`, `kto`, `reward`, `rloo`; PPO was moved to `trl.experimental` ([trl#4466](https://github.com/huggingface/trl/issues/4466)) and has since been removed entirely | Active (Hugging Face) | flags | native: `torchrun -m trl.scripts.<method>` |
 | TorchTune | SFT only, in the Kubeflow integration | Stopped 15 Jul 2025 ([#2883](https://github.com/meta-pytorch/torchtune/issues/2883)) | flags | via `tune run` (plugin rewrites the command) |
 | LlamaFactory | Broad, but built on HF `Trainer` and PEFT | Active | config file | wrapped: needs `FORCE_TORCHRUN=1` and renamed env |
 | Axolotl | Broad, but its GRPO is TRL's `GRPOTrainer` | Active | config file | native with `--launcher torchrun` (default is accelerate) |
@@ -756,9 +806,9 @@ TRL branch to the plugin.
 `mlPolicy.torch: {}`, `command: [torchrun, -m, trl.scripts.sft]`, and mounts `initializer` at
 `/workspace`.
 
-**Launch-path test** — `examples/trl/local_torchrun_proof.sh` (already committed and passing,
-see [Proof of concept](#proof-of-concept)): two `torchrun -m trl.scripts.sft` launches with only
-the five `PET_*` variables set must form world size 2, asserted by the per-step epoch value
+**Launch-path test** — the proof script from the [PoC branch](https://github.com/YassinNouh21/trainer/blob/01b96f38608467d96acfc01c7500d49ebeca5d6f/examples/trl/README.md), moved into
+`examples/trl/` as part of S1: two `torchrun -m trl.scripts.sft` launches with only the five
+`PET_*` variables set must form world size 2, asserted by the per-step epoch value
 (`0.0588` → `0.1111`); the single-node control run guards the assertion itself. Re-run on every
 `trl` version bump in `requirements.txt`.
 
@@ -769,6 +819,10 @@ Client side:
 - `to_args()` for each of `TRLSFTConfig`, `TRLDPOConfig`, `TRLGRPOConfig`: the module name is
   the first element; bools render as store_true flags; lists expand after their flag.
 - Passing a method-specific parameter to the wrong method config raises `TypeError`.
+- Setting both an `Initializer` and `model_name_or_path` (or `dataset_name`) raises `ValueError`
+  at submit; with an `Initializer` alone the rendered args carry the `/workspace` paths.
+- `num_nodes` and `resources_per_node` never appear in `to_args()` output; `extra_args` renders
+  last.
 - `register_framework` rejects a config declaring no framework or no command.
 - `get_runtime_trainer()` resolves `trainer_type` and `command` from the registry for both
   `torchtune` and `trl`, and falls through to torch/mpi/default for unregistered labels.
@@ -805,7 +859,7 @@ the client-side integration tests need a TRL runtime to run against.
 
 | Phase | Contents |
 |---|---|
-| S1 | `cmd/trainers/trl/` with pinned versions, the launch-path proof script, image publishing in the existing workflow |
+| S1 | `cmd/trainers/trl/` with pinned versions and the launch-path proof script, both promoted from the [PoC branch](https://github.com/YassinNouh21/trainer/blob/01b96f38608467d96acfc01c7500d49ebeca5d6f/examples/trl/README.md); image publishing in the existing workflow |
 | S2 | `manifests/base/runtimes/trl/` + kustomization entry, manifest tests, an `examples/trl/` TrainJob |
 | S3 | The `torch_test.go` regression cases, then the two-node cluster E2E (CPU is sufficient — the launch path is device-agnostic) |
 
@@ -874,7 +928,17 @@ TRL reachable from Python.
    understand the torchrun limitations first, which this KEP now records. It is deliberately
    kept separate from shipping TRL, along with dynamic registration (see #2): both would need
    their own design discussion, and neither blocks TRL.
-4. **Does a compute-profile runtime axis appear for GRPO?** GRPO rollouts can use a vLLM server,
+4. **Flat exports, or a `kubeflow.trainer.trl` submodule?** `TRLSFTConfig` in the existing flat
+   `__all__` matches today's `__init__.py`; a submodule keeps the top level at one name per
+   framework. Frozen once shipped, so it needs a decision before the first release rather than
+   after.
+5. **Do we expose experimental TRL methods?** PPO is the cautionary case: it was moved to
+   `trl.experimental` ([trl#4466](https://github.com/huggingface/trl/issues/4466)) and has since
+   been removed from the package entirely. Exporting a config for a method upstream later drops
+   leaves us holding a public name. The proposal is to export only methods with a stable
+   `trl/scripts/` module, and if experimental ones are ever wanted, to put them in a namespace
+   carrying no stability promise.
+6. **Does a compute-profile runtime axis appear for GRPO?** GRPO rollouts can use a vLLM server,
    which may justify a second TRL runtime. Deferred until there is a working GRPO E2E to measure.
 
 ## Implementation History
@@ -884,9 +948,13 @@ TRL reachable from Python.
 - **2026-08-16**: transferred to `kubeflow/trainer` as KEP-2839 and extended with the server
   side ([#3930](https://github.com/kubeflow/trainer/pull/3930)), superseding
   [#3263](https://github.com/kubeflow/trainer/pull/3263).
-- **2026-08-30**: proof-of-concept results added; torchrun confirmed as the launcher and the
-  `accelerate launch` route recorded as a limitation.
-- **2026-09-02**: reviewed on the Kubeflow Trainer community call. Agreed: restructure to the
+- **2026-08-23**: proof of concept built on the `poc/trl-torch-plugin` branch (pinned at
+  [`01b96f3`](https://github.com/YassinNouh21/trainer/tree/01b96f38608467d96acfc01c7500d49ebeca5d6f)); torchrun confirmed as the
+  launcher and the `accelerate launch` route recorded as a limitation.
+- **2026-08-30**: config-shape options compared in a [design note](https://claude.ai/code/artifact/29468417-11ca-42d8-a8d2-b23c0939a14c); the typed slot chosen.
+- **2026-09-02**: reviewed on the Kubeflow Trainer community call. The client-side design here
+  supersedes the parallel SDK proposal in
+  [sdk#627](https://github.com/kubeflow/sdk/pull/627), which covered the same ground. Agreed: restructure to the
   community KEP template with the server and client designs separated; drop the general SDK
   trainer hierarchy inherited from sdk#285; give `TRLConfig` a typed per-method slot instead of
   a flat config with a method enum; do **not** mirror TorchTune's per-model-family runtime
@@ -906,7 +974,7 @@ TRL reachable from Python.
 
 ## Alternatives
 
-### A flat `TRLConfig` with a method enum
+### A. A flat `TRLConfig` with a method enum
 
 The shape in the previous draft: `TRLConfig(method=TRLMethod.GRPO, beta=0.04, ...)` with a
 `_METHOD_SCOPED_FIELDS` map validating at construction. Rejected because `loss_type` and `beta`
@@ -914,12 +982,19 @@ have conflicting types and meanings across methods, so the flat class cannot be 
 because the runtime map has to be hand-maintained anyway. See
 [Choosing the config shape](#choosing-the-config-shape).
 
-### Top-level per-method configs
+### B. Top-level per-method configs
 
 `BuiltinTrainer(config=TRLGRPOConfig(...))`, with no outer TRL config. Reads best at the call
-site, but three classes would claim the `trl` label in a registry keyed one config per
-framework, and the shared fields would be duplicated or hoisted into a base that then *is* the
-outer config. See [Choosing the config shape](#choosing-the-config-shape).
+site, but three classes would claim the `trl` label in a registry keyed one config per framework,
+and the 161 shared flags would be re-frozen in every public signature or hoisted into a base that
+then *is* the outer config. See [Choosing the config shape](#choosing-the-config-shape).
+
+### D. Shared model, dataset and training specs
+
+Grouping the shared fields into nested `ModelSpec` / `DatasetSpec` objects. Rejected because the
+surface is shared only as a concept — TRL, LlamaFactory and TorchTune each name these differently,
+and TorchTune's Hydra overrides could not use the block at all — and because it is a one-way door:
+moving a field into `config.model` later is a breaking change.
 
 ### One trainer class per framework (`TRLTrainer`, `TorchTuneTrainer`)
 
@@ -959,7 +1034,11 @@ controller's release cycle.
   [#3718](https://github.com/kubeflow/trainer/pull/3718)
 - Earlier drafts, superseded: [trainer#3263](https://github.com/kubeflow/trainer/pull/3263),
   [sdk#285](https://github.com/kubeflow/sdk/issues/285),
-  [sdk#310 registry PoC](https://github.com/kubeflow/sdk/pull/310)
+  [sdk#627](https://github.com/kubeflow/sdk/pull/627) (KEP-626, the SDK-side twin of this
+  proposal), [sdk#310 registry PoC](https://github.com/kubeflow/sdk/pull/310)
+- Proof of concept: [`poc/trl-torch-plugin`](https://github.com/YassinNouh21/trainer/tree/01b96f38608467d96acfc01c7500d49ebeca5d6f)
+  — the TRL image, runtime manifest, example TrainJob and the launch-path proof script
+- Config-shape comparison: [design note](https://claude.ai/code/artifact/29468417-11ca-42d8-a8d2-b23c0939a14c)
 - [Runtime guide — the framework label](https://www.kubeflow.org/docs/components/trainer/operator-guides/runtime/)
 - [SDK types](https://github.com/kubeflow/sdk/blob/main/kubeflow/trainer/types/types.py),
   [SDK TrainerClient](https://github.com/kubeflow/sdk/blob/main/kubeflow/trainer/api/trainer_client.py)
@@ -980,10 +1059,10 @@ controller's release cycle.
 - `accelerate.state.PartialState` — in-process env detection: `LOCAL_RANK != -1` → multi-GPU
   (nccl); `WORLD_SIZE > 1` on CPU → multi-CPU (gloo). This is what makes the script work under
   torchrun with no launcher flags.
-- `accelerate.commands.launch` — the *launcher* limitations recorded above: `launch_command`'s
-  distributed branches are each guarded `and not args.cpu`; `prepare_simple_launcher_cmd_env`
-  sets `MASTER_ADDR` / `MASTER_PORT` but never `RANK` / `WORLD_SIZE`; the `multi_gpu`
-  auto-enable guard is keyed on `torch.cuda.device_count()`.
-- [trl#4466](https://github.com/huggingface/trl/issues/4466) — PPO moved to experimental.
+- `accelerate.commands.launch` — the source behind the two *launcher* limitations recorded above;
+  the line-level detail is in the
+  [PoC write-up](https://github.com/YassinNouh21/trainer/blob/01b96f38608467d96acfc01c7500d49ebeca5d6f/examples/trl/README.md).
+- [trl#4466](https://github.com/huggingface/trl/issues/4466) — PPO moved to experimental; it is
+  absent from `trl/trainer/` and `trl/experimental/` at main.
   [torchtune#2883](https://github.com/meta-pytorch/torchtune/issues/2883) — development halted,
   15 July 2025.

--- a/proposals/2839-dynamic-llm-trainer/README.md
+++ b/proposals/2839-dynamic-llm-trainer/README.md
@@ -1,131 +1,208 @@
 # KEP-2839: Kubeflow Dynamic LLM Trainer Framework
 
-|                |                                                              |
-| -------------- | ------------------------------------------------------------ |
-| **Authors**    | @szaher, @YassinNouh21                                       |
-| **Status**     | Draft                                                        |
-| **Created**    | 2026-02-11                                                   |
-| **Reviewers**  | @andreyvelich, @astefanutti, @kramaranya                     |
-| **Supersedes** | [kubeflow/trainer#3263](https://github.com/kubeflow/trainer/pull/3263) |
-| **Transferred from** | `kubeflow/sdk` `docs/proposals/285-specialized-trainers`, which was scoped SDK-only |
-| **Relevant Issues** | [trainer#2839](https://github.com/kubeflow/trainer/issues/2839), [sdk#285](https://github.com/kubeflow/sdk/issues/285), [sdk#626](https://github.com/kubeflow/sdk/issues/626) (parked) |
+Authors:
 
-## Table of Contents
+- Yassin Nouh - [@YassinNouh21](https://github.com/YassinNouh21)
+- Shady Zaher - [@szaher](https://github.com/szaher)
 
-<!-- toc -->
-- [KEP-2839: Kubeflow Dynamic LLM Trainer Framework](#kep-2839-kubeflow-dynamic-llm-trainer-framework)
-  - [Table of Contents](#table-of-contents)
-  - [Overview](#overview)
-  - [Goals](#goals)
-  - [Non-Goals](#non-goals)
-  - [Part I: Server Side (`kubeflow/trainer`)](#part-i-server-side-kubeflowtrainer)
-    - [I.1 What the torch plugin already provides](#i1-what-the-torch-plugin-already-provides)
-    - [I.2 `PET_*` is torchrun's private interface](#i2-pet_-is-torchruns-private-interface)
-    - [I.3 Proof of concept](#i3-proof-of-concept)
-    - [I.4 Limitation: the TRL CLI and `accelerate launch`](#i4-limitation-the-trl-cli-and-accelerate-launch)
-    - [I.5 What changes in the plugin](#i5-what-changes-in-the-plugin)
-    - [I.6 New artifacts](#i6-new-artifacts)
-  - [Part II: Client Side (`kubeflow/sdk`)](#part-ii-client-side-kubeflowsdk)
-    - [II.1 Current limitations](#ii1-current-limitations)
-    - [II.2 `BaseTrainer`](#ii2-basetrainer)
-    - [II.3 `FuncTrainer` and the framework trainers](#ii3-functrainer-and-the-framework-trainers)
-    - [II.4 `ConfigTrainer`](#ii4-configtrainer)
-    - [II.5 `RuntimeConfig`](#ii5-runtimeconfig)
-    - [II.6 `TrainerClient` and runtime auto-discovery](#ii6-trainerclient-and-runtime-auto-discovery)
-    - [II.7 `FrameworkConfig`, the registry, and `TRLConfig`](#ii7-frameworkconfig-the-registry-and-trlconfig)
-    - [II.8 Which framework, and why TRL](#ii8-which-framework-and-why-trl)
-  - [Migration and Backward Compatibility](#migration-and-backward-compatibility)
-  - [Test Plan](#test-plan)
-  - [Implementation Plan](#implementation-plan)
-  - [Graduation Criteria](#graduation-criteria)
-  - [Open Questions](#open-questions)
-  - [Alternatives Considered](#alternatives-considered)
-  - [References](#references)
-<!-- /toc -->
+Creation date: 2026-02-11
 
----
-
-## Overview
+## Summary
 
 Kubeflow Trainer can run exactly one config-driven LLM framework: TorchTune, whose upstream
-development stopped in July 2025. This proposal makes the framework axis extensible and
-lands Hugging Face TRL as the second framework.
+development stopped in July 2025. This proposal makes the framework axis extensible and lands
+Hugging Face TRL as the second framework, adding the post-training methods the SDK cannot
+express today — DPO and GRPO.
 
-The work spans two repositories.
+The work spans two repositories, and each side is independently useful.
 
-**Server side (`kubeflow/trainer`).** A framework becomes supportable by adding a runtime
-image and a `ClusterTrainingRuntime`. The CRDs, the controller and the torch plugin are
-unchanged — no Go at all. The torch plugin already publishes the cluster topology as
-`PET_*` environment variables, and `PET_*` is torchrun's own env interface. So the TRL
-runtime launches TRL's training script **with torchrun**
-(`torchrun -m trl.scripts.sft`), and the topology flows through with no translation
-([I.2](#i2-pet_-is-torchruns-private-interface) explains why this works). The `trl` CLI is
-not used: it hands off to `accelerate launch`, which does not read `PET_*` and degrades to
-single-process training while still reporting success. That failure is documented as a
-limitation ([I.4](#i4-limitation-the-trl-cli-and-accelerate-launch)), and supporting
-accelerate is deferred to a later phase.
+**Server side (`kubeflow/trainer`).** A framework becomes supportable by adding a runtime image
+and a `ClusterTrainingRuntime`. The CRDs, the controller and the torch plugin are unchanged —
+no Go at all. The torch plugin already publishes the cluster topology as `PET_*` environment
+variables, and `PET_*` is torchrun's own env interface, so the TRL runtime launches TRL's
+training script with torchrun (`torchrun -m trl.scripts.sft`) and the topology flows through
+with no translation. The `trl` CLI is not used: it hands off to `accelerate launch`, which does
+not read `PET_*` and degrades to single-process training while still reporting success. That
+failure is recorded as a limitation, and supporting accelerate is deferred.
 
-**Client side (`kubeflow/sdk`).** Two additive changes: a trainer type hierarchy
-(`BaseTrainer` → `FuncTrainer` / `ConfigTrainer`) with runtime auto-discovery by the
-`trainer.kubeflow.org/framework` label, and a `RuntimeConfig` dataclass separating per-job
-environment settings from training logic. `CustomTrainer`, `BuiltinTrainer` and
-`TrainerClient.train()` keep working unchanged.
+**Client side (`kubeflow/sdk`).** One additive change: `FrameworkConfig`, an abstract config
+that knows its framework label, its entrypoint and how to render itself as arguments, plus a
+registry keyed on the framework label. `TorchTuneConfig` becomes an instance of it and
+`BuiltinTrainer.config` widens from the concrete `TorchTuneConfig` to `FrameworkConfig`. TRL
+then arrives as `TRLConfig`, carrying a typed per-method config in its `method` slot.
 
-The contract between the two sides already exists and is narrow: the framework label, and
-the container `command` the SDK appends rendered arguments to. Each side is independently
-useful — the runtime is usable from raw YAML before any SDK change ships.
+The contract between the two sides already exists and is narrow: the framework label, and the
+container `command` the SDK appends rendered arguments to. The runtime is usable from raw YAML
+before any SDK change ships.
 
 A proof of concept for the server side was built and run on a cluster; its results are in
-[I.3](#i3-proof-of-concept) and they changed the design.
+[Proof of concept](#proof-of-concept) and they changed the design.
 
-## Goals
+## Motivation
+
+TorchTune is the only config-driven framework the Trainer supports, it covers supervised
+fine-tuning only, and its upstream development halted on 15 July 2025
+([torchtune#2883](https://github.com/meta-pytorch/torchtune/issues/2883)). A data scientist who
+wants DPO or GRPO has no supported path: `BuiltinTrainer` accepts a `TorchTuneConfig` and
+nothing else, and the SDK hardcodes TorchTune at four points, so a second framework cannot be
+added without changing shared code each time.
+
+Meanwhile LLM post-training has moved past SFT. Reward-driven alignment (DPO) and
+group-relative policy optimization (GRPO) are the techniques users are asking for
+([#3508](https://github.com/kubeflow/trainer/issues/3508)), and the Trainer has no surface for
+either.
+
+### Goals
 
 **Server side**
 
-1. Ship TRL as the second in-tree config-driven framework — a `cmd/trainers/trl/` image and
-   manifests under `manifests/base/runtimes/trl/`, mirroring what TorchTune already has —
-   launched with **torchrun**, the canonical launcher the torch plugin already serves.
+1. Ship TRL as the second in-tree config-driven framework — a `cmd/trainers/trl/` image and a
+   runtime under `manifests/base/runtimes/trl/`, launched with **torchrun**, the canonical
+   launcher the torch plugin already serves.
 2. Keep the control plane completely unchanged: no Go, no CRD change, no knowledge of TRL.
-3. Document precisely why the `trl` CLI / `accelerate launch` route is excluded from phase
-   one (it fails *silently* at world size 1), so the future accelerate discussion can start
-   from measured results.
+3. Document precisely why the `trl` CLI / `accelerate launch` route is excluded from phase one
+   (it fails *silently* at world size 1), so the future accelerate discussion can start from
+   measured results.
 
 **Client side**
 
-4. Define `BaseTrainer`, plus `FuncTrainer` (function-driven) and `ConfigTrainer`
-   (config-driven), so the SDK and backends handle every trainer through one interface.
-5. Implement `TorchTrainer`, `DeepSpeedTrainer`, `JAXTrainer` and `XGBoostTrainer` with
-   runtime auto-discovery and validation by framework label.
+4. Introduce `FrameworkConfig` and a framework registry, so the SDK resolves the entrypoint and
+   the argument rendering from the config rather than from a TorchTune branch — removing the
+   four hardcoded TorchTune couplings.
+5. Add `TRLConfig` with typed per-method configs for SFT, DPO and GRPO, proving the extension
+   model with no new trainer class.
 6. Provide an extension point for community config-driven frameworks — a `FrameworkConfig`
-   subclass in any package.
-7. Introduce `RuntimeConfig`.
-8. Keep 100% backward compatibility with `CustomTrainer`, `CustomTrainerContainer`,
+   subclass in any package, registered by import.
+7. Keep 100% backward compatibility with `CustomTrainer`, `CustomTrainerContainer`,
    `BuiltinTrainer` and `TrainerClient.train()`.
 
-## Non-Goals
+### Non-Goals
 
 1. **Any control-plane change.** No CRD or schema change, no version bump, and no Go: the
-   server-side work is a new image and new manifests. `EnforceMLPolicy` and `Validate` are
-   both unchanged — see [I.5](#i5-what-changes-in-the-plugin).
-2. **A new framework plugin.** TRL reuses the torch plugin via `mlPolicy.torch`; no entry
-   is added to `pkg/runtime/framework/plugins/registry.go`.
+   server-side work is a new image and new manifests. `EnforceMLPolicy` and `Validate` are both
+   unchanged — see [What changes in the plugin](#what-changes-in-the-plugin).
+2. **A new framework plugin.** TRL reuses the torch plugin via `mlPolicy.torch`; no entry is
+   added to `pkg/runtime/framework/plugins/registry.go`.
 3. **New runtime labels or conventions.** `trainer.kubeflow.org/framework` is unchanged.
-4. **Supporting `accelerate launch`.** torchrun is the only launcher in scope, and the
-   plugin's existing `mlPolicy.torch` is the only mechanism used. Accelerate's launcher, and
-   the launcher-level options only it offers, is a separate discussion together with
-   dynamic registration. See
-   [I.4](#i4-limitation-the-trl-cli-and-accelerate-launch) for why it is excluded and
-   [Open Question #7](#open-questions) for what taking it up would involve.
-5. **Deprecating `CustomTrainer` or `BuiltinTrainer`.** Both stay supported.
-6. **In-tree Axolotl, LlamaFactory or Unsloth runtimes.** Only TRL is proposed here;
-   further frameworks are follow-up work.
-7. **Changes to `TrainJobTemplate`.**
+4. **Supporting `accelerate launch`.** torchrun is the only launcher in scope. Accelerate's
+   launcher, and the launcher-level options only it offers, is a separate discussion together
+   with dynamic registration. See
+   [Limitation: the TRL CLI and `accelerate launch`](#limitation-the-trl-cli-and-accelerate-launch)
+   for why it is excluded and [Open Questions](#open-questions) for what taking it up would
+   involve.
+5. **A general SDK trainer hierarchy.** An earlier draft of this KEP, inherited from
+   [sdk#285](https://github.com/kubeflow/sdk/issues/285), also proposed `BaseTrainer` /
+   `FuncTrainer` / `ConfigTrainer`, per-framework trainer classes (`TorchTrainer`,
+   `DeepSpeedTrainer`, `JAXTrainer`, `XGBoostTrainer`), `RuntimeConfig` and runtime
+   auto-discovery. None of that is needed to land TRL, and it is removed here so this KEP
+   covers one feature. It remains tracked in sdk#285.
+6. **Deprecating `CustomTrainer` or `BuiltinTrainer`.** Both stay supported, unchanged.
+7. **In-tree Axolotl, LlamaFactory or Unsloth runtimes.** Only TRL is proposed here; further
+   frameworks are follow-up work reached through the same extension point.
+8. **Changes to `TrainJobTemplate`.**
 
----
+## Proposal
 
-## Part I: Server Side (`kubeflow/trainer`)
+Add a TRL runtime image and manifest on the server, and on the client replace the hardcoded
+TorchTune branch with a framework registry that any config-driven framework can join. TRL is
+the first framework to join it.
 
-### I.1 What the torch plugin already provides
+### User Stories
+
+#### Story 1: Platform admin installs TRL
+
+As a platform admin, I install the Trainer and get a `trl-distributed`
+`ClusterTrainingRuntime` alongside the TorchTune runtimes. I did not have to build an image or
+write a plugin, and I can verify the runtime is correct by submitting a raw-YAML `TrainJob`
+against it before anyone uses the SDK.
+
+#### Story 2: Data scientist runs supervised fine-tuning
+
+As a data scientist, I fine-tune a model with TRL from the SDK using the same
+`BuiltinTrainer` I already use for TorchTune, swapping only the config:
+
+```python
+TrainerClient().train(
+    runtime=TrainerClient().get_runtime("trl-distributed"),
+    trainer=BuiltinTrainer(
+        config=TRLConfig(
+            method=TRLSFTConfig(packing=True),
+            model_name_or_path="Qwen/Qwen2.5-0.5B",
+            dataset_name="trl-lib/Capybara",
+            learning_rate=2e-5,
+        ),
+        num_nodes=2,
+    ),
+)
+```
+
+#### Story 3: Data scientist runs GRPO
+
+As a data scientist, I run a post-training method the SDK cannot express today. My editor
+tells me which parameters belong to GRPO, and passing a DPO-only parameter is an error I see
+before the job is submitted, not a flag TRL silently ignores at runtime:
+
+```python
+TrainerClient().train(
+    trainer=BuiltinTrainer(
+        config=TRLConfig(
+            method=TRLGRPOConfig(
+                beta=0.04,
+                num_generations=8,
+                reward_funcs=["think_format_reward"],
+            ),
+            model_name_or_path="Qwen/Qwen2.5-0.5B",
+            dataset_name="trl-lib/tldr",
+            learning_rate=1e-6,
+        ),
+        num_nodes=2,
+        resources_per_node={"gpu": 1},
+    ),
+)
+```
+
+#### Story 4: Community adds a framework out of tree
+
+As a maintainer of another config-driven framework, I publish a runtime image labelled with my
+framework and a `FrameworkConfig` subclass in my own package. Importing my package registers
+it. Neither the Trainer controller nor the SDK needs a commit.
+
+### Notes/Constraints/Caveats
+
+**TRL loads models and datasets from local paths, not only the Hugging Face Hub.** TRL's
+`--dataset_name` is documented as "Path or name of the dataset to load", and
+`--model_name_or_path` is passed to `from_pretrained`, which accepts a local directory. So the
+initializer-staged `/workspace/model` and `/workspace/dataset` work, and the Trainer's existing
+dataset and model initializers apply unchanged. Two caveats: a local dataset *directory* is
+loaded as parquet/JSON/CSV, so dataset repositories that ship a loading script are not
+equivalent; and a dataset with several configurations additionally needs `--dataset_config`.
+
+**A TRL upgrade is an image rebuild, not a controller release.** Which module torchrun runs
+(`trl.scripts.sft` vs `.dpo` vs `.grpo`) is chosen by the SDK and shipped in the image, so the
+control plane never learns a TRL version.
+
+**Elastic training is not supported by the Trainer for either launcher.** `torch.go:109`
+carries the TODO to add it once JobSet supports elastic jobs. Choosing torchrun does not change
+this — see [What torchrun gives up](#what-torchrun-gives-up).
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **A silently degraded run looks like success.** The `trl-demo` failure exited 0 on both pods, so a two-node job that trained two isolated copies was indistinguishable from one that trained jointly. torchrun-first removes that particular cause, not the class. | The E2E test asserts the achieved world size from the logs, not just `Complete`. Closing the class needs a runtime→status channel, which is out of scope here — see [Open Questions](#open-questions). |
+| **TRL's surface is not frozen**, and typed configs mirroring its flags will drift. TRL moved PPO to `trl.experimental` in a minor release. | The configs target the *script flags*, not the Python API, so a TRL upgrade changes the image rather than the SDK types, and drift is confined to the per-method config classes. The launch-path proof re-runs on every `trl` version bump. |
+| **TRL ignores unknown flags.** `trl/scripts/*.py` parse with `fail_with_unknown_args=False`, so a misapplied flag is dropped rather than rejected. | The typed per-method configs make a wrong-method parameter a construction-time `TypeError` in the SDK, before the TrainJob is created. This is the primary reason for the config shape in [Choosing the config shape](#choosing-the-config-shape). |
+| **A framework registered twice** (in-tree and out-of-tree) claims the same label. | Registration is explicit and import-ordered; a later registration wins, which is what lets a fork shadow a stalled in-tree config. Documented, not silent. |
+
+## Design Details
+
+The two sides are independent and are described separately. The contract between them is the
+framework label `trainer.kubeflow.org/framework` and the container `command` that the SDK
+appends rendered arguments to.
+
+### Server Side (`kubeflow/trainer`)
+
+#### What the torch plugin already provides
 
 Any runtime declaring `mlPolicy.torch` is processed by the torch plugin
 (`pkg/runtime/framework/plugins/torch/torch.go`). Its `EnforceMLPolicy` injects into the
@@ -139,23 +216,23 @@ trainer container:
 | `PET_MASTER_ADDR` | `<trainjob>-node-0-0.<trainjob>` | `torch.go:161-162` |
 | `PET_MASTER_PORT` | `29500` | `torch.go:163-165` |
 
-It also opens port 29500 for the headless service, and rejects a `TrainJob` that tries to
-set any of those five variables itself.
+It also opens port 29500 for the headless service, and rejects a `TrainJob` that tries to set
+any of those five variables itself.
 
 There is exactly one framework-specific branch: when `spec.trainer.command` equals
-`["tune", "run"]`, the plugin withholds `PET_MASTER_ADDR` / `PET_MASTER_PORT` and rewrites
-the command with `--rdzv_endpoint=<host>:29500` plus the recipe, config and runtime-derived
+`["tune", "run"]`, the plugin withholds `PET_MASTER_ADDR` / `PET_MASTER_PORT` and rewrites the
+command with `--rdzv_endpoint=<host>:29500` plus the recipe, config and runtime-derived
 overrides (`torch.go:175-201`). Every other command gets all five and no rewrite.
 
 So a second framework inherits a complete description of the topology for free. **The only
 question is whether its launcher reads it.**
 
-### I.2 `PET_*` is torchrun's private interface
+#### `PET_*` is torchrun's private interface
 
 `PET_*` is not a Kubeflow convention. It is how torchrun reads its own flags from the
 environment: for every flag, torchrun also accepts a `PET_`-prefixed env var
-(`torch.distributed.argparse_util`), so `PET_NNODES` is simply `--nnodes`. That puts
-`PET_*` at a specific layer:
+(`torch.distributed.argparse_util`), so `PET_NNODES` is simply `--nnodes`. That puts `PET_*` at
+a specific layer:
 
 ```
 1. Torch plugin        →  sets PET_NNODES, PET_NPROC_PER_NODE, PET_NODE_RANK,
@@ -166,8 +243,8 @@ environment: for every flag, torchrun also accepts a `PET_`-prefixed env var
 4. Training script     →  reads those standard variables
 ```
 
-`PET_*` is the launcher's **input**; `RANK` / `WORLD_SIZE` are its **output**. A framework
-that does not launch through torchrun never reaches step 2, so nothing produces step 3.
+`PET_*` is the launcher's **input**; `RANK` / `WORLD_SIZE` are its **output**. A framework that
+does not launch through torchrun never reaches step 2, so nothing produces step 3.
 
 TRL's *CLI* is such a case: `trl sft` hands off to `accelerate launch`
 (`trl/cli/accelerate_launcher.py` resolves the training script and calls accelerate's
@@ -176,9 +253,9 @@ source** — it is a *peer* of torchrun that takes topology from flags.
 
 But the CLI is only a wrapper. What it wraps — `trl/scripts/sft.py` — is a **plain training
 script**: `TrlParser` argument parsing plus `SFTTrainer(...).train()`, no launcher logic,
-runnable as a module. And the accelerate *library* inside it (`PartialState`, a hard
-dependency of TRL) detects torchrun's step-3 output from the environment: `LOCAL_RANK` set →
-multi-GPU (nccl); `WORLD_SIZE > 1` on CPU → multi-CPU (gloo).
+runnable as a module. And the accelerate *library* inside it (`PartialState`, a hard dependency
+of TRL) detects torchrun's step-3 output from the environment: `LOCAL_RANK` set → multi-GPU
+(nccl); `WORLD_SIZE > 1` on CPU → multi-CPU (gloo).
 
 So TRL fits the diagram directly by making torchrun the launcher of TRL's own script:
 
@@ -186,13 +263,12 @@ So TRL fits the diagram directly by making torchrun the launcher of TRL's own sc
 command: [torchrun, -m, trl.scripts.sft]
 ```
 
-torchrun consumes the plugin's `PET_*` natively (including `numProcPerNode: "auto"`, which
-it resolves itself), and the script's in-process accelerate reads what torchrun exports.
-No translation of variables, no translation of commands, no plugin change — the same path
-other torchrun-native frameworks in the Trainer already use, Megatron included. This is the design; the `accelerate launch`
-route is a documented limitation ([I.4](#i4-limitation-the-trl-cli-and-accelerate-launch)).
+torchrun consumes the plugin's `PET_*` natively (including `numProcPerNode: "auto"`, which it
+resolves itself), and the script's in-process accelerate reads what torchrun exports. No
+translation of variables, no translation of commands, no plugin change — the same path other
+torchrun-native frameworks in the Trainer already use, Megatron included.
 
-### I.3 Proof of concept
+#### Proof of concept
 
 Three runs — two on the cluster, one reproducible locally — all with the exact `PET_*`
 variables the unmodified torch plugin injects. The only difference is what consumed them.
@@ -203,52 +279,50 @@ variables the unmodified torch plugin injects. The only difference is what consu
 | torchrun + TRL script | Linux container, 2 simulated nodes | `torchrun -m trl.scripts.sft` — the runtime's exact command | First-step `epoch` moved from `0.05882` (1/17, single-node control) to `0.1111` (1/9): the dataset sharded across 2 ranks. **World size 2**, both launches completed. |
 | `trl-demo` | cluster, 2 CPU nodes | `trl sft` → `accelerate launch`, via a flag-translating entrypoint | Flags translated **correctly** per pod, yet `epoch` advanced `1/52002` per step instead of `2/52002`: **world size 1**. Both pods `Succeeded`, TrainJob `Complete` — a silent failure. |
 
-The probe proves the plugin→torchrun half on real infrastructure: each rank contributes
-`1.0` to a Gloo all-reduce, so a sum of `2.0` can only come from two processes that
-exchanged data. The container run proves the torchrun→TRL half with TRL's real `sft.py`,
-launched with **only** the five `PET_*` variables set — no topology flags, no CLI. The
-epoch value cannot lie: 17 examples become 9 steps/epoch only when the data is split
-across 2 workers, and a worker that failed to connect would hang rather than complete. The
-run is committed as `examples/trl/local_torchrun_proof.sh` (needs only docker) and used
-`--use_cpu`, so reproducing it — and the eventual cluster E2E — needs no GPUs.
+The probe proves the plugin→torchrun half on real infrastructure: each rank contributes `1.0`
+to a Gloo all-reduce, so a sum of `2.0` can only come from two processes that exchanged data.
+The container run proves the torchrun→TRL half with TRL's real `sft.py`, launched with **only**
+the five `PET_*` variables set — no topology flags, no CLI. The epoch value cannot lie: 17
+examples become 9 steps/epoch only when the data is split across 2 workers, and a worker that
+failed to connect would hang rather than complete. The run is committed as
+`examples/trl/local_torchrun_proof.sh` (needs only docker) and used `--use_cpu`, so reproducing
+it — and the eventual cluster E2E — needs no GPUs.
 
 **What is not yet proven.** The two halves were verified separately: cross-pod rendezvous on
-the cluster, and the TRL script under torchrun locally. Running the TRL script across two
-real pods is the remaining step, and it is the first item of the E2E phase. Nothing in the
-two results suggests it will behave differently — the local run used the manifest's exact
-command, and the pod-to-pod path is what the probe already exercised — but it has not been
-run.
+the cluster, and the TRL script under torchrun locally. Running the TRL script across two real
+pods is the remaining step, and it is the first item of the E2E phase. Nothing in the two
+results suggests it will behave differently — the local run used the manifest's exact command,
+and the pod-to-pod path is what the probe already exercised — but it has not been run.
 
-`trl-demo` is the failure case, and the reason the accelerate route is excluded from phase
-one; [I.4](#i4-limitation-the-trl-cli-and-accelerate-launch) records its causes.
-
-### I.4 Limitation: the TRL CLI and `accelerate launch`
+#### Limitation: the TRL CLI and `accelerate launch`
 
 The TRL CLI cannot be the runtime command. `trl-demo` failed for two causes, both in
-accelerate's launcher and both **exiting 0** — JobSet observes completion, the TrainJob
-reports `Succeeded`, and no signal reaches the control plane:
+accelerate's launcher and both **exiting 0** — JobSet observes completion, the TrainJob reports
+`Succeeded`, and no signal reaches the control plane:
 
 1. **`--use_cpu` disables every distributed path** *(demonstrated on the cluster)*. Each
-   distributed branch in `launch_command` is guarded `... and not args.cpu`, so a CPU run
-   falls through to `simple_launcher`, which never sets `RANK` / `WORLD_SIZE`.
+   distributed branch in `launch_command` is guarded `... and not args.cpu`, so a CPU run falls
+   through to `simple_launcher`, which never sets `RANK` / `WORLD_SIZE`.
 2. **`--multi_gpu` is inferred only from local device count** *(from source)*. Accelerate
-   auto-enables it when `torch.cuda.device_count() > 1` in the current process — never true
-   at one GPU per pod.
+   auto-enables it when `torch.cuda.device_count() > 1` in the current process — never true at
+   one GPU per pod.
 
 Both are properties of the *launcher* and vanish when torchrun launches the script: the
-container run in [I.3](#i3-proof-of-concept) used `--use_cpu` and still reached world
+container run in [Proof of concept](#proof-of-concept) used `--use_cpu` and still reached world
 size 2, because in-process accelerate reads the env torchrun had already exported.
 
 Choosing torchrun is also the pattern the Trainer already follows for other frameworks —
-Megatron runs under the torchrun launcher today — so TRL joins an established path rather
-than introducing a second one. Axolotl and LlamaFactory can both be launched by torchrun as
-well, which is a useful signal for later frameworks but not part of this proposal.
+Megatron runs under the torchrun launcher today — so TRL joins an established path rather than
+introducing a second one. Axolotl and LlamaFactory can both be launched by torchrun as well,
+which is a useful signal for later frameworks but not part of this proposal.
 
-**What torchrun gives up.** Most of what `accelerate launch` configures is also exposed by
-HF `TrainingArguments`, so it survives as ordinary script flags: `--deepspeed`, `--fsdp`,
-`--fsdp_config`, `--accelerator_config`, `--bf16` / `--fp16`, `--gradient_checkpointing`,
-`--torch_compile`, `--ddp_backend`. DeepSpeed and FSDP are therefore **not** lost. What is
-genuinely unavailable under torchrun:
+##### What torchrun gives up
+
+Most of what `accelerate launch` configures is also exposed by HF `TrainingArguments`, so it
+survives as ordinary script flags: `--deepspeed`, `--fsdp`, `--fsdp_config`,
+`--accelerator_config`, `--bf16` / `--fp16`, `--gradient_checkpointing`, `--torch_compile`,
+`--ddp_backend`. DeepSpeed and FSDP are therefore **not** lost. What is genuinely unavailable
+under torchrun:
 
 | Not available | Impact |
 |---|---|
@@ -259,26 +333,20 @@ genuinely unavailable under torchrun:
 | `--mpirun_hostfile` | Only needed because accelerate cannot do multi-process CPU without MPI. torchrun does it natively over gloo, so this is a limitation torchrun *removes*. |
 
 **Elasticity and preemption are not lost either.** For multi-GPU and DeepSpeed,
-`accelerate launch` runs torchrun itself — `import torch.distributed.run as distrib_run`,
-then `distrib_run.run(args)` — and its elastic flags (`--max_restarts`,
-`--monitor_interval`, `--rdzv_backend`, `--rdzv_conf`) are passed straight through to
-torchrun's own parser. Calling torchrun directly gives the same behaviour with one less
-layer. Elastic training is in any case not supported by the Trainer yet, for either
-launcher: `torch.go:109` carries the TODO to add it once JobSet supports elastic jobs.
+`accelerate launch` runs torchrun itself — `import torch.distributed.run as distrib_run`, then
+`distrib_run.run(args)` — and its elastic flags (`--max_restarts`, `--monitor_interval`,
+`--rdzv_backend`, `--rdzv_conf`) are passed straight through to torchrun's own parser. Calling
+torchrun directly gives the same behaviour with one less layer.
 
-Supporting `accelerate launch` is **out of scope here** and left to a later discussion
-([Open Question #7](#open-questions)).
-
-**In short: we do not use accelerate's launcher — torchrun launches TRL's script directly.
+**In short: we do not use accelerate's launcher — torchrun launches TRL's script directly.**
 accelerate is still in the image because TRL depends on it (`accelerate>=1.4.0`, and HF
-`Trainer` cannot be imported without it), but in-process it only reads the variables
-torchrun exported.** The distinction matters for review: what is excluded here is a second
-launcher, not a library.
+`Trainer` cannot be imported without it), but in-process it only reads the variables torchrun
+exported. What is excluded here is a second launcher, not a library.
 
-### I.5 What changes in the plugin
+#### What changes in the plugin
 
-Nothing. `EnforceMLPolicy` today supports the torchrun launcher through the `PET_*`
-variables, and that is what TRL needs — every run in [I.3](#i3-proof-of-concept) used an
+Nothing. `EnforceMLPolicy` today supports the torchrun launcher through the `PET_*` variables,
+and that is what TRL needs — every run in [Proof of concept](#proof-of-concept) used an
 unmodified `torch.go`. `Validate` is unchanged too.
 
 The difference from TorchTune is where the training arguments are built:
@@ -290,32 +358,25 @@ The difference from TorchTune is where the training arguments are built:
 | Who builds the arguments | the plugin, in Go: `torchtune.go` picks the recipe, adds `--config`, and appends the path overrides read from the runtime | the SDK, in Python: `TRLConfig.to_args()`, passed through unchanged as `args` |
 | Go needed | the existing branch | none |
 
-So supporting TRL adds no logic to the controller. Which module torchrun runs
-(`trl.scripts.sft` vs `.dpo` vs `.grpo`) is declared in the runtime manifest and shipped in
-the image, so a TRL upgrade is an image rebuild rather than a controller release.
+So supporting TRL adds no logic to the controller.
 
-### I.6 New artifacts
+#### New artifacts
 
-Two, mirroring what TorchTune already has. No extra script or binary in the image — the
-command is torchrun invoking TRL's training module.
+Two, mirroring what TorchTune already has. No extra script or binary in the image — the command
+is torchrun invoking TRL's training module.
 
-**1. `cmd/trainers/trl/`** — `Dockerfile` on the same PyTorch base as
-`cmd/trainers/torchtune`, installing pinned `trl` + dependencies. accelerate is among them
-— TRL requires it (`accelerate>=1.4.0`) and HF `Trainer` cannot be imported without it — but
-it is used only in-process; its launcher is never invoked. With:
+**1. `cmd/trainers/trl/`** — `Dockerfile` on the same PyTorch base as `cmd/trainers/torchtune`,
+installing pinned `trl` + dependencies. accelerate is among them — TRL requires it
+(`accelerate>=1.4.0`) and HF `Trainer` cannot be imported without it — but it is used only
+in-process; its launcher is never invoked.
 
-```dockerfile
-ENTRYPOINT ["torchrun", "-m", "trl.scripts.sft"]
-```
-
-**2. `manifests/base/runtimes/trl/`** — one `ClusterTrainingRuntime` per base model,
-mirroring `manifests/base/runtimes/torchtune/`. Initializer replicatedJobs are identical and
-omitted here:
+**2. `manifests/base/runtimes/trl/`** — a **single** `ClusterTrainingRuntime`, `trl-distributed`.
+Initializer replicatedJobs are identical to the TorchTune runtimes and omitted here:
 
 ```yaml
 kind: ClusterTrainingRuntime
 metadata:
-  name: trl-qwen2.5-1.5b
+  name: trl-distributed
   labels:
     trainer.kubeflow.org/framework: trl   # the SDK's discovery key
 spec:
@@ -324,8 +385,7 @@ spec:
                     - name: node
                       image: ghcr.io/kubeflow/trainer/trl-trainer
                       # torchrun reads PET_* natively; the trl CLI and
-                      # accelerate launch are never invoked. Other methods
-                      # swap the module: trl.scripts.dpo, trl.scripts.grpo.
+                      # accelerate launch are never invoked.
                       command: [torchrun, -m, trl.scripts.sft]
                       args:
                         - --model_name_or_path=/workspace/model
@@ -333,38 +393,41 @@ spec:
                         - --output_dir=/workspace/output
 ```
 
-The command is not `["tune", "run"]`, so `EnforceMLPolicy` takes its default path. The
-manifest's `sft` module is the raw-YAML default; an SDK-submitted `TrainJob` carries
+##### Why one runtime, not one per model family
+
+TorchTune ships one runtime per base model (`llama3_2`, `qwen2_5`) because its recipes and
+configs *are* per model: `tune run` selects a recipe and a model-specific config file, so the
+model family is baked into the runtime.
+
+TRL has no such axis. Its scripts are model-agnostic, and the model and dataset are ordinary
+flags the SDK sets per job. Mirroring the TorchTune layout would therefore produce N runtimes
+that differ only in a default flag value. The method is not an axis either: the manifest's
+`sft` module is the raw-YAML default, and an SDK-submitted `TrainJob` carries
 `command: [torchrun, -m]` with the method's module as the first entry of `args`
-(`TRLConfig.to_args()`, [II.7](#ii7-frameworkconfig-the-registry-and-trlconfig)), so one
-runtime serves every method.
+(`TRLConfig.to_args()`), so one runtime serves SFT, DPO and GRPO alike.
 
-**The server side stops here** — an image and manifests, no control-plane code. One gap is
-deferred rather than dismissed: none of this lets a runtime *report* its achieved world
-size, so a silently degraded run (the `trl-demo` shape, in any framework) is still
-indistinguishable from success at the control plane. See
-[Open Question #6](#open-questions).
+A runtime is still required, because the image must carry `trl` and its dependencies; the
+default `torch-distributed` runtime cannot run TRL.
 
----
+If a genuine axis appears later, the candidates are the *compute profile* (CPU, single-GPU,
+multi-GPU/vLLM for GRPO rollouts) rather than the model family. That would be additive: a
+second runtime with the same framework label, selected with `train(runtime=...)`.
 
-## Part II: Client Side (`kubeflow/sdk`)
+**Relationship to [#3718](https://github.com/kubeflow/trainer/pull/3718).** That PR proposes a
+per-method GRPO runtime (`cmd/trainers/grpo/`, `manifests/base/runtimes/grpo/`) with its own
+`train.py`. This KEP supersedes that layout: one `trl-trainer` image and one `trl-distributed`
+runtime cover GRPO through `trl.scripts.grpo`, with no bespoke training script to maintain. The
+GRPO work in #3718 lands as the `TRLGRPOConfig` and the GRPO E2E test rather than as a separate
+image.
 
-### II.1 Current limitations
+**The server side stops here** — an image and a manifest, no control-plane code.
 
-The SDK offers `CustomTrainer` (a flat dataclass taking `func`, `func_args`, `image`,
-`packages_to_install`, `pip_index_urls`, `num_nodes`, `resources_per_node`, `env`) and
-`BuiltinTrainer` (a single field, `config: TorchTuneConfig`).
+### Client Side (`kubeflow/sdk`)
 
-| # | Limitation | Impact |
-|---|---|---|
-| 1 | **Missing middle abstraction** | Most workloads fall between `BuiltinTrainer` (too specific) and `CustomTrainer` (too generic) |
-| 2 | **Mixed concerns in `CustomTrainer`** | Runtime env, scaling and training logic tangled in one dataclass |
-| 3 | **No framework validation** | Mismatched trainer/runtime pairs fail at execution, not submission |
-| 4 | **No typed framework arguments** | `max-restarts`, `deepspeed_config` have no home but the untyped `func_args` |
-| 5 | **`BuiltinTrainer` is not extensible** | A new config-driven framework means changing the class |
-| 6 | **No runtime auto-discovery** | `runtime=None` defaults to `torch-distributed` regardless of trainer type |
+#### Current limitations
 
-TorchTune is hardcoded at four points, and #3 is the one that blocks everything else:
+`BuiltinTrainer` has a single field, `config: TorchTuneConfig`. TorchTune is hardcoded at four
+points:
 
 | # | Coupling | Location |
 |---|---|---|
@@ -373,222 +436,17 @@ TorchTune is hardcoded at four points, and #3 is the one that blocks everything 
 | 3 | `trainer_type` and entrypoint selected by string-comparing the label against it | `utils.py:114-119`, `:140-158` |
 | 4 | Config-to-argument translation guarded by `isinstance(..., TorchTuneConfig)` | `utils.py:451-452` |
 
-`trainer_type` is not a field on the Runtime CR; the SDK computes it as `BUILTIN_TRAINER if
-framework == TORCH_TUNE else CUSTOM_TRAINER`. A runtime labelled `trl` therefore resolves to
-`CUSTOM_TRAINER` today and `ConfigTrainer.validate_runtime()` would reject it. Until
-`get_runtime_trainer()` changes, no config-driven framework but TorchTune can run.
+Coupling #3 is the one that blocks everything else. `trainer_type` is not a field on the
+Runtime CR; the SDK computes it as `BUILTIN_TRAINER if framework == TORCH_TUNE else
+CUSTOM_TRAINER`. A runtime labelled `trl` therefore resolves to `CUSTOM_TRAINER` today, and the
+SDK would try to build a training-function command for it. Until `get_runtime_trainer()`
+changes, no config-driven framework but TorchTune can run.
 
-### II.2 `BaseTrainer`
+#### `FrameworkConfig` and the registry
 
-```python
-@dataclass(kw_only=True)
-class BaseTrainer(ABC):
-    """Common fields, runtime auto-discovery and framework validation.
-
-    Subclasses use FuncTrainer or ConfigTrainer rather than inheriting directly.
-    supported_frameworks must match `trainer.kubeflow.org/framework` values, and
-    is ordered by preference — the first entry wins auto-discovery.
-    """
-    supported_frameworks: ClassVar[tuple[str, ...]]
-
-    num_nodes: Optional[int] = None
-    resources_per_node: Optional[dict] = None
-    image: Optional[str] = None
-
-    def __init_subclass__(cls, **kwargs: object) -> None:
-        """Reject a concrete subclass that forgot to declare supported_frameworks,
-        at class-definition time. Abstract intermediates (FuncTrainer,
-        ConfigTrainer) are skipped."""
-
-    def validate_runtime(self, runtime: "Runtime") -> None:
-        """Raise ValueError if the runtime's framework is unsupported."""
-        if runtime.trainer.framework not in self.supported_frameworks:
-            raise ValueError(...)
-```
-
-- `supported_frameworks` is a `ClassVar[tuple[...]]` — immutable, class-level, ordered by
-  preference. `__init_subclass__` catches a missing declaration at class-definition time.
-- `@dataclass(kw_only=True)`: `BaseTrainer`'s fields have defaults, so without it
-  `FuncTrainer.func` could not be required. Existing types keep their bare declarations —
-  their signatures are public API.
-- No shared argument-rendering method: `FuncTrainer` declares `get_framework_args()`, the
-  config-driven path renders through `config.to_args()`. A dict-shaped accessor on
-  `BaseTrainer` would duplicate `to_args()`.
-
-### II.3 `FuncTrainer` and the framework trainers
-
-```python
-@dataclass(kw_only=True)
-class FuncTrainer(BaseTrainer):
-    """The user provides a training function, executed in the distributed
-    environment the runtime configures.
-
-    func_args should hold only user hyperparameters — rdzv_endpoint, nnodes and
-    the rest are injected by the controller.
-    """
-    func: Callable
-    func_args: Optional[dict] = None
-
-    @abstractmethod
-    def get_framework_args(self) -> dict:
-        """Framework CLI/env arguments that do not overlap with controller-injected ones."""
-
-    def get_train_func(self) -> Callable: return self.func
-    def get_train_func_args(self) -> Optional[dict]: return self.func_args
-
-    def validate_runtime(self, runtime: "Runtime") -> None:
-        super().validate_runtime(runtime)
-        # FuncTrainer additionally requires trainer_type == CUSTOM_TRAINER.
-```
-
-Concrete trainers add only `supported_frameworks`, typed fields, and
-`get_framework_args()`:
-
-```python
-@dataclass
-class TorchTrainer(FuncTrainer):
-    supported_frameworks: ClassVar[tuple[str, ...]] = ("torch",)
-
-    max_restarts: Optional[int] = None       # torchrun --max-restarts
-    monitor_interval: Optional[float] = None # torchrun --monitor-interval
-
-    def get_framework_args(self) -> dict:
-        args = {}
-        if self.max_restarts is not None:
-            args["max-restarts"] = str(self.max_restarts)
-        if self.monitor_interval is not None:
-            args["monitor-interval"] = str(self.monitor_interval)
-        return args
-```
-
-| Trainer | `supported_frameworks` | Typed fields | Notes |
-|---|---|---|---|
-| `TorchTrainer` | `("torch",)` | `max_restarts`, `monitor_interval` | |
-| `DeepSpeedTrainer` | `("deepspeed", "torch")` | `deepspeed_config`, `num_proc_per_node` | Bootstraps via torchrun or mpirun, so it accepts both runtime types; when both exist the user picks explicitly. `deepspeed_config` accepts a path or a dict (JSON-encoded). |
-| `JAXTrainer` | `("jax",)` | — | `get_framework_args()` returns `{}` |
-| `XGBoostTrainer` | `("xgboost",)` | — | `get_framework_args()` returns `{}` |
-
-### II.4 `ConfigTrainer`
-
-```python
-@dataclass(kw_only=True)
-class ConfigTrainer(BaseTrainer):
-    """Config-driven trainers take no training function. The config fully
-    describes the job and the runtime's entrypoint executes it."""
-    config: FrameworkConfig
-
-    @property
-    def supported_frameworks(self) -> tuple[str, ...]:
-        """The framework is carried by the config, not fixed per class."""
-        return (self.config.framework,)
-
-    def validate_runtime(self, runtime: "Runtime") -> None:
-        super().validate_runtime(runtime)
-        # ConfigTrainer additionally requires trainer_type == BUILTIN_TRAINER.
-```
-
-A property rather than a `ClassVar`, because the framework comes from the instance's
-config. The `__init_subclass__` guard does not inspect its value here — it does not need
-to, since the registry already rejects a `FrameworkConfig` that declares no framework.
-
-`ConfigTrainer` is **not** subclassed per framework. `BuiltinTrainer` stays exactly where it
-is, keeping its construction signature; only its `config` field widens from `TorchTuneConfig`
-to `FrameworkConfig`. Both entry points then accept any framework:
-
-```python
-BuiltinTrainer(config=TorchTuneConfig(...))   # today, still valid
-ConfigTrainer(config=TRLConfig(...))          # new code, same machinery
-```
-
-| Aspect | `BuiltinTrainer` today | proposed |
-|---|---|---|
-| Runtime discovery | none (hardcoded) | auto via `config.framework` |
-| Framework validation | none | `validate_runtime()` |
-| `RuntimeConfig` support | no | yes |
-| Extension model | modify the class | add a `FrameworkConfig` subclass |
-
-### II.5 `RuntimeConfig`
-
-```python
-@dataclass
-class RuntimeConfig:
-    """Per-job runtime environment, separate from training-loop and scaling config.
-
-    Passed to TrainerClient.train() and applied whatever the trainer type.
-    """
-    packages_to_install: Optional[list[str]] = None
-    pip_index_urls: list[str] = field(
-        default_factory=lambda: list(constants.DEFAULT_PIP_INDEX_URLS))
-    env: Optional[dict[str, str]] = None
-```
-
-- A `@dataclass`, consistent with the rest of the SDK; field names match `CustomTrainer`'s
-  and KFP's `PipelinesClient`. Pip options are flat rather than a nested `PipConfig`.
-- A separate `train()` parameter rather than a trainer field: the same runtime settings
-  apply whatever the trainer type, and this leaves room to apply env to initializers later
-  without touching trainer classes.
-- **Merge semantics** are field-level: a `RuntimeConfig` field overrides the corresponding
-  `CustomTrainer` field only when it is not `None`. `RuntimeConfig(env=...)` alongside
-  `CustomTrainer(packages_to_install=[...])` preserves the packages.
-
-### II.6 `TrainerClient` and runtime auto-discovery
-
-```python
-def train(
-    self,
-    runtime: Optional[Union[str, "Runtime"]] = None,
-    initializer: Optional["Initializer"] = None,
-    trainer: Optional[Union[
-        "CustomTrainer", "CustomTrainerContainer", "BuiltinTrainer",
-        "BaseTrainer",                                   # NEW
-    ]] = None,
-    runtime_config: Optional["RuntimeConfig"] = None,    # NEW
-    options: Optional[list] = None,
-) -> str:
-```
-
-`_resolve_runtime()` lives on the client, not the backend, so behaviour is identical across
-backends. Given an explicit `runtime`, it calls `trainer.validate_runtime()`. Given `None`,
-it walks `supported_frameworks` in declaration order and takes the first framework with
-matches: exactly one match is selected; zero raises listing the available runtimes; more
-than one raises listing the candidates and asking for an explicit choice.
-
-So `DeepSpeedTrainer(("deepspeed", "torch"))` selects `torch-distributed` on a cluster with
-only that, and `deepspeed-mpi` without ambiguity on a cluster with both.
-
-`runtime=None` behaviour is deliberately split: `CustomTrainer` and `BuiltinTrainer` keep
-defaulting to `constants.DEFAULT_TRAINING_RUNTIME`, so existing code does not change;
-`BaseTrainer` subclasses get auto-discovery.
-
-**Validation is a hard fail, not a warning**, at three levels: framework label
-(`BaseTrainer`), `trainer_type` (`FuncTrainer` / `ConfigTrainer`), and framework-specific
-overrides. A `ValueError` before the CR is created beats a job that fails minutes later in
-the controller. The SDK checks only what it can know for certain (the label and the trainer
-type); the control plane still has the final say on quotas, policy and versions.
-
-Trainers are **plain data, not builders**. They hold the function or config, framework
-arguments, and scaling; the backend builds the `TrainJob` CR; the controller owns the
-distributed topology. So a new trainer needs no backend change, and a new backend needs no
-trainer change:
-
-```python
-def _build_trainer_cr(self, runtime, trainer):
-    # num_nodes, resources_per_node, image copied across as today.
-    if isinstance(trainer, FuncTrainer):
-        trainer_cr.command = get_command_using_train_func(runtime, trainer.get_train_func(), ...)
-        trainer_cr.args = [f"--{k}={v}" for k, v in trainer.get_framework_args().items()]
-    elif isinstance(trainer, ConfigTrainer):
-        # Entrypoint comes from the runtime, exactly as today. Each config
-        # renders its own args, so there is no framework branch here.
-        trainer_cr.command = list(runtime.trainer.command)
-        trainer_cr.args = trainer.config.to_args()
-```
-
-### II.7 `FrameworkConfig`, the registry, and `TRLConfig`
-
-A config knows three things nothing else knows: the framework label it claims, the
-entrypoint that runs it, and how it renders itself as that entrypoint's arguments. Those are
-couplings #1–#4 from [II.1](#ii1-current-limitations), moved onto one object.
+A config knows three things nothing else knows: the framework label it claims, the entrypoint
+that runs it, and how it renders itself as that entrypoint's arguments. Those are all four
+couplings above, moved onto one object.
 
 ```python
 @dataclass(kw_only=True)
@@ -601,11 +459,11 @@ class FrameworkConfig(abc.ABC):
         """Render this config as arguments for `command`."""
 ```
 
-`to_args()` renders only the config's own fields and takes no initializer: configs stay
-plain dataclasses, so nothing in `types.py` needs to know how a backend stages data.
+`to_args()` renders only the config's own fields and takes no initializer: configs stay plain
+dataclasses, so nothing in `types.py` needs to know how a backend stages data.
 
-The framework label resolves through a registry rather than a constant. It serves exactly
-one lookup — `get_runtime_trainer()`'s — and is the out-of-tree extension path:
+The framework label resolves through a registry rather than a constant. It serves exactly one
+lookup — `get_runtime_trainer()`'s — and is the out-of-tree extension path:
 
 ```python
 # kubeflow/trainer/types/registry.py
@@ -623,32 +481,69 @@ def get_framework(framework: str) -> Optional[type["FrameworkConfig"]]:
 ```
 
 An explicit decorator, matching how the control plane registers its plugins by hand in
-`plugins/registry.go` ([sdk#310](https://github.com/kubeflow/sdk/pull/310) is the PoC for
-this shape). There is no automatic discovery: a config must be imported before it can be
+`plugins/registry.go` ([sdk#310](https://github.com/kubeflow/sdk/pull/310) is the PoC for this
+shape). There is no automatic discovery: a config must be imported before it can be
 constructed, and importing it registers it.
 
-`TorchTuneConfig` keeps every field and its signature, gaining
-`framework = "torchtune"`, `command = ("tune", "run")`, and a `to_args()` delegating to the
-existing emitter.
+`TorchTuneConfig` keeps every field and its signature, gaining `framework = "torchtune"`,
+`command = ("tune", "run")`, and a `to_args()` delegating to the existing emitter.
+
+#### `TRLConfig` and the per-method configs
+
+`TRLConfig` carries the fields shared by every TRL method, and one typed slot — `method` —
+holding the config for the method being run. The subclass in that slot selects the script
+module.
 
 ```python
 # kubeflow/trainer/types/trl.py
 
-class TRLMethod(Enum):
-    """Post-training method; the value names the TRL script module
-    (trl/scripts/<method>.py), launched as `torchrun -m trl.scripts.<method>`."""
-    SFT = "sft"; DPO = "dpo"; GRPO = "grpo"
+@dataclass(kw_only=True)
+class TRLMethodConfig(abc.ABC):
+    """Per-method TRL config. The subclass selects trl.scripts.<module>."""
+    module: ClassVar[str]
+
+    @abstractmethod
+    def to_args(self) -> list[str]:
+        """Render the method-specific flags."""
+
+
+@dataclass(kw_only=True)
+class TRLSFTConfig(TRLMethodConfig):
+    module: ClassVar[str] = "sft"
+    loss_type: Optional[Literal["nll", "dft", "chunked_nll"]] = None
+    packing: Optional[bool] = None
+    completion_only_loss: Optional[bool] = None
+
+
+@dataclass(kw_only=True)
+class TRLDPOConfig(TRLMethodConfig):
+    module: ClassVar[str] = "dpo"
+    beta: Optional[float] = None                    # deviation from the reference model
+    loss_type: Optional[list[str]] = None           # combinable; weighted by loss_weights
+    loss_weights: Optional[list[float]] = None
+
+
+@dataclass(kw_only=True)
+class TRLGRPOConfig(TRLMethodConfig):
+    module: ClassVar[str] = "grpo"
+    beta: Optional[float] = None                    # KL coefficient
+    loss_type: Optional[Literal[
+        "grpo", "dr_grpo", "dapo", "bnpo", "cispo", "sapo", "luspo", "vespo"]] = None
+    num_generations: Optional[int] = None
+    reward_funcs: Optional[list[str]] = None
+
 
 @register_framework
-@dataclass
+@dataclass(kw_only=True)
 class TRLConfig(FrameworkConfig):
     framework: ClassVar[str] = "trl"
-    # torchrun launches TRL's plain training script as a module (see I.2/I.6);
-    # to_args() supplies the module name as the first positional argument, so
-    # the full argv is `torchrun -m trl.scripts.<method> --flag value ...`.
+    # torchrun launches TRL's plain training script as a module; to_args()
+    # supplies the module name as the first positional argument, so the full
+    # argv is `torchrun -m trl.scripts.<module> --flag value ...`.
     command: ClassVar[tuple[str, ...]] = ("torchrun", "-m")
 
-    method: TRLMethod
+    method: TRLMethodConfig                         # the typed slot
+
     model_name_or_path: str
     dataset_name: str
 
@@ -662,61 +557,103 @@ class TRLConfig(FrameworkConfig):
     lora_alpha: Optional[int] = None
     lora_target_modules: Optional[list[str]] = None
 
-    beta: Optional[float] = None              # DPO, GRPO
-    num_generations: Optional[int] = None     # GRPO
-    reward_funcs: Optional[list[str]] = None  # GRPO
-
-    # Fields valid only for a subset of methods; anything absent applies to all.
-    _METHOD_SCOPED_FIELDS: ClassVar[dict[str, frozenset[TRLMethod]]] = {
-        "beta": frozenset({TRLMethod.DPO, TRLMethod.GRPO}),
-        "num_generations": frozenset({TRLMethod.GRPO}),
-        "reward_funcs": frozenset({TRLMethod.GRPO}),
-    }
-
-    def __post_init__(self) -> None:
-        self.validate()   # raises ValueError on a field set for the wrong method,
-                          # or on method=grpo without reward_funcs
-
     def to_args(self) -> list[str]:
-        """Render as [trl.scripts.<method>, --flag, value, ...]: the module name
-        first (torchrun's -m positional), then the script flags — bools become
-        store_true flags, lists expand after their flag, everything else is
-        --name value."""
+        """[trl.scripts.<module>, --flag, value, ...]: the module name first
+        (torchrun's -m positional), then shared flags, then the method's own.
+        Bools become store_true flags, lists expand after their flag."""
+        return (
+            [f"trl.scripts.{self.method.module}"]
+            + self._shared_args()
+            + self.method.to_args()
+        )
 ```
 
-Users reach both through the trainer they already know:
+##### Why the shared fields sit on the outer config
+
+The fields on `TRLConfig` are the ones TRL itself shares. `SFTConfig`, `DPOConfig` and
+`GRPOConfig` all inherit HF `TrainingArguments`, and TRL's own `GRPOConfig` docstring says it
+"includes only the parameters that are specific to GRPO training. For a full list of training
+arguments, please refer to the `TrainingArguments` documentation." Splitting along the same
+seam means each field is declared once, and the split matches upstream rather than inventing
+one.
+
+`model_name_or_path` and `dataset_name` come from `ModelConfig` and `ScriptArguments`, which
+are also method-independent, so they belong outside too.
+
+#### Choosing the config shape
+
+Three shapes were considered. The one above is B.
+
+| | **A. Flat + method enum** | **B. Typed slot** (chosen) | **C. Top-level per-method configs** |
+|---|---|---|---|
+| Call | `TRLConfig(method=TRLMethod.GRPO, beta=0.04)` | `TRLConfig(method=TRLGRPOConfig(beta=0.04), ...)` | `BuiltinTrainer(config=TRLGRPOConfig(...))` |
+| Wrong-method parameter | accepted, then **silently dropped by TRL** | `TypeError` at construction | `TypeError` at construction |
+| Conflicting field types | **cannot be typed** — see below | each declared once, correctly | each declared once, correctly |
+| Shared fields | declared once | declared once | **duplicated** per class, or need a shared base |
+| Registry | one config per framework ✓ | one config per framework ✓ | **N configs claim one label** — needs a registry redesign |
+| Adding a method | one enum member + one map entry | one dataclass | one dataclass + a new export + registry change |
+
+**Why A cannot be typed.** The same parameter name has a different type and different valid
+values per method, verified against TRL's config sources:
+
+| Field | `SFTConfig` | `DPOConfig` | `GRPOConfig` |
+|---|---|---|---|
+| `loss_type` | `str \| None`; `'nll'`, `'dft'`, `'chunked_nll'` | `list[str]`, default `["sigmoid"]`; 15 values, combinable | `str`, default `"dapo"`; `'grpo'`, `'dr_grpo'`, `'dapo'`, `'bnpo'`, `'cispo'`, … |
+| `beta` | — | `float = 0.1`, deviation from the **reference model** | `float = 0.0`, **KL coefficient** |
+
+A flat dataclass must pick one annotation for `loss_type`, so it is either wrong for two
+methods or degraded to `Any`. And `beta` is one name for two different quantities with
+different defaults, which no annotation can disambiguate.
+
+**Why the type error matters here specifically.** TRL's scripts call
+`parser.parse_args_and_config(fail_with_unknown_args=False)`, so an argument that does not
+belong to the method being run is **ignored, not rejected**. A user who sets `num_generations`
+on an SFT job gets a successful run that silently ignored it. Shape A pushes that detection to
+nowhere; shape B turns it into a `TypeError` before the TrainJob is created.
+
+The current draft's `_METHOD_SCOPED_FIELDS` map was an attempt to recover this at runtime. It
+has to be maintained either way, so expressing it as subclasses removes a hand-maintained map
+rather than adding one.
+
+**Why not C.** It reads best at the call site, but the registry is keyed one config per
+framework label, and three classes claiming `trl` would need it redesigned to represent one
+framework's internal methods. Shared fields would also be duplicated across the three classes
+or hoisted into a shared base — at which point the base *is* shape B's outer config, without
+the single entry point.
+
+**Precedent.** The typed slot is the ordinary shape for "one of N variants, plus shared
+settings": Keras `compile(optimizer=...)` takes an `Optimizer` instance with the shared
+hyperparameters on the base class; `tf.data.Options` holds nested typed option objects
+(`autotune`, `threading`, `experimental_optimization`); scikit-learn meta-estimators take
+estimator *objects* as parameters (`GridSearchCV(estimator=..., cv=...)`); and in the Trainer's
+own API, `MLPolicy` carries an `MLPolicySource` union whose member selects the behaviour. TRL
+itself is organized this way, one config class per trainer.
+
+##### Naming the slot: `method`
+
+Both `method` and `trainer` were proposed. This KEP uses **`method`**, because the user already
+writes `train(trainer=BuiltinTrainer(...))`, so a nested `trainer=` inside that call would use
+one word for two different things. "Method" is also the word the ecosystem uses for the SFT /
+DPO / GRPO axis — TRL's README calls them "fine-tuning methods" reached "via trainers" — and it
+matches how sibling KEPs name a variant slot after the concept
+(KEP-3562's `algorithm=RandomSearch()`).
+
+#### Wiring it up
+
+`BuiltinTrainer` stays exactly where it is and keeps its construction signature; only its
+`config` field widens from `TorchTuneConfig` to `FrameworkConfig`. Both entry points then
+accept any framework:
 
 ```python
-TrainerClient().train(
-    trainer=BuiltinTrainer(
-        config=TRLConfig(
-            method=TRLMethod.DPO,
-            model_name_or_path="Qwen/Qwen2.5-0.5B",
-            dataset_name="trl-lib/ultrafeedback_binarized",
-            beta=0.1,
-        ),
-        num_nodes=2,
-        resources_per_node={"gpu": 1},
-    ),
-)
+BuiltinTrainer(config=TorchTuneConfig(...))   # today, still valid
+BuiltinTrainer(config=TRLConfig(...))         # new, same machinery
 ```
 
-**Design decisions**
+Three call sites change, and each one *loses* a branch:
 
-- **The framework is a config, not a trainer subclass.** A `BuiltinTrainer` holding a
-  `TRLConfig` and one holding a `TorchTuneConfig` differ in data, not behaviour: the trainer
-  hands `command` and `to_args()` to the backend either way. So `BuiltinTrainer(config=...)`
-  stays the single config-driven entry point. (Alternative 8.)
-- **Method is a field, not a config subclass.** TRL's methods differ only in which fields
-  apply. Adding `kto` is one enum member and one map entry — no export, no backend change.
-  (Alternative 7.)
-- **`command` and `framework` are `ClassVar`s on the config, but `RuntimeTrainer.command`
-  stays the field consumers read.** That field is not config-specific:
-  `command[0] == "mpirun"` drives MPI detection, `get_runtime_packages` rewrites it for
-  single-process, and the localprocess backend joins it into an entrypoint. Moving it onto
-  the config would special-case all of those. Instead `get_runtime_trainer()` resolves it
-  through the registry, replacing the `framework == TORCH_TUNE` branch at `utils.py:150-158`
-  and deleting `constants.TORCH_TUNE_COMMAND`:
+- **`get_runtime_trainer()` resolves the command through the registry**, replacing the
+  `framework == TORCH_TUNE` branch at `utils.py:150-158` and deleting
+  `constants.TORCH_TUNE_COMMAND`:
 
   ```python
   if config_cls := registry.get_framework(framework):
@@ -726,39 +663,40 @@ TrainerClient().train(
   # ... mpi, default unchanged
   ```
 
-  Adding a framework then adds no lines to `utils.py`.
-- **`trainer_type` comes from the registry.** `BUILTIN_TRAINER` when `get_framework()` finds
-  a registered config, `CUSTOM_TRAINER` otherwise — replacing `utils.py:114-119` and
-  deleting the `TORCH_TUNE` constant. The framework label stays the sole discovery key.
-- **Each config renders itself, so the backend has no framework branch.** One line —
-  `trainer_cr.args = trainer.config.to_args()` — deletes the `isinstance` check at
-  `utils.py:451-452` rather than relocating it. This is the one-time change that makes a
-  *further* framework require none.
-- **TorchTune's initializer-derived dataset overrides stay in the backend.** The
-  `dataset.data_files=` / `data_dir=` args are computed from the HF dataset initializer,
-  which is staging knowledge the backend owns; they are appended to whatever `to_args()`
-  renders. `TRLConfig` needs nothing from the initializer.
-- **`TorchTuneConfig.to_args()` delegates to the existing emitter.**
-  `get_args_from_peft_config` maps `LoraConfig` onto nested `model.*` keys; a flat
-  `key=value` walk would emit `lora_rank=8` instead of `model.lora_rank=8` and fail the job.
-  The emitters move verbatim to `types/torchtune.py` — they hold no Kubernetes logic, and
-  leaving them in the backend would make `types.py` import a backend module.
-- **Registration happens at import time; a later registration wins.** `TRLConfig` must be exported from
-  `kubeflow/trainer/__init__.py`, or a process that never imports it finds no claimant for
-  `trl` and treats the runtime as function-driven. Shadowing lets a fork replace a stalled
-  in-tree config without an upstream commit.
-- **Named `FrameworkConfig`, not the earlier draft's `LLMBackend`.** `backends/` here means
-  *execution* backend, and nothing about this object is LLM-specific.
-- **`LoraConfig` is not reused for TRL.** It is TorchTune-shaped — `apply_lora_to_output`
-  and `quantize_base` have no TRL analogue, and TRL's PEFT surface is `--use_peft` /
-  `--lora_r` / `--lora_alpha` / `--lora_target_modules`. Sharing it needs a lossy translation.
-- **Unsloth is a runtime-image concern.** An Unsloth-accelerated image is still labelled
-  `framework: trl`, so it resolves to the same config and is chosen with `train(runtime=...)`.
-  No SDK field.
-- **Nothing is deprecated.** `BuiltinTrainer(config=TorchTuneConfig(...))` produces
-  byte-identical `TrainJob` arguments. No successor class, no `FutureWarning`.
+- **`trainer_type` comes from the registry**: `BUILTIN_TRAINER` when `get_framework()` finds a
+  registered config, `CUSTOM_TRAINER` otherwise — replacing `utils.py:114-119` and deleting the
+  `TORCH_TUNE` constant. The framework label stays the sole discovery key.
 
-### II.8 Which framework, and why TRL
+- **The backend has no framework branch.** One line —
+  `trainer_cr.args = trainer.config.to_args()` — deletes the `isinstance` check at
+  `utils.py:451-452` rather than relocating it. `command` still comes from the runtime, exactly
+  as today.
+
+`RuntimeTrainer.command` stays the field consumers read. It is not config-specific:
+`command[0] == "mpirun"` drives MPI detection, `get_runtime_packages` rewrites it for
+single-process, and the localprocess backend joins it into an entrypoint. Moving it onto the
+config would special-case all of those.
+
+Adding a further framework then adds no lines to `utils.py` and none to the backends. That is
+the one-time change this KEP is buying.
+
+Two details preserved from the TorchTune path:
+
+- **TorchTune's initializer-derived dataset overrides stay in the backend.** The
+  `dataset.data_files=` / `data_dir=` args are computed from the HF dataset initializer, which
+  is staging knowledge the backend owns; they are appended to whatever `to_args()` renders.
+  `TRLConfig` needs nothing from the initializer.
+- **`TorchTuneConfig.to_args()` delegates to the existing emitter.** `get_args_from_peft_config`
+  maps `LoraConfig` onto nested `model.*` keys; a flat `key=value` walk would emit `lora_rank=8`
+  instead of `model.lora_rank=8` and fail the job. The emitters move verbatim to
+  `types/torchtune.py` — they hold no Kubernetes logic, and leaving them in the backend would
+  make `types.py` import a backend module.
+
+`LoraConfig` is **not** reused for TRL. It is TorchTune-shaped — `apply_lora_to_output` and
+`quantize_base` have no TRL analogue, and TRL's PEFT surface is `--use_peft` / `--lora_r` /
+`--lora_alpha` / `--lora_target_modules`. Sharing it would need a lossy translation.
+
+#### Which framework, and why TRL
 
 | Framework | Post-training methods | Maintenance | Argument shape | torchrun path |
 |---|---|---|---|---|
@@ -768,29 +706,19 @@ TrainerClient().train(
 | Axolotl | Broad, but its GRPO is TRL's `GRPOTrainer` | Active | config file | native with `--launcher torchrun` (default is accelerate) |
 | Unsloth | None of its own; an acceleration layer | Active | n/a | n/a — not a launcher |
 
-TRL is selected on three grounds. Its per-method scripts cover what the SDK cannot express
-at all today — DPO and GRPO. It is the engine rather than a wrapper: LlamaFactory and
-Axolotl are both built on the HF `Trainer` and PEFT, so an in-tree TRL trainer adds
-capability where an in-tree wrapper would add a second surface over the same engine. And its
-scripts take flags, so `TRLConfig` renders straight into `args`; a file-first framework
-would need the SDK to stage a ConfigMap or volume first. TRL is also the cleanest fit for
-the torchrun-first pattern: its scripts are launched by torchrun directly, with no wrapper
-CLI and no environment renaming in the path.
+TRL is selected on three grounds. Its per-method scripts cover what the SDK cannot express at
+all today — DPO and GRPO. It is the engine rather than a wrapper: LlamaFactory and Axolotl are
+both built on the HF `Trainer` and PEFT, so an in-tree TRL trainer adds capability where an
+in-tree wrapper would add a second surface over the same engine. And its scripts take flags, so
+`TRLConfig` renders straight into `args`; a file-first framework would need the SDK to stage a
+ConfigMap or volume first.
 
 Choosing TRL first closes no doors: every alternative reaches the SDK out of tree as a
-`FrameworkConfig` subclass, which is why LlamaFactory is the reference out-of-tree
-framework. GRPO via TRL is already in flight in the Trainer
-([#3508](https://github.com/kubeflow/trainer/issues/3508),
-[#3718](https://github.com/kubeflow/trainer/pull/3718)); this proposal provides the surface
-for that effort rather than a parallel track.
+`FrameworkConfig` subclass, which is why LlamaFactory is the reference out-of-tree framework.
+An Unsloth-accelerated image is still labelled `framework: trl`, so it resolves to the same
+config and is chosen with `train(runtime=...)` — no SDK field.
 
-**Risk:** TRL's surface is not frozen, and a typed dataclass mirroring its flags will drift.
-`TRLConfig` targets the script flags rather than the Python API, so a TRL upgrade changes
-the image rather than the SDK type, and the drift is confined to the one config class.
-
----
-
-## Migration and Backward Compatibility
+### Migration and Backward Compatibility
 
 **Server side.** Additive; no existing code path is touched.
 
@@ -800,64 +728,78 @@ the image rather than the SDK type, and the drift is confined to the one config 
 | Torch plugin | **No change.** Neither `EnforceMLPolicy` nor `Validate` is touched; TRL falls through the default path. A unit test asserts it stays that way. |
 | Plugin registry | **No change.** TRL reuses the torch plugin via `mlPolicy.torch`. |
 | Existing TorchTune runtimes | **No change.** Same images, manifests, rendered `TrainJob`s. |
-| Default manifests | **Additive.** New runtimes under a new name prefix; nothing renamed or removed. |
+| Default manifests | **Additive.** A new runtime under a new name; nothing renamed or removed. |
 
 **Client side.** Additive.
 
 | Aspect | Impact |
 |---|---|
 | `CustomTrainer`, `CustomTrainerContainer` | **No change.** All fields retained. |
-| `BuiltinTrainer` | **Construction signature unchanged**; produces byte-identical `TrainJob` arguments. `config` widens to `FrameworkConfig`. Nothing deprecated. |
-| `TrainerClient.train()` | **Additive.** `runtime_config` is optional, defaulting to `None`; the `trainer` union gains `BaseTrainer`. |
-| `TrainJobTemplate` | **No change** in this proposal. |
+| `BuiltinTrainer` | **Construction signature unchanged**; produces byte-identical `TrainJob` arguments for TorchTune. `config` widens to `FrameworkConfig`. Nothing deprecated. |
+| `TorchTuneConfig` | **No change** to fields or signature; gains two `ClassVar`s and `to_args()`. |
+| `TrainerClient.train()` | **No change** to the signature. |
+| `TrainJobTemplate` | **No change.** |
 | Python version | No new floor. `kw_only=True` needs 3.10, already the SDK's minimum. |
-| Public exports | New names only: `BaseTrainer`, `FuncTrainer`, `ConfigTrainer`, `TorchTrainer`, `DeepSpeedTrainer`, `JAXTrainer`, `XGBoostTrainer`, `RuntimeConfig`, `FrameworkConfig`, `TRLConfig`, `TRLMethod`. Nothing removed or renamed. |
+| Public exports | New names only: `FrameworkConfig`, `TRLConfig`, `TRLMethodConfig`, `TRLSFTConfig`, `TRLDPOConfig`, `TRLGRPOConfig`. Nothing removed or renamed. |
 
-## Test Plan
+### Test Plan
 
-**Server-side Go unit tests** (`torch_test.go`, extending the table-driven cases). Two
-cases, asserted alongside each other so the paths stay visibly distinct: a
-`[torchrun, -m, trl.scripts.sft]` command is left alone and gets all five `PET_*`,
-including the master vars the TorchTune path suppresses; a `[tune, run]` command is still
-rewritten. The first is the regression guard for
-[I.5](#i5-what-changes-in-the-plugin) — it fails the moment anyone adds a TRL branch to
-the plugin.
+**Server-side Go unit tests** (`torch_test.go`, extending the table-driven cases). Two cases,
+asserted alongside each other so the paths stay visibly distinct: a
+`[torchrun, -m, trl.scripts.sft]` command is left alone and gets all five `PET_*`, including
+the master vars the TorchTune path suppresses; a `[tune, run]` command is still rewritten. The
+first is the regression guard for
+[What changes in the plugin](#what-changes-in-the-plugin) — it fails the moment anyone adds a
+TRL branch to the plugin.
 
-**Manifest tests** — each `manifests/base/runtimes/trl/*.yaml` carries `framework: trl`,
-`mlPolicy.torch: {}`, `command: [torchrun, -m, trl.scripts.<method>]`, and mounts
-`initializer` at `/workspace`.
+**Manifest tests** — `manifests/base/runtimes/trl/` carries `framework: trl`,
+`mlPolicy.torch: {}`, `command: [torchrun, -m, trl.scripts.sft]`, and mounts `initializer` at
+`/workspace`.
 
-**Launch-path test** — `examples/trl/local_torchrun_proof.sh` (already committed and
-passing, see [I.3](#i3-proof-of-concept)): two `torchrun -m trl.scripts.sft` launches with
-only the five `PET_*` variables set must form world size 2, asserted by the per-step
-epoch value (`0.0588` → `0.1111`); the single-node control run guards the assertion itself.
-Re-run on every `trl` version bump in `requirements.txt`.
+**Launch-path test** — `examples/trl/local_torchrun_proof.sh` (already committed and passing,
+see [Proof of concept](#proof-of-concept)): two `torchrun -m trl.scripts.sft` launches with only
+the five `PET_*` variables set must form world size 2, asserted by the per-step epoch value
+(`0.0588` → `0.1111`); the single-node control run guards the assertion itself. Re-run on every
+`trl` version bump in `requirements.txt`.
 
-**E2E** — a two-node TRL `TrainJob` reaches `Complete` **and** its logs show the two-node
-epoch increment. Asserting completion alone would have passed for the accelerate failure in
-[I.4](#i4-limitation-the-trl-cli-and-accelerate-launch); the world-size assertion is the
-part with teeth. Runs on CPU — no GPU gate needed for the launch path.
+#### Unit Tests
 
-**Client-side unit tests** — type-hierarchy compliance; `validate_runtime()` positive,
-negative framework, and negative `trainer_type`; `get_framework_args()` excludes
-controller-injected arguments; `RuntimeConfig` defaults and merge precedence; auto-discovery
-with one, zero and several matches (the last two raising, with names in the message).
+Client side:
 
-**Client-side integration tests** — `TorchTrainer` end-to-end on the Kubernetes and
-Container backends; `RuntimeConfig` packages installed and env set. Plus the **cross-repo
-contract**: with the `trl-qwen2.5-1.5b` runtime installed,
-`BuiltinTrainer(config=TRLConfig(...))` resolves it by label, yields
-`trainer_type == BUILTIN_TRAINER`, and emits `command: [torchrun, -m]` with
-`args == config.to_args()` (module name first). This single assertion ties the two parts
-together and fails if either side changes the label or the launch shape.
+- `to_args()` for each of `TRLSFTConfig`, `TRLDPOConfig`, `TRLGRPOConfig`: the module name is
+  the first element; bools render as store_true flags; lists expand after their flag.
+- Passing a method-specific parameter to the wrong method config raises `TypeError`.
+- `register_framework` rejects a config declaring no framework or no command.
+- `get_runtime_trainer()` resolves `trainer_type` and `command` from the registry for both
+  `torchtune` and `trl`, and falls through to torch/mpi/default for unregistered labels.
+- `TorchTuneConfig.to_args()` emits nested `model.*` keys for `LoraConfig`, matching the
+  current emitter byte for byte.
+
+#### Integration tests
+
+- With the `trl-distributed` runtime installed, `BuiltinTrainer(config=TRLConfig(...))` resolves
+  it by label, yields `trainer_type == BUILTIN_TRAINER`, and emits `command: [torchrun, -m]`
+  with `args == config.to_args()` (module name first). This is the **cross-repo contract**: it
+  fails if either side changes the label or the launch shape.
+- `BuiltinTrainer(config=TorchTuneConfig(...))` produces byte-identical `TrainJob` arguments to
+  the current implementation.
+
+#### E2E tests
+
+- A two-node TRL `TrainJob` reaches `Complete` **and** its logs show the two-node epoch
+  increment. Asserting completion alone would have passed for the accelerate failure in
+  [Limitation: the TRL CLI and `accelerate launch`](#limitation-the-trl-cli-and-accelerate-launch);
+  the world-size assertion is the part with teeth. Runs on CPU — no GPU gate needed for the
+  launch path.
+- `dpo` and `grpo` exercised end to end, not only `sft` (Beta).
 
 **Backward compatibility** — every existing `CustomTrainer`, `BuiltinTrainer` and
 `TrainJobTemplate` test passes unmodified.
 
-## Implementation Plan
+### Implementation Plan
 
-The parts are independent. Part I ships first because it is smaller and because Part II's
-integration tests need a TRL runtime to run against.
+The two sides are independent. The server side ships first because it is smaller and because
+the client-side integration tests need a TRL runtime to run against.
 
 **Server side**
 
@@ -865,144 +807,183 @@ integration tests need a TRL runtime to run against.
 |---|---|
 | S1 | `cmd/trainers/trl/` with pinned versions, the launch-path proof script, image publishing in the existing workflow |
 | S2 | `manifests/base/runtimes/trl/` + kustomization entry, manifest tests, an `examples/trl/` TrainJob |
-| S3 | The `torch_test.go` regression cases, then the two-node cluster E2E (CPU is sufficient — the launch path is device-agnostic). |
+| S3 | The `torch_test.go` regression cases, then the two-node cluster E2E (CPU is sufficient — the launch path is device-agnostic) |
 
-S1 and S2 must ship together: a manifest referencing an unpublished image is untestable, and
-an image with no manifest is unreachable.
+S1 and S2 must ship together: a manifest referencing an unpublished image is untestable, and an
+image with no manifest is unreachable.
 
 **Client side**
 
 | Phase | Contents |
 |---|---|
-| 1 | `BaseTrainer`, `FuncTrainer`, `ConfigTrainer`, `RuntimeConfig`, `_resolve_runtime()`, the `train()` signature, unit tests |
-| 2 | `TorchTrainer`; `FuncTrainer` / `ConfigTrainer` dispatch in all three backends; integration tests; docs |
-| 3 | `DeepSpeedTrainer` (multi-runtime), `JAXTrainer`, `XGBoostTrainer` |
-| 4 | Public exports, sdk.kubeflow.org documentation, migration guide |
+| C1 | `FrameworkConfig`, the registry, `TorchTuneConfig` migrated onto it, `BuiltinTrainer.config` widened, the three call-site changes; unit tests. No user-visible change yet. |
+| C2 | `TRLConfig` and the three method configs; public exports; integration tests including the cross-repo contract |
+| C3 | Docs on sdk.kubeflow.org and an operator guide for building a runtime image for a new framework |
 
-Phases 1 and 2 must ship in the same release: the type hierarchy without backend support
-makes `TorchTrainer` importable but unusable, failing with a confusing `ValueError`.
+C1 is a pure refactor with no behaviour change, so it can merge on its own; C2 is what makes
+TRL reachable from Python.
 
-## Graduation Criteria
+### Graduation Criteria
 
-**Alpha** — *Server:* the `trl-trainer` image is published and at least one runtime installs
-by default; a two-node TRL job completes with `world_size == numNodes × numProcPerNode`,
-verified in E2E rather than from job status; the torch plugin is unchanged, with a test
-asserting it. *Client:* the type hierarchy and
-`RuntimeConfig` are implemented and exported; `TorchTrainer` works on all three backends;
-auto-discovery and `validate_runtime()` are functional and covered; merge semantics tested;
-all existing tests pass.
+**Alpha**
 
-**Beta** — `DeepSpeedTrainer`, `JAXTrainer`, `XGBoostTrainer`; `TRLConfig` alongside
-`TorchTuneConfig`, proving the extension model with no new trainer class; TRL runtimes for
-the model families TorchTune covers, with `dpo` and `grpo` exercised end-to-end, not only
-`sft`; an out-of-tree config published **paired with an out-of-tree runtime image**, proving
-both halves of the extension path (LlamaFactory is the reference — torchrun-wrapped rather
-than torchrun-native); the torchrun-first launch pattern documented on kubeflow.org as
-operator guidance for building a runtime image; SDK docs and a migration guide.
+- *Server:* the `trl-trainer` image is published and the `trl-distributed` runtime installs by
+  default; a two-node TRL job completes with `world_size == numNodes × numProcPerNode`, verified
+  in E2E rather than from job status; the torch plugin is unchanged, with a test asserting it.
+- *Client:* `FrameworkConfig` and the registry are implemented; `TorchTuneConfig` runs through
+  them with byte-identical output; `TRLConfig` with SFT is exported and works end to end; all
+  existing tests pass.
 
-**GA** — Tier 1 trainers stable for a release; `BuiltinTrainer` and `CustomTrainer`'s
-runtime-environment fields formally deprecated; at least one community `ConfigTrainer`
-subclass; a runtime can report its achieved world size to `TrainJob` status, so a silently
-degraded run is observable (Open Question #6).
+**Beta**
+
+- `dpo` and `grpo` exercised end to end, not only `sft`.
+- An out-of-tree config published **paired with an out-of-tree runtime image**, proving both
+  halves of the extension path (LlamaFactory is the reference — torchrun-wrapped rather than
+  torchrun-native).
+- The torchrun-first launch pattern documented on kubeflow.org as operator guidance for building
+  a runtime image.
+- SDK reference docs for `TRLConfig` and the method configs.
+
+**GA**
+
+- `TRLConfig` stable for a release, with the TRL version pin exercised by CI on every bump.
+- At least one community `FrameworkConfig` subclass in the wild.
+- A runtime can report its achieved world size to `TrainJob` status, so a silently degraded run
+  is observable (see [Open Questions](#open-questions)).
 
 ## Open Questions
 
-1. **DeepSpeed launcher detection.** `DeepSpeedTrainer` supports torchrun and mpirun; the
-   `Runtime` type exposes no launcher metadata. Inspect `runtime.trainer.command`, add a
-   launcher label, or defer to the controller?
-2. **Does dynamic registration extend to the control plane?** *Partly answered.* The registry
-   is SDK-side and stays there — Part I shows a new runtime needs no control-plane
+1. **Should a runtime report its achieved world size?** The largest gap left open, and not
+   TRL-specific. The `trl-demo` failure exited 0 on both pods, so a two-node job that trained
+   two isolated copies was indistinguishable from one that trained jointly. torchrun-first
+   removes that particular cause but not the class: any image whose launch degrades silently
+   produces the same signature. A minimal mechanism: rank 0 reports the world size it joined
+   with, and the controller surfaces it as a status condition, failing the job when it disagrees
+   with `numNodes × numProcPerNode`. That is a control-plane change, out of scope here — but
+   without it, "the TrainJob succeeded" is not evidence that distributed training happened.
+   [KEP-2779](../2779-trainjob-progress/README.md) already establishes a runtime→status channel
+   this could reuse.
+2. **Does dynamic registration extend to the control plane?** *Partly answered.* The registry is
+   SDK-side and stays there — the server side shows a new runtime needs no control-plane
    registration at all, only an image and a manifest. Open: whether the Trainer should
    *provision* runtimes for frameworks it does not ship (e.g. from a catalog CR).
-3. **Observability.** Should the SDK log the auto-discovered runtime and framework at `INFO`?
-4. **`resources_per_node` typing.** Should the untyped `Optional[dict]` become a structured
-   `ResourceRequirements` dataclass?
-5. **Backend validation safety net.** Should backends call `validate_runtime()` defensively,
-   in case a trainer is passed to a backend directly?
-6. **Should a runtime report its achieved world size?** The largest gap left open, and not
-   TRL-specific. The `trl-demo` failure in
-   [I.4](#i4-limitation-the-trl-cli-and-accelerate-launch) exited 0 on both pods, so a
-   two-node job that trained two isolated copies was indistinguishable from one that trained
-   jointly. torchrun-first removes that particular cause but not the class: any image whose
-   launch degrades silently produces the same signature. A minimal mechanism: rank 0 reports
-   the world size it joined with, and the controller surfaces it as a status condition,
-   failing the job when it disagrees with `numNodes × numProcPerNode`. That is a
-   control-plane change, out of scope here — but without it, "the TrainJob succeeded" is not
-   evidence that distributed training happened.
-   [KEP-2779](../2779-trainjob-progress/README.md) already establishes a runtime→status
-   channel this could reuse.
-7. **Should accelerate get its own plugin later?** The launcher-only options in
-   [I.4](#i4-limitation-the-trl-cli-and-accelerate-launch) — an accelerate config file per
-   job, the Megatron-LM plugin, TPU — are the reasons the question will return. The
-   position from the SDK call was that a dedicated accelerate plugin is not objectionable in
-   principle — the ask was to understand the torchrun limitations first, which
-   [I.4](#i4-limitation-the-trl-cli-and-accelerate-launch) now records. It is deliberately
-   kept separate from shipping TRL, along with dynamic registration
-   (see #2): both would need their own design discussion, and neither blocks TRL.
+3. **Should accelerate get its own plugin later?** The launcher-only options in
+   [What torchrun gives up](#what-torchrun-gives-up) — an accelerate config file per job, the
+   Megatron-LM plugin, TPU — are the reasons the question will return. The position from the SDK
+   call was that a dedicated accelerate plugin is not objectionable in principle; the ask was to
+   understand the torchrun limitations first, which this KEP now records. It is deliberately
+   kept separate from shipping TRL, along with dynamic registration (see #2): both would need
+   their own design discussion, and neither blocks TRL.
+4. **Does a compute-profile runtime axis appear for GRPO?** GRPO rollouts can use a vLLM server,
+   which may justify a second TRL runtime. Deferred until there is a working GRPO E2E to measure.
 
-## Alternatives Considered
+## Implementation History
 
-| # | Alternative | Why rejected |
-|---|---|---|
-| 1 | Add a `framework` field to `CustomTrainer` instead of new classes | No home for typed framework arguments; no extension model; the class grows with every framework |
-| 2 | Pydantic `BaseModel` instead of `@dataclass` | The SDK uses dataclasses exclusively; adds a dependency for validation `__post_init__` already covers |
-| 3 | `RuntimeConfig` as a `BaseTrainer` field | The same runtime settings apply to every trainer type; as a `train()` parameter it can extend to initializers later |
-| 4 | Scoring/ranking when several runtimes match | Implicit heuristics are fragile and hard to debug; multiple runtimes per framework is deliberate platform configuration, so the user should choose. A clear error listing them beats a wrong guess |
-| 5 | Flat hierarchy, everything inherits `BaseTrainer` | Config trainers would carry `get_train_func()` returning `None`; func trainers would redeclare `func`/`func_args`; dispatch would test values instead of types |
-| 6 | Specialized trainers inherit `CustomTrainer` | Forces them to carry the runtime-env fields this proposal is separating out |
+- **2026-02-11**: KEP drafted in `kubeflow/sdk` as `docs/proposals/285-specialized-trainers`,
+  scoped SDK-only.
+- **2026-08-16**: transferred to `kubeflow/trainer` as KEP-2839 and extended with the server
+  side ([#3930](https://github.com/kubeflow/trainer/pull/3930)), superseding
+  [#3263](https://github.com/kubeflow/trainer/pull/3263).
+- **2026-08-30**: proof-of-concept results added; torchrun confirmed as the launcher and the
+  `accelerate launch` route recorded as a limitation.
+- **2026-09-02**: reviewed on the Kubeflow Trainer community call. Agreed: restructure to the
+  community KEP template with the server and client designs separated; drop the general SDK
+  trainer hierarchy inherited from sdk#285; give `TRLConfig` a typed per-method slot instead of
+  a flat config with a method enum; do **not** mirror TorchTune's per-model-family runtime
+  layout, since the model family is not a TRL axis.
 
-**7. One config class per method (`SFTConfig`, `DPOConfig`, `GRPOConfig`).** The method axis
-changes only *which fields apply*, while `to_args()`, `command` and the framework label are
-per-framework — so once a second framework supports the same method, `SFTConfig` needs a
-framework discriminator anyway. Methods are also the volatile axis: TRL moved PPO to
-`trl.experimental` in a minor release. An enum member can be added or deprecated freely; an
-exported class name cannot. The taxonomy is still captured, as `TRLMethod` and
-`_METHOD_SCOPED_FIELDS`, where regrouping is a data change rather than an API change.
+## Drawbacks
 
-**8. One trainer class per framework (`TRLTrainer`, `TorchTuneTrainer`).** The trainer does
-nothing different per framework — it hands `command` and `to_args()` to the backend — so a
-subclass per framework encodes in the type hierarchy a distinction that exists only in data.
-It makes every framework a new exported class name, frozen public API, and forces
-`BuiltinTrainer` onto a deprecation path toward a `TorchTuneTrainer` successor for no
-behaviour change. *What it gets right:* typed per-framework fields and a flatter call. The
-accepted design keeps the typed fields — on the config — at the cost of one level of nesting.
+- **A second config-driven framework is a second thing to keep working.** The TRL version pin
+  has to track upstream, and TRL moves fast enough to have relocated PPO in a minor release. The
+  mitigation is that the pin lives in an image and a CI-exercised proof script, not in the
+  control plane.
+- **The SDK gains an indirection.** `BuiltinTrainer.config` is no longer one concrete type, so
+  reading the code requires following the registry to find what a label resolves to. The
+  alternative is a branch per framework in shared code, which is what this replaces.
+- **Two repositories must stay in step** on the framework label and the launch shape. One
+  integration test asserts the contract, but it can only run where both are installed.
+
+## Alternatives
+
+### A flat `TRLConfig` with a method enum
+
+The shape in the previous draft: `TRLConfig(method=TRLMethod.GRPO, beta=0.04, ...)` with a
+`_METHOD_SCOPED_FIELDS` map validating at construction. Rejected because `loss_type` and `beta`
+have conflicting types and meanings across methods, so the flat class cannot be typed, and
+because the runtime map has to be hand-maintained anyway. See
+[Choosing the config shape](#choosing-the-config-shape).
+
+### Top-level per-method configs
+
+`BuiltinTrainer(config=TRLGRPOConfig(...))`, with no outer TRL config. Reads best at the call
+site, but three classes would claim the `trl` label in a registry keyed one config per
+framework, and the shared fields would be duplicated or hoisted into a base that then *is* the
+outer config. See [Choosing the config shape](#choosing-the-config-shape).
+
+### One trainer class per framework (`TRLTrainer`, `TorchTuneTrainer`)
+
+The trainer does nothing different per framework — it hands `command` and `to_args()` to the
+backend — so a subclass per framework would encode in the type hierarchy a distinction that
+exists only in data. It also makes every framework a new exported class name and frozen public
+API, and forces `BuiltinTrainer` onto a deprecation path toward a `TorchTuneTrainer` successor
+for no behaviour change. *What it gets right:* typed per-framework fields and a flatter call.
+The accepted design keeps the typed fields — on the config — at the cost of one level of
+nesting.
+
+### One runtime per base model, mirroring TorchTune
+
+Rejected because TorchTune's per-model runtimes exist to select per-model recipes and configs,
+and TRL has no equivalent: its scripts are model-agnostic and the model is a flag. See
+[Why one runtime, not one per model family](#why-one-runtime-not-one-per-model-family).
+
+### A dedicated TRL plugin in the control plane
+
+A `pkg/runtime/framework/plugins/trl/` alongside the torch plugin. Rejected: the proof of
+concept shows the torch plugin already injects everything torchrun needs, so a TRL plugin would
+duplicate `EnforceMLPolicy` to produce identical output, and would put the TRL version in the
+controller's release cycle.
 
 ## References
 
 **Kubeflow**
 
 - [KEP-2170: Trainer V2 API](../2170-kubeflow-trainer-v2/README.md)
-- [KEP-2401: LLM Trainer V2](../2401-llm-trainer-v2/README.md) — the TorchTune integration
-  this generalizes; its "Complement Torch Plugin" section originated the `EnforceMLPolicy`
-  TorchTune branch
+- [KEP-2401: LLM Trainer V2](../2401-llm-trainer-v2/README.md) — the TorchTune integration this
+  generalizes; its "Complement Torch Plugin" section originated the `EnforceMLPolicy` TorchTune
+  branch
 - [KEP-2779: TrainJob progress](../2779-trainjob-progress/README.md) — the runtime→status
-  channel Open Question #6 would reuse
-- Tracking issue [trainer#2839](https://github.com/kubeflow/trainer/issues/2839); GRPO via
-  TRL in flight in [#3508](https://github.com/kubeflow/trainer/issues/3508) /
+  channel Open Question #1 would reuse
+- Tracking issue [trainer#2839](https://github.com/kubeflow/trainer/issues/2839); GRPO via TRL
+  in flight in [#3508](https://github.com/kubeflow/trainer/issues/3508) /
   [#3718](https://github.com/kubeflow/trainer/pull/3718)
-- Earlier draft, superseded: [trainer#3263](https://github.com/kubeflow/trainer/pull/3263),
+- Earlier drafts, superseded: [trainer#3263](https://github.com/kubeflow/trainer/pull/3263),
+  [sdk#285](https://github.com/kubeflow/sdk/issues/285),
   [sdk#310 registry PoC](https://github.com/kubeflow/sdk/pull/310)
 - [Runtime guide — the framework label](https://www.kubeflow.org/docs/components/trainer/operator-guides/runtime/)
 - [SDK types](https://github.com/kubeflow/sdk/blob/main/kubeflow/trainer/types/types.py),
   [SDK TrainerClient](https://github.com/kubeflow/sdk/blob/main/kubeflow/trainer/api/trainer_client.py)
 
-**Upstream sources cited in Part I**
+**Upstream sources cited above**
 
 - `torch.distributed.argparse_util` — the `env` action deriving `PET_{DEST}`; why `PET_*` is
   torchrun's interface and nothing else's. `torch.distributed.run` — `auto` handling and the
   `-m` / `--module` invocation the runtime command uses.
 - `trl/scripts/sft.py` — a plain script (`TrlParser` + `SFTTrainer`, `__main__` guard, no
-  launcher logic); one sibling module per method. `trl/cli/accelerate_launcher.py` —
-  `launch_training_script` resolves `resources.files("trl.scripts")` and calls accelerate's
-  `launch_command`, which is why the CLI is accelerate-bound.
+  launcher logic); one sibling module per method; parses with `fail_with_unknown_args=False`.
+  `trl/cli/accelerate_launcher.py` — `launch_training_script` resolves
+  `resources.files("trl.scripts")` and calls accelerate's `launch_command`, which is why the CLI
+  is accelerate-bound.
+- `trl/trainer/{sft,dpo,grpo}_config.py` — the per-method `loss_type` and `beta` declarations
+  quoted in [Choosing the config shape](#choosing-the-config-shape); each inherits HF
+  `TrainingArguments` for the shared arguments.
 - `accelerate.state.PartialState` — in-process env detection: `LOCAL_RANK != -1` → multi-GPU
-  (nccl); `WORLD_SIZE > 1` on CPU → multi-CPU (gloo). This is what makes the script work
-  under torchrun with no launcher flags.
-- `accelerate.commands.launch` — the *launcher* limitations recorded in I.4:
-  `launch_command`'s distributed branches are each guarded `and not args.cpu`;
-  `prepare_simple_launcher_cmd_env` sets `MASTER_ADDR` / `MASTER_PORT` but never `RANK` /
-  `WORLD_SIZE`; the `multi_gpu` auto-enable guard is keyed on
-  `torch.cuda.device_count()`.
+  (nccl); `WORLD_SIZE > 1` on CPU → multi-CPU (gloo). This is what makes the script work under
+  torchrun with no launcher flags.
+- `accelerate.commands.launch` — the *launcher* limitations recorded above: `launch_command`'s
+  distributed branches are each guarded `and not args.cpu`; `prepare_simple_launcher_cmd_env`
+  sets `MASTER_ADDR` / `MASTER_PORT` but never `RANK` / `WORLD_SIZE`; the `multi_gpu`
+  auto-enable guard is keyed on `torch.cuda.device_count()`.
 - [trl#4466](https://github.com/huggingface/trl/issues/4466) — PPO moved to experimental.
-  [torchtune#2883](https://github.com/meta-pytorch/torchtune/issues/2883) — development
-  halted, 15 July 2025.
+  [torchtune#2883](https://github.com/meta-pytorch/torchtune/issues/2883) — development halted,
+  15 July 2025.


### PR DESCRIPTION
Transfers KEP-2839 into this repository and expands it to cover both sides of the work. Addresses the action items from the community sync: *transfer the KEP to kubeflow/trainer*, and *add server side and client side changes*.

Part of #2839

## Why

The KEP was drafted in kubeflow/sdk#285 and scoped SDK-only — its first non-goal read *"this proposal is SDK-only"*. Landing TRL as a second config-driven framework needs a runtime image and manifests here too. The file also sat under `docs/proposals/`, which has since moved to `proposals/`.

## What changed

Split into **Part I (server)** and **Part II (client)**. Part II is the existing SDK content. Part I is new, and follows the SDK-call consensus: **torchrun is the canonical launcher; accelerate is out of scope for phase one.**

- The TRL runtime launches TRL's plain training script directly: `command: [torchrun, -m, trl.scripts.sft]`. torchrun consumes the plugin's `PET_*` natively; the script's in-process accelerate (`PartialState`) reads the `RANK`/`WORLD_SIZE` env torchrun exports. Zero translation, no adapter.
- **No control-plane change** — no CRD edit and no Go. `EnforceMLPolicy` and `Validate` are untouched.
- The `trl` CLI / `accelerate launch` route is documented under **Limitations (I.4)**: it ignores `PET_*` and fails *silently* at world size 1. Supporting it later (also the route to FSDP/DeepSpeed config files) is Open Question 7, deliberately decoupled from shipping TRL.

## Evidence

All against an unmodified torch plugin:

| Run | Where | Result |
|---|---|---|
| bare `torchrun` probe | cluster, 2 CPU nodes | `world_size=2`, Gloo all-reduce summing to `2.0` — real rendezvous from the plugin's injected `PET_*` |
| `torchrun -m trl.scripts.sft` (the manifest's exact command) | Linux container, 2 simulated nodes, only the five `PET_*` set | first-step epoch `0.05882` (1/17, world 1 control) → `0.1111` (1/9): dataset sharded across 2 ranks, **world size 2**, both completed |
| `trl sft` → `accelerate launch` | cluster, 2 CPU nodes | flags translated correctly, still **world size 1**, both pods `Succeeded` — the silent failure that justifies the limitation |

The container proof is committed as a reproducible script (docker-only, no GPUs needed) and referenced from the Test Plan.

## Notes for reviewers

- Docs only — no Go, YAML or Python changes in this PR.
- Draft status. The parts most worth pushing back on: reopening accelerate as a phase-two launcher (Open Question 7) and reporting achieved world size to `TrainJob` status (Open Question 6).