### PR TITLE
fix(framework): validate runtimePatches against the runtime template

### DIFF
--- a/pkg/runtime/core/trainingruntime.go
+++ b/pkg/runtime/core/trainingruntime.go
@@ -126,6 +126,9 @@ func (r *TrainingRuntime) RuntimeInfo(
 	if !ok {
 		return nil, fmt.Errorf("unsupported runtimeTemplateSpec")
 	}
+	if err := r.mergeRuntimePatches(trainJob, &jobSetTemplateSpec); err != nil {
+		return nil, err
+	}
 	info, err := r.newRuntimeInfo(trainJob, jobSetTemplateSpec, mlPolicy, podGroupPolicy)
 	if err != nil {
 		return nil, err
@@ -146,6 +149,11 @@ func (r *TrainingRuntime) RuntimeInfo(
 	return info, nil
 }
 
+// newRuntimeInfo builds the Info from the runtime template as it is declared. Only the build
+// path merges the TrainJob's runtimePatches into that template beforehand: validation compares
+// those patches against the runtime, and an Info that already carried them would accept every
+// patch. Metadata from the patches is propagated here in both cases, since the labels and
+// annotations the managers set are validated as well.
 func (r *TrainingRuntime) newRuntimeInfo(
 	trainJob *trainer.TrainJob, jobSetTemplateSpec trainer.JobSetTemplateSpec, mlPolicy *trainer.MLPolicy, podGroupPolicy *trainer.PodGroupPolicy,
 ) (*runtime.Info, error) {
@@ -166,10 +174,6 @@ func (r *TrainingRuntime) newRuntimeInfo(
 				propagationAnnotations[k] = v
 			}
 		}
-	}
-	err := r.mergeRuntimePatches(trainJob, &jobSetTemplateSpec)
-	if err != nil {
-		return nil, err
 	}
 
 	jobSetSpecApply, err := apply.FromTypedObjWithFields[jobsetv1alpha2ac.JobSetSpecApplyConfiguration](&jobsetv1alpha2.JobSet{

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -58,6 +58,13 @@ var (
 	runtimePatchesPath = field.NewPath("spec").Child("runtimePatches")
 )
 
+// containerNames holds the initContainer and container names declared by a replicated job.
+// They are kept apart because a patch may only target the list the container is declared in.
+type containerNames struct {
+	initContainers sets.Set[string]
+	containers     sets.Set[string]
+}
+
 type JobSet struct {
 	client     client.Client
 	restMapper meta.RESTMapper
@@ -96,24 +103,26 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 	}
 
 	// TODO (andreyvelich): Refactor this test to verify the ancestor label in PodTemplate.
-	rJobContainerNames := make(map[string]sets.Set[string])
+	rJobContainerNames := make(map[string]containerNames)
 	for _, rJob := range jobSetSpec.ReplicatedJobs {
-		rJobContainerNames[*rJob.Name] = sets.New[string]()
-
-		// Names of initContainer and containers are unique.
+		names := containerNames{
+			initContainers: sets.New[string](),
+			containers:     sets.New[string](),
+		}
 		for _, c := range rJob.Template.Spec.Template.Spec.InitContainers {
-			rJobContainerNames[*rJob.Name].Insert(*c.Name)
+			names.initContainers.Insert(*c.Name)
 		}
 		for _, c := range rJob.Template.Spec.Template.Spec.Containers {
-			rJobContainerNames[*rJob.Name].Insert(*c.Name)
+			names.containers.Insert(*c.Name)
 		}
+		rJobContainerNames[*rJob.Name] = names
 	}
 
 	if newObj.Spec.Initializer != nil && newObj.Spec.Initializer.Dataset != nil {
-		containers, ok := rJobContainerNames[constants.DatasetInitializer]
+		names, ok := rJobContainerNames[constants.DatasetInitializer]
 		if !ok {
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have %s job when trainJob is configured with input datasetConfig", constants.DatasetInitializer)))
-		} else if !containers.Has(constants.DatasetInitializer) {
+		} else if !names.containers.Has(constants.DatasetInitializer) {
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have container with name - %s in the %s job", constants.DatasetInitializer, constants.DatasetInitializer)))
 		} else {
 			hasVolumeMount := false
@@ -140,10 +149,10 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 	}
 
 	if newObj.Spec.Initializer != nil && newObj.Spec.Initializer.Model != nil {
-		containers, ok := rJobContainerNames[constants.ModelInitializer]
+		names, ok := rJobContainerNames[constants.ModelInitializer]
 		if !ok {
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have %s job when trainJob is configured with input modelConfig", constants.ModelInitializer)))
-		} else if !containers.Has(constants.ModelInitializer) {
+		} else if !names.containers.Has(constants.ModelInitializer) {
 			allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have container with name - %s in the %s job", constants.ModelInitializer, constants.ModelInitializer)))
 		} else {
 			hasVolumeMount := false
@@ -179,7 +188,7 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 			continue
 		}
 		for _, rJobPatch := range runtimePatch.TrainingRuntimeSpec.Template.Spec.ReplicatedJobs {
-			containers, ok := rJobContainerNames[rJobPatch.Name]
+			names, ok := rJobContainerNames[rJobPatch.Name]
 			if !ok {
 				allErrs = append(allErrs, field.Invalid(runtimePatchesPath, newObj.Spec.RuntimePatches,
 					"must not have replicated job that doesn't exist in the runtime job template"))
@@ -191,13 +200,13 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 			}
 			podSpecPatch := rJobPatch.Template.Spec.Template.Spec
 			for _, c := range podSpecPatch.InitContainers {
-				if !containers.Has(c.Name) {
+				if !names.initContainers.Has(c.Name) {
 					allErrs = append(allErrs, field.Invalid(runtimePatchesPath, newObj.Spec.RuntimePatches,
 						fmt.Sprintf("must not have initContainer that doesn't exist in the runtime job %s", rJobPatch.Name)))
 				}
 			}
 			for _, c := range podSpecPatch.Containers {
-				if !containers.Has(c.Name) {
+				if !names.containers.Has(c.Name) {
 					allErrs = append(allErrs, field.Invalid(runtimePatchesPath, newObj.Spec.RuntimePatches,
 						fmt.Sprintf("must not have container that doesn't exist in the runtime job %s", rJobPatch.Name)))
 				} else if len(c.Env) > 0 && (c.Name == constants.DatasetInitializer || c.Name == constants.ModelInitializer || c.Name == constants.Node) {

--- a/pkg/runtime/framework/plugins/jobset/jobset_test.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset_test.go
@@ -505,6 +505,56 @@ func TestJobSet(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
+	nodePatch := func(podSpecPatch trainer.PodSpecPatch) []trainer.RuntimePatch {
+		return []trainer.RuntimePatch{{
+			Manager: "test.io/manager",
+			TrainingRuntimeSpec: &trainer.TrainingRuntimeSpecPatch{
+				Template: &trainer.JobSetTemplatePatch{
+					Spec: &trainer.JobSetSpecPatch{
+						ReplicatedJobs: []trainer.ReplicatedJobPatch{{
+							Name: constants.Node,
+							Template: &trainer.JobTemplatePatch{
+								Spec: &trainer.JobSpecPatch{
+									Template: &trainer.PodTemplatePatch{Spec: &podSpecPatch},
+								},
+							},
+						}},
+					},
+				},
+			},
+		}}
+	}
+	patchContainerWithInitContainerName := nodePatch(trainer.PodSpecPatch{
+		Containers: []trainer.ContainerPatch{{Name: "warmup"}},
+	})
+	patchInitContainerWithContainerName := nodePatch(trainer.PodSpecPatch{
+		InitContainers: []trainer.ContainerPatch{{Name: constants.Node}},
+	})
+	nodeJobWithInitContainer := &runtime.Info{
+		TemplateSpec: runtime.TemplateSpec{
+			ObjApply: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
+				ReplicatedJobs: []jobsetv1alpha2ac.ReplicatedJobApplyConfiguration{
+					{
+						Name: ptr.To(constants.Node),
+						Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+							Spec: &batchv1ac.JobSpecApplyConfiguration{
+								Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+									Spec: &corev1ac.PodSpecApplyConfiguration{
+										InitContainers: []corev1ac.ContainerApplyConfiguration{
+											{Name: ptr.To("warmup")},
+										},
+										Containers: []corev1ac.ContainerApplyConfiguration{
+											{Name: ptr.To(constants.Node)},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 	cases := map[string]struct {
 		info         *runtime.Info
 		oldObj       *trainer.TrainJob
@@ -1115,6 +1165,24 @@ func TestValidate(t *testing.T) {
 						},
 					},
 					fmt.Sprintf("must not have container that doesn't exist in the runtime job %s", constants.Node)),
+			},
+		},
+		"runtimePatches patch a container with the name of an initContainer": {
+			info: nodeJobWithInitContainer,
+			newObj: utiltesting.MakeTrainJobWrapper("default", "test").
+				RuntimePatches(patchContainerWithInitContainerName).Obj(),
+			wantError: field.ErrorList{
+				field.Invalid(runtimePatchesPath, patchContainerWithInitContainerName,
+					fmt.Sprintf("must not have container that doesn't exist in the runtime job %s", constants.Node)),
+			},
+		},
+		"runtimePatches patch an initContainer with the name of a container": {
+			info: nodeJobWithInitContainer,
+			newObj: utiltesting.MakeTrainJobWrapper("default", "test").
+				RuntimePatches(patchInitContainerWithContainerName).Obj(),
+			wantError: field.ErrorList{
+				field.Invalid(runtimePatchesPath, patchInitContainerWithContainerName,
+					fmt.Sprintf("must not have initContainer that doesn't exist in the runtime job %s", constants.Node)),
 			},
 		},
 		"runtimePatches contain envs for reserved container": {

--- a/pkg/webhooks/trainjob_webhook_test.go
+++ b/pkg/webhooks/trainjob_webhook_test.go
@@ -32,6 +32,7 @@ import (
 	clocktesting "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
@@ -312,6 +313,44 @@ func TestDefault(t *testing.T) {
 }
 
 func TestValidateCreate(t *testing.T) {
+	runtimePatch := func(rJobName string, podSpecPatch trainer.PodSpecPatch) []trainer.RuntimePatch {
+		return []trainer.RuntimePatch{{
+			Manager: "test.io/manager",
+			TrainingRuntimeSpec: &trainer.TrainingRuntimeSpecPatch{
+				Template: &trainer.JobSetTemplatePatch{
+					Spec: &trainer.JobSetSpecPatch{
+						ReplicatedJobs: []trainer.ReplicatedJobPatch{{
+							Name: rJobName,
+							Template: &trainer.JobTemplatePatch{
+								Spec: &trainer.JobSpecPatch{
+									Template: &trainer.PodTemplatePatch{Spec: &podSpecPatch},
+								},
+							},
+						}},
+					},
+				},
+			},
+		}}
+	}
+	patchForUnknownReplicatedJob := runtimePatch("unknown-job", trainer.PodSpecPatch{
+		NodeSelector: map[string]string{"zone": "a"},
+	})
+	patchForUnknownContainer := runtimePatch(constants.Node, trainer.PodSpecPatch{
+		Containers: []trainer.ContainerPatch{{Name: "unknown-container"}},
+	})
+	patchForUnknownInitContainer := runtimePatch(constants.Node, trainer.PodSpecPatch{
+		InitContainers: []trainer.ContainerPatch{{Name: constants.Node}},
+	})
+	patchWithEmptyVolcanoQueue := []trainer.RuntimePatch{{
+		Manager: "test.io/manager",
+		TrainingRuntimeSpec: &trainer.TrainingRuntimeSpecPatch{
+			Template: &trainer.JobSetTemplatePatch{
+				Metadata: &metav1.ObjectMeta{
+					Annotations: map[string]string{volcanov1beta1.QueueNameAnnotationKey: ""},
+				},
+			},
+		},
+	}}
 	cases := map[string]struct {
 		obj                    *trainer.TrainJob
 		clusterTrainingRuntime *trainer.ClusterTrainingRuntime
@@ -348,6 +387,87 @@ func TestValidateCreate(t *testing.T) {
 				},
 			},
 			wantWarnings: nil,
+		},
+		"runtimePatches reference a replicated job that the runtime does not have": {
+			obj: testingutil.MakeTrainJobWrapper("default", "valid-job-name").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
+				RuntimePatches(patchForUnknownReplicatedJob).
+				Obj(),
+			clusterTrainingRuntime: testingutil.MakeClusterTrainingRuntimeWrapper("test-runtime").
+				RuntimeSpec(trainer.TrainingRuntimeSpec{
+					Template: trainer.JobSetTemplateSpec{
+						Spec: testingutil.MakeJobSetWrapper("", "").Obj().Spec,
+					},
+				}).Obj(),
+			wantError: field.ErrorList{
+				&field.Error{
+					Type:     field.ErrorTypeInvalid,
+					Field:    "spec.runtimePatches",
+					BadValue: patchForUnknownReplicatedJob,
+				},
+			},
+		},
+		"runtimePatches reference a container that the runtime does not have": {
+			obj: testingutil.MakeTrainJobWrapper("default", "valid-job-name").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
+				RuntimePatches(patchForUnknownContainer).
+				Obj(),
+			clusterTrainingRuntime: testingutil.MakeClusterTrainingRuntimeWrapper("test-runtime").
+				RuntimeSpec(trainer.TrainingRuntimeSpec{
+					Template: trainer.JobSetTemplateSpec{
+						Spec: testingutil.MakeJobSetWrapper("", "").Obj().Spec,
+					},
+				}).Obj(),
+			wantError: field.ErrorList{
+				&field.Error{
+					Type:     field.ErrorTypeInvalid,
+					Field:    "spec.runtimePatches",
+					BadValue: patchForUnknownContainer,
+				},
+			},
+		},
+		"runtimePatches reference an initContainer that the runtime does not have": {
+			obj: testingutil.MakeTrainJobWrapper("default", "valid-job-name").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
+				RuntimePatches(patchForUnknownInitContainer).
+				Obj(),
+			clusterTrainingRuntime: testingutil.MakeClusterTrainingRuntimeWrapper("test-runtime").
+				RuntimeSpec(trainer.TrainingRuntimeSpec{
+					Template: trainer.JobSetTemplateSpec{
+						Spec: testingutil.MakeJobSetWrapper("", "").Obj().Spec,
+					},
+				}).Obj(),
+			wantError: field.ErrorList{
+				&field.Error{
+					Type:     field.ErrorTypeInvalid,
+					Field:    "spec.runtimePatches",
+					BadValue: patchForUnknownInitContainer,
+				},
+			},
+		},
+		"runtimePatches set an empty Volcano queue name": {
+			obj: testingutil.MakeTrainJobWrapper("default", "valid-job-name").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind), "test-runtime").
+				RuntimePatches(patchWithEmptyVolcanoQueue).
+				Obj(),
+			clusterTrainingRuntime: testingutil.MakeClusterTrainingRuntimeWrapper("test-runtime").
+				RuntimeSpec(trainer.TrainingRuntimeSpec{
+					Template: trainer.JobSetTemplateSpec{
+						Spec: testingutil.MakeJobSetWrapper("", "").Obj().Spec,
+					},
+					PodGroupPolicy: &trainer.PodGroupPolicy{
+						PodGroupPolicySource: trainer.PodGroupPolicySource{
+							Volcano: &trainer.VolcanoPodGroupPolicySource{},
+						},
+					},
+				}).Obj(),
+			wantError: field.ErrorList{
+				&field.Error{
+					Type:     field.ErrorTypeInvalid,
+					Field:    "spec.annotations[" + volcanov1beta1.QueueNameAnnotationKey + "]",
+					BadValue: "",
+				},
+			},
 		},
 		"deprecated runtime referenced": {
 			obj: testingutil.MakeTrainJobWrapper("default", "valid-job-name").

--- a/test/integration/webhooks/trainjob_test.go
+++ b/test/integration/webhooks/trainjob_test.go
@@ -651,6 +651,38 @@ var _ = ginkgo.Describe("TrainJob marker validations and defaulting", ginkgo.Ord
 						Obj()
 				},
 				testingutil.BeForbiddenError()),
+			ginkgo.Entry("Should fail to create trainJob with RuntimePatches for a container that the runtime does not have",
+				func() *trainer.TrainJob {
+					return testingutil.MakeTrainJobWrapper(ns.Name, "unknown-container-in-runtimepatches").
+						RuntimeRef(trainer.GroupVersion.WithKind(trainer.TrainingRuntimeKind), "testing").
+						RuntimePatches([]trainer.RuntimePatch{
+							{
+								Manager: "acme.io/manager",
+								TrainingRuntimeSpec: &trainer.TrainingRuntimeSpecPatch{
+									Template: &trainer.JobSetTemplatePatch{
+										Spec: &trainer.JobSetSpecPatch{
+											ReplicatedJobs: []trainer.ReplicatedJobPatch{{
+												Name: constants.Node,
+												Template: &trainer.JobTemplatePatch{
+													Spec: &trainer.JobSpecPatch{
+														Template: &trainer.PodTemplatePatch{
+															Spec: &trainer.PodSpecPatch{
+																Containers: []trainer.ContainerPatch{{
+																	Name: "unknown-container",
+																}},
+															},
+														},
+													},
+												},
+											}},
+										},
+									},
+								},
+							},
+						}).
+						Obj()
+				},
+				testingutil.BeForbiddenError()),
 			ginkgo.Entry("Should succeed to create TrainJob with valid terminationGracePeriodSeconds in RuntimePatches",
 				func() *trainer.TrainJob {
 					return testingutil.MakeTrainJobWrapper(ns.Name, "valid-termination-grace-period").


### PR DESCRIPTION
## Summary

The Info that `JobSet.Validate` inspects is built after the TrainJob's `runtimePatches` have been merged into the runtime template. That merge is a strategic merge patch keyed on `name`, so an entry the runtime never declared is added rather than flagged, and every guard that checks a patch against the runtime — unknown replicated job, initContainer, or container — compared the patch with itself and passed. Since `ContainerPatch` cannot set an image, such a patch yields a Pod the JobSet controller can never run, and the TrainJob fails long after admission with nothing pointing back at the patch.

Merging now happens on the build path alone. Patch metadata still propagates into the Info that validation sees, because the labels and annotations managers set — the Volcano queue name among them — are validated themselves.

A second gap had the same effect: a replicated job's initContainer and container names were kept in one set, so a patch could address a container by the name of an initContainer, or the reverse.

## Behavior change

A TrainJob whose runtimePatches reference a replicated job, initContainer, or container that the runtime does not declare is now rejected at admission.

**Checklist:**

- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing

---
Generated-by: Claude Code (Claude Opus 5), reviewed by the author, per the [Kubeflow AI Policy](https://www.kubeflow.org/docs/about/ai_policy/)