### PR TITLE
fix: propagate TrainJob env vars to MPI launcher and worker containers

### DIFF
--- a/pkg/runtime/framework/plugins/mpi/mpi.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi.go
@@ -190,6 +190,9 @@ func (m *MPI) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) er
 			if container.Name != constants.Node {
 				continue
 			}
+			if trainJob.Spec.Trainer != nil {
+				apply.UpsertEnvVars(&info.TemplateSpec.PodSets[psIdx].Containers[cIdx].Env, apply.EnvVars(trainJob.Spec.Trainer.Env...)...)
+			}
 			apply.UpsertVolumeMounts(
 				&info.TemplateSpec.PodSets[psIdx].Containers[cIdx].VolumeMounts,
 				[]corev1ac.VolumeMountApplyConfiguration{

--- a/pkg/runtime/framework/plugins/mpi/mpi_test.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi_test.go
@@ -919,6 +919,73 @@ trainJob-node-1-0.trainJob slots=1
 	}
 }
 
+func TestMPIEnforceMLPolicyPropagatesTrainerEnv(t *testing.T) {
+	info := &runtime.Info{
+		RuntimePolicy: runtime.RuntimePolicy{
+			MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
+				MPIPolicy(ptr.To[int32](1), trainer.MPIImplementationOpenMPI, ptr.To("/root/.ssh"), ptr.To(false)).
+				Obj(),
+		},
+		TemplateSpec: runtime.TemplateSpec{
+			PodSets: []runtime.PodSet{
+				{
+					Name: constants.Launcher,
+					Count: ptr.To[int32](1),
+					Endpoints: func(yield func(string) bool) {
+						yield("trainJob-launcher-0-0.trainJob")
+					},
+					Containers: []runtime.Container{{Name: constants.Node}},
+				},
+				{
+					Name:     constants.Node,
+					Ancestor: ptr.To(constants.AncestorTrainer),
+					Count:    ptr.To[int32](1),
+					Endpoints: func(yield func(string) bool) {
+						yield("trainJob-node-1-0.trainJob")
+					},
+					Containers: []runtime.Container{{Name: constants.Node}},
+				},
+			},
+		},
+	}
+	trainJob := utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "trainJob").
+		UID("trainJob").
+		Trainer(
+			utiltesting.MakeTrainJobTrainerWrapper().
+				NumNodes(1).
+				Env(corev1.EnvVar{Name: "CUSTOM_ENV", Value: "custom-value"}).
+				Obj(),
+		).
+		Obj()
+	p, err := New(context.Background(), utiltesting.NewClientBuilder().Build(), nil, nil)
+	if err != nil {
+		t.Fatalf("Failed to initialize MPI plugin: %v", err)
+	}
+	if err := p.(framework.EnforceMLPolicyPlugin).EnforceMLPolicy(info, trainJob); err != nil {
+		t.Fatalf("EnforceMLPolicy returned unexpected error: %v", err)
+	}
+	for _, podSet := range info.TemplateSpec.PodSets {
+		for _, container := range podSet.Containers {
+			if container.Name != constants.Node {
+				continue
+			}
+			actual := map[string]string{}
+			for _, env := range container.Env {
+				if env.Name != nil {
+					actual[*env.Name] = ptr.Deref(env.Value, "")
+				}
+			}
+			if got := actual["CUSTOM_ENV"]; got != "custom-value" {
+				t.Fatalf("podSet %q container %q missing CUSTOM_ENV: got %q", podSet.Name, container.Name, got)
+			}
+			if podSet.Name == constants.Launcher {
+				if got := actual[constants.OpenMPIEnvHostFileLocation]; got == "" {
+					t.Fatalf("launcher container %q missing required OpenMPI env %q", container.Name, constants.OpenMPIEnvHostFileLocation)
+				}
+			}
+		}
+	}
+}
 func TestValidate(t *testing.T) {
 	cases := map[string]struct {
 		info         *runtime.Info


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR fixes MPI MLPolicy behavior so environment variables defined in `TrainJob.spec.trainer.env` are propagated into MPI node containers (including launcher-as-node cases), matching user expectations and parity with other runtime plugins.


Under the hood, `MPI.EnforceMLPolicy` now merges user-provided trainer env vars into each MPI node container before applying MPI-managed OpenMPI env vars and mounts, so user env configuration is preserved without overriding reserved MPI settings.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #3427

**Checklist:**

- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing
