### PR TITLE
Release Training Operator Image for v1.9.4

### DIFF
--- a/manifests/overlays/kubeflow/kustomization.yaml
+++ b/manifests/overlays/kubeflow/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - kubeflow-training-roles.yaml
 images:
   - name: ghcr.io/kubeflow/training-v1/training-operator
-    newTag: v1-d6eb98e
+    newTag: v1-93c5489
 # TODO (tenzen-y): Once we support cert-manager, we need to remove this secret generation.
 # REF: https://github.com/kubeflow/training-operator/issues/2049
 secretGenerator:

--- a/manifests/overlays/standalone/kustomization.yaml
+++ b/manifests/overlays/standalone/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - namespace.yaml
 images:
   - name: ghcr.io/kubeflow/training-v1/training-operator
-    newTag: v1-d6eb98e
+    newTag: v1-93c5489
 secretGenerator:
   - name: training-operator-webhook-cert
     options:


### PR DESCRIPTION
I updated images for the Training Operator v1.9.4 release for the k8s version upgrade: https://github.com/kubeflow/trainer/pull/3924

/assign @robert-bell @tenzen-y @kannon92