### PR TITLE
chore(api): Use SSA to update TrainJob status - #3362 follow on

### DIFF
--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
@@ -5288,7 +5288,6 @@ spec:
             type: object
           status:
             description: status of TrainJob.
-            minProperties: 1
             properties:
               conditions:
                 description: conditions for the TrainJob.

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -5285,7 +5285,6 @@ spec:
             type: object
           status:
             description: status of TrainJob.
-            minProperties: 1
             properties:
               conditions:
                 description: conditions for the TrainJob.

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -50,6 +50,7 @@ type TrainJob struct {
 
 	// status of TrainJob.
 	// +optional
+	//nolint:kubeapilinter // optionalfields: an empty status is valid and must stay representable.
 	Status TrainJobStatus `json:"status,omitzero"`
 }
 
@@ -496,7 +497,6 @@ type ContainerPatch struct {
 }
 
 // TrainJobStatus represents the current status of TrainJob.
-// +kubebuilder:validation:MinProperties=1
 type TrainJobStatus struct {
 	// conditions for the TrainJob.
 	// +optional

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -72,6 +73,16 @@ func byVolumeName(a, b corev1ac.VolumeApplyConfiguration) bool {
 
 func byVolumeMountPath(a, b corev1ac.VolumeMountApplyConfiguration) bool {
 	return ptr.Equal(a.MountPath, b.MountPath)
+}
+
+func byConditionType(a, b metav1ac.ConditionApplyConfiguration) bool {
+	return ptr.Equal(a.Type, b.Type)
+}
+
+func UpsertConditions(conditions *[]metav1ac.ConditionApplyConfiguration, upConditions ...metav1ac.ConditionApplyConfiguration) {
+	for _, c := range upConditions {
+		upsert(conditions, c, byConditionType)
+	}
 }
 
 type compare[T any] func(T, T) bool

--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -42,6 +42,7 @@ import (
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	applyconfig "github.com/kubeflow/trainer/v2/pkg/client/applyconfiguration/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
 	jobruntimes "github.com/kubeflow/trainer/v2/pkg/runtime"
 	"github.com/kubeflow/trainer/v2/pkg/util/trainjob"
@@ -92,8 +93,6 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	var err error
-	// Keep track of the origin TrainJob status
-	prevTrainJob := trainJob.DeepCopy()
 
 	runtimeRefGK := jobruntimes.RuntimeRefToRuntimeRegistryKey(trainJob.Spec.RuntimeRef)
 	runtime, ok := r.runtimes[runtimeRefGK]
@@ -117,16 +116,20 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	setSuspendedCondition(&trainJob)
 
-	if statusErr := setTrainJobStatus(ctx, runtime, &trainJob); statusErr != nil {
+	// The deadline is reconciled before the status is built, so that the Failed condition it
+	// may set is captured in the apply configuration.
+	deadlineResult := r.reconcileDeadline(ctx, &trainJob)
+
+	statusApply, statusErr := trainJobStatus(ctx, runtime, &trainJob)
+	if statusErr != nil {
 		err = errors.Join(err, statusErr)
 	}
 
-	deadlineResult := r.reconcileDeadline(ctx, &trainJob)
-
-	if !equality.Semantic.DeepEqual(trainJob.Status, prevTrainJob.Status) {
-		// TODO(astefanutti): Consider using SSA once controller-runtime client has SSA support
-		// for sub-resources. See: https://github.com/kubernetes-sigs/controller-runtime/issues/3183
-		err = errors.Join(err, r.client.Status().Patch(ctx, &trainJob, client.MergeFrom(prevTrainJob)))
+	if statusApply != nil {
+		trainJobApply := applyconfig.TrainJob(trainJob.Name, trainJob.Namespace).WithStatus(statusApply)
+		if applyErr := r.client.Status().Apply(ctx, trainJobApply, client.ForceOwnership, client.FieldOwner("trainjob_controller")); applyErr != nil {
+			err = errors.Join(err, applyErr)
+		}
 	}
 
 	if deadlineResult.RequeueAfter > 0 {
@@ -239,23 +242,37 @@ func setFailedCondition(trainJob *trainer.TrainJob, message, reason string) {
 	meta.SetStatusCondition(&trainJob.Status.Conditions, newCond)
 }
 
-func setTrainJobStatus(ctx context.Context, runtime jobruntimes.Runtime, trainJob *trainer.TrainJob) error {
-	deadlineCond := meta.FindStatusCondition(trainJob.Status.Conditions, trainer.TrainJobFailed)
-	if deadlineCond != nil && deadlineCond.Reason != trainer.TrainJobDeadlineExceededReason {
-		deadlineCond = nil
+func trainJobStatus(ctx context.Context, runtime jobruntimes.Runtime, trainJob *trainer.TrainJob) (*applyconfig.TrainJobStatusApplyConfiguration, error) {
+	var statusApply *applyconfig.TrainJobStatusApplyConfiguration
+	var err error
+	if runtime != nil {
+		statusApply, err = runtime.TrainJobStatus(ctx, trainJob)
+	}
+	if statusApply == nil {
+		statusApply = applyconfig.TrainJobStatus()
 	}
 
-	status, err := runtime.TrainJobStatus(ctx, trainJob)
-	if err != nil {
-		return err
+	for _, c := range trainJob.Status.Conditions {
+		exists := false
+		if statusApply.Conditions != nil {
+			for _, ac := range statusApply.Conditions {
+				if ac.Type != nil && *ac.Type == c.Type {
+					exists = true
+					break
+				}
+			}
+		}
+		if !exists {
+			statusApply.WithConditions(metav1ac.Condition().
+				WithType(c.Type).
+				WithStatus(c.Status).
+				WithReason(c.Reason).
+				WithMessage(c.Message).
+				WithLastTransitionTime(c.LastTransitionTime))
+		}
 	}
-	if status != nil {
-		trainJob.Status = *status
-	}
-	if deadlineCond != nil {
-		meta.SetStatusCondition(&trainJob.Status.Conditions, *deadlineCond)
-	}
-	return nil
+
+	return statusApply, err
 }
 
 func (r *TrainJobReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {

--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -42,6 +42,7 @@ import (
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	"github.com/kubeflow/trainer/v2/pkg/apply"
 	applyconfig "github.com/kubeflow/trainer/v2/pkg/client/applyconfiguration/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
 	jobruntimes "github.com/kubeflow/trainer/v2/pkg/runtime"
@@ -93,12 +94,15 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	var err error
+	conditions := currentConditions(&trainJob)
 
 	runtimeRefGK := jobruntimes.RuntimeRefToRuntimeRegistryKey(trainJob.Spec.RuntimeRef)
 	runtime, ok := r.runtimes[runtimeRefGK]
 	if !ok {
 		err = fmt.Errorf("unsupported runtime: %s", runtimeRefGK)
-		setFailedCondition(&trainJob, fmt.Sprintf("unsupported runtime: %s", runtimeRefGK), trainer.TrainJobRuntimeNotSupportedReason)
+		upsertCondition(&trainJob, &conditions, trainer.TrainJobFailed, metav1.ConditionTrue,
+			trainer.TrainJobRuntimeNotSupportedReason, fmt.Sprintf("unsupported runtime: %s", runtimeRefGK),
+		)
 	} else if !trainjob.IsTrainJobFinished(&trainJob) {
 		err = r.reconcileObjects(ctx, runtime, &trainJob)
 		if err != nil {
@@ -114,22 +118,20 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	}
 
-	setSuspendedCondition(&trainJob)
+	suspendedCondition(&trainJob, &conditions)
 
 	// The deadline is reconciled before the status is built, so that the Failed condition it
 	// may set is captured in the apply configuration.
-	deadlineResult := r.reconcileDeadline(ctx, &trainJob)
+	deadlineResult := r.reconcileDeadline(ctx, &trainJob, &conditions)
 
-	statusApply, statusErr := trainJobStatus(ctx, runtime, &trainJob)
+	statusApply, statusErr := trainJobStatus(ctx, runtime, &trainJob, conditions)
 	if statusErr != nil {
 		err = errors.Join(err, statusErr)
 	}
 
-	if statusApply != nil {
-		trainJobApply := applyconfig.TrainJob(trainJob.Name, trainJob.Namespace).WithStatus(statusApply)
-		if applyErr := r.client.Status().Apply(ctx, trainJobApply, client.ForceOwnership, client.FieldOwner("trainjob_controller")); applyErr != nil {
-			err = errors.Join(err, applyErr)
-		}
+	trainJobApply := applyconfig.TrainJob(trainJob.Name, trainJob.Namespace).WithStatus(statusApply)
+	if applyErr := r.client.Status().Apply(ctx, trainJobApply, client.ForceOwnership, client.FieldOwner("trainjob_controller")); applyErr != nil {
+		err = errors.Join(err, applyErr)
 	}
 
 	if deadlineResult.RequeueAfter > 0 {
@@ -151,7 +153,7 @@ func (r *TrainJobReconciler) reconcileObjects(ctx context.Context, runtime jobru
 	return nil
 }
 
-func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *trainer.TrainJob) ctrl.Result {
+func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *trainer.TrainJob, conditions *[]metav1ac.ConditionApplyConfiguration) ctrl.Result {
 	if trainJob.Spec.ActiveDeadlineSeconds == 0 || trainjob.IsTrainJobFinished(trainJob) || ptr.Deref(trainJob.Spec.Suspend, false) {
 		return ctrl.Result{}
 	}
@@ -170,7 +172,8 @@ func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *tr
 			"activeDeadlineSeconds", trainJob.Spec.ActiveDeadlineSeconds,
 			"startTime", startTime,
 			"deadline", deadline)
-		setFailedCondition(trainJob, constants.TrainJobDeadlineExceededMessage, trainer.TrainJobDeadlineExceededReason)
+		upsertCondition(trainJob, conditions, trainer.TrainJobFailed, metav1.ConditionTrue,
+			trainer.TrainJobDeadlineExceededReason, constants.TrainJobDeadlineExceededMessage)
 		jobSet := &jobsetv1alpha2.JobSet{
 			ObjectMeta: metav1.ObjectMeta{Name: trainJob.Name, Namespace: trainJob.Namespace},
 		}
@@ -209,40 +212,66 @@ func (r *TrainJobReconciler) Generic(e event.TypedGenericEvent[*trainer.TrainJob
 	return true
 }
 
-func setSuspendedCondition(trainJob *trainer.TrainJob) {
-	var newCond metav1.Condition
+// suspendedCondition appends the Suspended condition apply configuration if the
+// TrainJob has been suspended at any point.
+func suspendedCondition(trainJob *trainer.TrainJob, conditions *[]metav1ac.ConditionApplyConfiguration) {
 	switch {
 	case ptr.Deref(trainJob.Spec.Suspend, false):
-		newCond = metav1.Condition{
-			Type:    trainer.TrainJobSuspended,
-			Status:  metav1.ConditionTrue,
-			Message: constants.TrainJobSuspendedMessage,
-			Reason:  trainer.TrainJobSuspendedReason,
-		}
+		upsertCondition(trainJob, conditions, trainer.TrainJobSuspended, metav1.ConditionTrue,
+			trainer.TrainJobSuspendedReason, constants.TrainJobSuspendedMessage)
 	case meta.IsStatusConditionTrue(trainJob.Status.Conditions, trainer.TrainJobSuspended):
-		newCond = metav1.Condition{
-			Type:    trainer.TrainJobSuspended,
-			Status:  metav1.ConditionFalse,
-			Message: constants.TrainJobResumedMessage,
-			Reason:  trainer.TrainJobResumedReason,
-		}
+		upsertCondition(trainJob, conditions, trainer.TrainJobSuspended, metav1.ConditionFalse,
+			trainer.TrainJobResumedReason, constants.TrainJobResumedMessage)
 	default:
-		return
+		if existing := meta.FindStatusCondition(trainJob.Status.Conditions, trainer.TrainJobSuspended); existing != nil {
+			upsertCondition(trainJob, conditions, trainer.TrainJobSuspended, existing.Status,
+				existing.Reason, existing.Message)
+		}
 	}
-	meta.SetStatusCondition(&trainJob.Status.Conditions, newCond)
 }
 
-func setFailedCondition(trainJob *trainer.TrainJob, message, reason string) {
-	newCond := metav1.Condition{
-		Type:    trainer.TrainJobFailed,
-		Status:  metav1.ConditionTrue,
-		Message: message,
-		Reason:  reason,
+// currentConditions initializes the conditions slice with existing conditions
+func currentConditions(trainJob *trainer.TrainJob) []metav1ac.ConditionApplyConfiguration {
+	var conditions []metav1ac.ConditionApplyConfiguration
+	for _, c := range trainJob.Status.Conditions {
+		// This preserves terminal conditions like Complete across reconciles where the runtime
+		// plugin may short-circuit (e.g., JobSet deleted after completion).
+		if c.Type == trainer.TrainJobSuspended {
+			continue
+		}
+		if c.Type == trainer.TrainJobFailed && c.Reason != trainer.TrainJobDeadlineExceededReason {
+			continue
+		}
+		conditions = append(conditions, *metav1ac.Condition().
+			WithType(c.Type).
+			WithStatus(c.Status).
+			WithReason(c.Reason).
+			WithMessage(c.Message).
+			WithLastTransitionTime(c.LastTransitionTime))
 	}
-	meta.SetStatusCondition(&trainJob.Status.Conditions, newCond)
+	return conditions
 }
 
-func trainJobStatus(ctx context.Context, runtime jobruntimes.Runtime, trainJob *trainer.TrainJob) (*applyconfig.TrainJobStatusApplyConfiguration, error) {
+// upsertCondition adds or replaces a condition in the conditions slice, preserving
+// LastTransitionTime from the existing TrainJob status when the status has not changed.
+func upsertCondition(trainJob *trainer.TrainJob, conditions *[]metav1ac.ConditionApplyConfiguration, condType string, status metav1.ConditionStatus, reason, message string) {
+	ac := metav1ac.Condition().
+		WithType(condType).
+		WithStatus(status).
+		WithReason(reason).
+		WithMessage(message)
+	existing := meta.FindStatusCondition(trainJob.Status.Conditions, condType)
+	if existing != nil && existing.Status == status {
+		ac.WithLastTransitionTime(existing.LastTransitionTime)
+	} else {
+		ac.WithLastTransitionTime(metav1.Now())
+	}
+	apply.UpsertConditions(conditions, *ac)
+}
+
+// trainJobStatus builds the complete status apply configuration by merging the runtime status
+// with the conditions collected during reconciliation.
+func trainJobStatus(ctx context.Context, runtime jobruntimes.Runtime, trainJob *trainer.TrainJob, conditions []metav1ac.ConditionApplyConfiguration) (*applyconfig.TrainJobStatusApplyConfiguration, error) {
 	var statusApply *applyconfig.TrainJobStatusApplyConfiguration
 	var err error
 	if runtime != nil {
@@ -252,25 +281,8 @@ func trainJobStatus(ctx context.Context, runtime jobruntimes.Runtime, trainJob *
 		statusApply = applyconfig.TrainJobStatus()
 	}
 
-	for _, c := range trainJob.Status.Conditions {
-		exists := false
-		if statusApply.Conditions != nil {
-			for _, ac := range statusApply.Conditions {
-				if ac.Type != nil && *ac.Type == c.Type {
-					exists = true
-					break
-				}
-			}
-		}
-		if !exists {
-			statusApply.WithConditions(metav1ac.Condition().
-				WithType(c.Type).
-				WithStatus(c.Status).
-				WithReason(c.Reason).
-				WithMessage(c.Message).
-				WithLastTransitionTime(c.LastTransitionTime))
-		}
-	}
+	// Merge conditions into the runtime status, overriding runtime conditions of the same type.
+	apply.UpsertConditions(&statusApply.Conditions, conditions...)
 
 	return statusApply, err
 }

--- a/pkg/runtime/core/clustertrainingruntime.go
+++ b/pkg/runtime/core/clustertrainingruntime.go
@@ -30,9 +30,10 @@ import (
 
 	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	applyconfig "github.com/kubeflow/trainer/v2/pkg/client/applyconfiguration/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
-	trainingruntime "github.com/kubeflow/trainer/v2/pkg/util/trainingruntime"
+	"github.com/kubeflow/trainer/v2/pkg/util/trainingruntime"
 )
 
 var (
@@ -88,7 +89,7 @@ func (r *ClusterTrainingRuntime) RuntimeInfo(
 	return r.TrainingRuntime.RuntimeInfo(trainJob, runtimeTemplateSpec, mlPolicy, podGroupPolicy)
 }
 
-func (r *ClusterTrainingRuntime) TrainJobStatus(ctx context.Context, trainJob *trainer.TrainJob) (*trainer.TrainJobStatus, error) {
+func (r *ClusterTrainingRuntime) TrainJobStatus(ctx context.Context, trainJob *trainer.TrainJob) (*applyconfig.TrainJobStatusApplyConfiguration, error) {
 	return r.TrainingRuntime.TrainJobStatus(ctx, trainJob)
 }
 

--- a/pkg/runtime/core/trainingruntime.go
+++ b/pkg/runtime/core/trainingruntime.go
@@ -41,6 +41,7 @@ import (
 	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/apply"
+	applyconfig "github.com/kubeflow/trainer/v2/pkg/client/applyconfiguration/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
 	fwkcore "github.com/kubeflow/trainer/v2/pkg/runtime/framework/core"
@@ -297,7 +298,7 @@ func (r *TrainingRuntime) mergeRuntimePatches(trainJob *trainer.TrainJob, jobSet
 	return nil
 }
 
-func (r *TrainingRuntime) TrainJobStatus(ctx context.Context, trainJob *trainer.TrainJob) (*trainer.TrainJobStatus, error) {
+func (r *TrainingRuntime) TrainJobStatus(ctx context.Context, trainJob *trainer.TrainJob) (*applyconfig.TrainJobStatusApplyConfiguration, error) {
 	return r.framework.RunTrainJobStatusPlugin(ctx, trainJob)
 }
 

--- a/pkg/runtime/framework/core/framework.go
+++ b/pkg/runtime/framework/core/framework.go
@@ -27,6 +27,7 @@ import (
 
 	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	applyconfig "github.com/kubeflow/trainer/v2/pkg/client/applyconfiguration/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework"
 	fwkplugins "github.com/kubeflow/trainer/v2/pkg/runtime/framework/plugins"
@@ -172,7 +173,7 @@ func (f *Framework) RunComponentBuilderPlugins(ctx context.Context, info *runtim
 	return objs, nil
 }
 
-func (f *Framework) RunTrainJobStatusPlugin(ctx context.Context, trainJob *trainer.TrainJob) (*trainer.TrainJobStatus, error) {
+func (f *Framework) RunTrainJobStatusPlugin(ctx context.Context, trainJob *trainer.TrainJob) (*applyconfig.TrainJobStatusApplyConfiguration, error) {
 	if f.trainJobStatusPlugin != nil {
 		return f.trainJobStatusPlugin.Status(ctx, trainJob)
 	}

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	batchv1ac "k8s.io/client-go/applyconfigurations/batch/v1"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,6 +46,7 @@ import (
 	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/apply"
+	applyconfig "github.com/kubeflow/trainer/v2/pkg/client/applyconfiguration/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework"
@@ -2335,19 +2337,16 @@ func newFakeJobsStatusPlugin(context.Context, client.Client, client.FieldIndexer
 const fakeJobsStatusPluginName = "fake-train-job-status"
 
 func (f fakeTrainJobStatusPlugin) Name() string { return fakeJobsStatusPluginName }
-func (f fakeTrainJobStatusPlugin) Status(context.Context, *trainer.TrainJob) (*trainer.TrainJobStatus, error) {
-	return &trainer.TrainJobStatus{
-		JobsStatus: []trainer.JobStatus{
-			{
-				Name:      "fake-job",
-				Ready:     ptr.To(int32(1)),
-				Succeeded: ptr.To(int32(0)),
-				Failed:    ptr.To(int32(0)),
-				Active:    ptr.To(int32(1)),
-				Suspended: ptr.To(int32(0)),
-			},
-		},
-	}, nil
+func (f fakeTrainJobStatusPlugin) Status(context.Context, *trainer.TrainJob) (*applyconfig.TrainJobStatusApplyConfiguration, error) {
+	return applyconfig.TrainJobStatus().
+		WithJobsStatus(applyconfig.JobStatus().
+			WithName("fake-job").
+			WithReady(1).
+			WithSucceeded(0).
+			WithFailed(0).
+			WithActive(1).
+			WithSuspended(0),
+		), nil
 }
 
 func TestTrainJobStatusPlugins(t *testing.T) {
@@ -2356,7 +2355,7 @@ func TestTrainJobStatusPlugins(t *testing.T) {
 		registry   fwkplugins.Registry
 		trainJob   *trainer.TrainJob
 		jobSet     *jobsetv1alpha2.JobSet
-		wantStatus *trainer.TrainJobStatus
+		wantStatus *applyconfig.TrainJobStatusApplyConfiguration
 		wantError  error
 	}{
 		"jobSet has not been finalized, yet": {
@@ -2371,7 +2370,7 @@ func TestTrainJobStatusPlugins(t *testing.T) {
 					Status:  metav1.ConditionFalse,
 				}).
 				Obj(),
-			wantStatus: &trainer.TrainJobStatus{},
+			wantStatus: applyconfig.TrainJobStatus(),
 		},
 		"succeeded to obtain completed terminal condition": {
 			registry: fwkplugins.NewRegistry(),
@@ -2386,17 +2385,14 @@ func TestTrainJobStatusPlugins(t *testing.T) {
 					Status:             metav1.ConditionTrue,
 				}).
 				Obj(),
-			wantStatus: &trainer.TrainJobStatus{
-				Conditions: []metav1.Condition{
-					{
-						Type:               trainer.TrainJobComplete,
-						LastTransitionTime: lastTransitionTime,
-						Message:            jobsetconsts.AllJobsCompletedMessage,
-						Reason:             jobsetconsts.AllJobsCompletedReason,
-						Status:             metav1.ConditionTrue,
-					},
-				},
-			},
+			wantStatus: applyconfig.TrainJobStatus().
+				WithConditions(metav1ac.Condition().
+					WithType(trainer.TrainJobComplete).
+					WithStatus(metav1.ConditionTrue).
+					WithMessage(jobsetconsts.AllJobsCompletedMessage).
+					WithReason(jobsetconsts.AllJobsCompletedReason).
+					WithLastTransitionTime(lastTransitionTime),
+				),
 		},
 		"succeeded to obtain failed terminal condition": {
 			registry: fwkplugins.NewRegistry(),
@@ -2411,17 +2407,14 @@ func TestTrainJobStatusPlugins(t *testing.T) {
 					Status:             metav1.ConditionTrue,
 				}).
 				Obj(),
-			wantStatus: &trainer.TrainJobStatus{
-				Conditions: []metav1.Condition{
-					{
-						Type:               trainer.TrainJobFailed,
-						LastTransitionTime: lastTransitionTime,
-						Message:            jobsetconsts.FailedJobsMessage,
-						Reason:             jobsetconsts.FailedJobsReason,
-						Status:             metav1.ConditionTrue,
-					},
-				},
-			},
+			wantStatus: applyconfig.TrainJobStatus().
+				WithConditions(metav1ac.Condition().
+					WithType(trainer.TrainJobFailed).
+					WithStatus(metav1.ConditionTrue).
+					WithMessage(jobsetconsts.FailedJobsMessage).
+					WithReason(jobsetconsts.FailedJobsReason).
+					WithLastTransitionTime(lastTransitionTime),
+				),
 		},
 		"failed to obtain TrainJob status due to multiple trainJobStatus plugin": {
 			registry: fwkplugins.Registry{
@@ -2436,7 +2429,7 @@ func TestTrainJobStatusPlugins(t *testing.T) {
 				Obj(),
 			jobSet: testingutil.MakeJobSetWrapper(metav1.NamespaceDefault, "testing").
 				Obj(),
-			wantStatus: &trainer.TrainJobStatus{},
+			wantStatus: applyconfig.TrainJobStatus(),
 		},
 		"succeeded to obtain JobsStatus from JobSet with multiple replicated jobs": {
 			registry: fwkplugins.NewRegistry(),
@@ -2470,34 +2463,30 @@ func TestTrainJobStatusPlugins(t *testing.T) {
 					},
 				}).
 				Obj(),
-			wantStatus: &trainer.TrainJobStatus{
-				JobsStatus: []trainer.JobStatus{
-					{
-						Name:      constants.DatasetInitializer,
-						Ready:     ptr.To(int32(1)),
-						Succeeded: ptr.To(int32(1)),
-						Failed:    ptr.To(int32(0)),
-						Active:    ptr.To(int32(0)),
-						Suspended: ptr.To(int32(0)),
-					},
-					{
-						Name:      constants.ModelInitializer,
-						Ready:     ptr.To(int32(1)),
-						Succeeded: ptr.To(int32(1)),
-						Failed:    ptr.To(int32(0)),
-						Active:    ptr.To(int32(0)),
-						Suspended: ptr.To(int32(0)),
-					},
-					{
-						Name:      constants.Node,
-						Ready:     ptr.To(int32(2)),
-						Succeeded: ptr.To(int32(0)),
-						Failed:    ptr.To(int32(0)),
-						Active:    ptr.To(int32(2)),
-						Suspended: ptr.To(int32(0)),
-					},
-				},
-			},
+			wantStatus: applyconfig.TrainJobStatus().
+				WithJobsStatus(
+					applyconfig.JobStatus().
+						WithName(constants.DatasetInitializer).
+						WithReady(1).
+						WithSucceeded(1).
+						WithFailed(0).
+						WithActive(0).
+						WithSuspended(0),
+					applyconfig.JobStatus().
+						WithName(constants.ModelInitializer).
+						WithReady(1).
+						WithSucceeded(1).
+						WithFailed(0).
+						WithActive(0).
+						WithSuspended(0),
+					applyconfig.JobStatus().
+						WithName(constants.Node).
+						WithReady(2).
+						WithSucceeded(0).
+						WithFailed(0).
+						WithActive(2).
+						WithSuspended(0),
+				),
 		},
 		"succeeded to obtain JobsStatus from JobSet with failed job": {
 			registry: fwkplugins.NewRegistry(),
@@ -2515,18 +2504,16 @@ func TestTrainJobStatusPlugins(t *testing.T) {
 					},
 				}).
 				Obj(),
-			wantStatus: &trainer.TrainJobStatus{
-				JobsStatus: []trainer.JobStatus{
-					{
-						Name:      constants.Node,
-						Ready:     ptr.To(int32(0)),
-						Succeeded: ptr.To(int32(0)),
-						Failed:    ptr.To(int32(1)),
-						Active:    ptr.To(int32(0)),
-						Suspended: ptr.To(int32(0)),
-					},
-				},
-			},
+			wantStatus: applyconfig.TrainJobStatus().
+				WithJobsStatus(
+					applyconfig.JobStatus().
+						WithName(constants.Node).
+						WithReady(0).
+						WithSucceeded(0).
+						WithFailed(1).
+						WithActive(0).
+						WithSuspended(0),
+				),
 		},
 		"failed to obtain JobsStatus due to multiple JobsStatusPlugins": {
 			registry: fwkplugins.Registry{

--- a/pkg/runtime/framework/interface.go
+++ b/pkg/runtime/framework/interface.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	applyconfig "github.com/kubeflow/trainer/v2/pkg/client/applyconfiguration/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
 )
 
@@ -80,5 +81,5 @@ type ComponentBuilderPlugin interface {
 
 type TrainJobStatusPlugin interface {
 	Plugin
-	Status(ctx context.Context, trainJob *trainer.TrainJob) (*trainer.TrainJobStatus, error)
+	Status(ctx context.Context, trainJob *trainer.TrainJob) (*applyconfig.TrainJobStatusApplyConfiguration, error)
 }

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -46,6 +46,7 @@ import (
 	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/apply"
+	applyconfig "github.com/kubeflow/trainer/v2/pkg/client/applyconfiguration/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework"
@@ -447,7 +448,7 @@ func (j *JobSet) Build(ctx context.Context, info *runtime.Info, trainJob *traine
 	return []apiruntime.ApplyConfiguration{jobSet}, nil
 }
 
-func (j *JobSet) Status(ctx context.Context, trainJob *trainer.TrainJob) (*trainer.TrainJobStatus, error) {
+func (j *JobSet) Status(ctx context.Context, trainJob *trainer.TrainJob) (*applyconfig.TrainJobStatusApplyConfiguration, error) {
 	jobSet := &jobsetv1alpha2.JobSet{}
 	if err := j.client.Get(ctx, client.ObjectKeyFromObject(trainJob), jobSet); err != nil {
 		if apierrors.IsNotFound(err) && trainjob.IsTrainJobFinished(trainJob) {
@@ -457,29 +458,34 @@ func (j *JobSet) Status(ctx context.Context, trainJob *trainer.TrainJob) (*train
 		}
 		return nil, err
 	}
-	status := trainJob.Status.DeepCopy()
+	status := applyconfig.TrainJobStatus()
 
 	if completed := meta.FindStatusCondition(jobSet.Status.Conditions, string(jobsetv1alpha2.JobSetCompleted)); completed != nil && completed.Status == metav1.ConditionTrue {
-		completed.Type = trainer.TrainJobComplete
-		meta.SetStatusCondition(&status.Conditions, *completed)
+		status.WithConditions(metav1ac.Condition().
+			WithType(trainer.TrainJobComplete).
+			WithStatus(metav1.ConditionTrue).
+			WithReason(completed.Reason).
+			WithMessage(completed.Message).
+			WithLastTransitionTime(completed.LastTransitionTime))
 	}
 	if failed := meta.FindStatusCondition(jobSet.Status.Conditions, string(jobsetv1alpha2.JobSetFailed)); failed != nil && failed.Status == metav1.ConditionTrue {
-		failed.Type = trainer.TrainJobFailed
-		meta.SetStatusCondition(&status.Conditions, *failed)
+		status.WithConditions(metav1ac.Condition().
+			WithType(trainer.TrainJobFailed).
+			WithStatus(metav1.ConditionTrue).
+			WithReason(failed.Reason).
+			WithMessage(failed.Message).
+			WithLastTransitionTime(failed.LastTransitionTime))
 	}
 
-	var statuses []trainer.JobStatus
-	for _, status := range jobSet.Status.ReplicatedJobsStatus {
-		statuses = append(statuses, trainer.JobStatus{
-			Name:      status.Name,
-			Ready:     &status.Ready,
-			Succeeded: &status.Succeeded,
-			Failed:    &status.Failed,
-			Active:    &status.Active,
-			Suspended: &status.Suspended,
-		})
+	for _, js := range jobSet.Status.ReplicatedJobsStatus {
+		status.WithJobsStatus(applyconfig.JobStatus().
+			WithName(js.Name).
+			WithReady(js.Ready).
+			WithSucceeded(js.Succeeded).
+			WithFailed(js.Failed).
+			WithActive(js.Active).
+			WithSuspended(js.Suspended))
 	}
-	status.JobsStatus = statuses
 
 	return status, nil
 }

--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	applyconfig "github.com/kubeflow/trainer/v2/pkg/client/applyconfiguration/trainer/v1alpha1"
 )
 
 type ReconcilerBuilder func(*builder.Builder, client.Client, cache.Cache) *builder.Builder
@@ -34,7 +35,7 @@ type ReconcilerBuilder func(*builder.Builder, client.Client, cache.Cache) *build
 type Runtime interface {
 	NewObjects(ctx context.Context, trainJob *trainer.TrainJob) ([]runtime.ApplyConfiguration, error)
 	RuntimeInfo(trainJob *trainer.TrainJob, runtimeTemplateSpec any, mlPolicy *trainer.MLPolicy, podGroupPolicy *trainer.PodGroupPolicy) (*Info, error)
-	TrainJobStatus(ctx context.Context, trainJob *trainer.TrainJob) (*trainer.TrainJobStatus, error)
+	TrainJobStatus(ctx context.Context, trainJob *trainer.TrainJob) (*applyconfig.TrainJobStatusApplyConfiguration, error)
 	EventHandlerRegistrars() []ReconcilerBuilder
 	ValidateObjects(ctx context.Context, old, new *trainer.TrainJob) (admission.Warnings, field.ErrorList)
 }

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -40,6 +40,7 @@ var (
 	}
 	IgnoreConditions = cmp.Options{
 		cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime", "ObservedGeneration"),
+		cmpopts.SortSlices(func(a, b metav1.Condition) bool { return a.Type < b.Type }),
 	}
 	SortJobsStatus = cmp.Options{
 		cmpopts.SortSlices(func(a, b trainer.JobStatus) bool { return a.Name < b.Name }),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR completes the use of SSA throughout the TrainJob reconciliation as the Apply method is now accessible for the status sub-resource.

Follow up to #3362.

This PR rebases and addresses the conflicts.

It also fixes a small bug in the previous implementation where reconcile was temporarily failing due to the status being empty: TrainJobStatus had `+kubebuilder:validation:MinProperties=1` preventing an empty update which was happening in the reconcile loop.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #

**Checklist:**

- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing
