### PR TITLE
fix(manifests): grant the cache initializer access to its TrainJob

### DIFF
--- a/charts/kubeflow-trainer/templates/data-cache/cluster-role.yaml
+++ b/charts/kubeflow-trainer/templates/data-cache/cluster-role.yaml
@@ -37,4 +37,16 @@ rules:
     resources:
       - serviceaccounts
     verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups:
+      - trainer.kubeflow.org
+    resources:
+      - trainjobs
+    verbs: ["get"]
+  # Setting blockOwnerDeletion on the TrainJob owner reference requires update
+  # on the owner's finalizers subresource under OwnerReferencesPermissionEnforcement.
+  - apiGroups:
+      - trainer.kubeflow.org
+    resources:
+      - trainjobs/finalizers
+    verbs: ["update"]
 {{- end }}

--- a/charts/kubeflow-trainer/tests/data-cache/cluster_role_test.yaml
+++ b/charts/kubeflow-trainer/tests/data-cache/cluster_role_test.yaml
@@ -81,3 +81,31 @@ tests:
             resources:
               - serviceaccounts
             verbs: ["create", "delete", "get", "list", "watch"]
+
+  - it: Should have correct rules for trainjobs
+    set:
+      dataCache:
+        enabled: true
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - trainer.kubeflow.org
+            resources:
+              - trainjobs
+            verbs: ["get"]
+
+  - it: Should have correct rules for trainjobs finalizers
+    set:
+      dataCache:
+        enabled: true
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - trainer.kubeflow.org
+            resources:
+              - trainjobs/finalizers
+            verbs: ["update"]

--- a/manifests/overlays/data-cache/cluster_role.yaml
+++ b/manifests/overlays/data-cache/cluster_role.yaml
@@ -33,3 +33,15 @@ rules:
     resources:
       - serviceaccounts
     verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups:
+      - trainer.kubeflow.org
+    resources:
+      - trainjobs
+    verbs: ["get"]
+  # Setting blockOwnerDeletion on the TrainJob owner reference requires update
+  # on the owner's finalizers subresource under OwnerReferencesPermissionEnforcement.
+  - apiGroups:
+      - trainer.kubeflow.org
+    resources:
+      - trainjobs/finalizers
+    verbs: ["update"]


### PR DESCRIPTION
## Summary

The cache dataset initializer reads its TrainJob to set owner references on the ServiceAccount, Service, and LeaderWorkerSet it creates. However, `kubeflow-trainer-cache-initializer` lacks permissions for `trainer.kubeflow.org`, causing a 403 that `cache.py` swallows. The container exits successfully, and the TrainJob continues without a cache cluster.

Grant the initializer:

* `trainjobs: get`
* `trainjobs/finalizers: update`, required when `blockOwnerDeletion` is set under `OwnerReferencesPermissionEnforcement`.

The TrainJob controller already uses the same permissions.

The Helm chart currently defines this ClusterRole without a ServiceAccount or RoleBinding, so these permissions only apply to the kustomize overlay. That pre-existing gap is outside the scope of this change.


**Checklist:**

- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing