### PR TITLE
chore(docs): add gRPC API schema for SearchAlgorithmService to KEP-3562

### DIFF
--- a/pkg/apis/optimizer/v1alpha1/search_algorithm.proto
+++ b/pkg/apis/optimizer/v1alpha1/search_algorithm.proto
@@ -1,0 +1,267 @@
+/*
+Copyright The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+syntax = "proto3";
+
+package trainer.optimizer.v1alpha1;
+
+option go_package = "github.com/kubeflow/trainer/v2/pkg/apis/optimizer/v1alpha1;optimizerv1alpha1";
+
+// SearchAlgorithmService generates hyperparameter suggestions for an
+// OptimizationJob. The OptimizationJob controller is the only client.
+//
+// The service is a pure function of its request. It MUST NOT require any state
+// that survives a process restart: the controller reconstructs the full trial
+// history from child TrainJobs on every reconcile and sends it with each call.
+// A provider MAY cache a study in memory as an optimization, but dropping that
+// cache MUST NOT change the observable result beyond sampler randomness.
+service SearchAlgorithmService {
+  // Validate reports whether this provider can serve the given specification.
+  // The controller calls it once, before creating any TrainJob, so that an
+  // unsupported search space surfaces as a condition on the OptimizationJob
+  // rather than as a failed trial.
+  rpc Validate(ValidateRequest) returns (ValidateResponse);
+
+  // Suggest returns parameter assignments for trials the controller is about
+  // to create. The controller allocates trial names before calling, so the
+  // response can be bound to specific TrainJobs without a second round trip.
+  rpc Suggest(SuggestRequest) returns (SuggestResponse);
+}
+
+// ---------------------------------------------------------------------------
+// Requests and responses
+// ---------------------------------------------------------------------------
+
+message ValidateRequest {
+  // spec is the optimization specification to validate.
+  OptimizationSpec spec = 1;
+}
+
+message ValidateResponse {
+  // issues is empty when the specification is supported. Each entry is a
+  // human-readable reason the provider cannot serve the request, suitable for
+  // surfacing in an OptimizationJob condition message.
+  repeated ValidationIssue issues = 1;
+}
+
+message ValidationIssue {
+  // parameter is the name of the offending parameter, when the issue is
+  // attributable to one. Empty for specification-level issues.
+  optional string parameter = 1;
+
+  // message describes why the specification cannot be served.
+  string message = 2;
+}
+
+message SuggestRequest {
+  // spec is the optimization specification. It is immutable for the lifetime
+  // of an OptimizationJob (enforced by CEL on OptimizationJobSpec), so a
+  // provider MAY key a cached study on it.
+  OptimizationSpec spec = 1;
+
+  // trials is the complete history the controller knows about, reconstructed
+  // from child TrainJobs. It includes trials in every state, not only
+  // succeeded ones: a provider needs failures to avoid re-proposing a region
+  // that cannot be evaluated.
+  //
+  // Size note: this grows with the trial count. OptimizationJobSpec caps
+  // numTrials at 100 today, which keeps a request well inside gRPC's default
+  // 4 MiB receive limit. If that cap is raised, this field is what will exceed
+  // it first, and the request should gain a cursor rather than the limit being
+  // raised.
+  repeated TrialRecord trials = 2;
+
+  // trial_names are the names of the TrainJobs the controller has allocated
+  // and is about to create. The provider MUST return exactly one suggestion
+  // per name, in the same order.
+  //
+  // Allocating names before asking is what makes the call idempotent: a
+  // reconcile that is retried after a crash re-sends the same names, and the
+  // controller can detect that those TrainJobs already exist.
+  repeated string trial_names = 3;
+}
+
+message SuggestResponse {
+  // suggestions has one entry per entry in trial_names, in the same order.
+  repeated Suggestion suggestions = 1;
+}
+
+message Suggestion {
+  // trial_name echoes the requested name this suggestion is for.
+  string trial_name = 1;
+
+  // assignments is the value chosen for every parameter in the search space.
+  repeated ParameterAssignment assignments = 2;
+}
+
+// ---------------------------------------------------------------------------
+// Specification
+// ---------------------------------------------------------------------------
+
+// OptimizationSpec mirrors the parts of OptimizationJobSpec a provider needs.
+// It deliberately omits fields that are the controller's concern, such as
+// numTrials, parallelTrials and the TrainJob template.
+message OptimizationSpec {
+  // objective is the metric being optimized. OptimizationJobSpec permits
+  // exactly one objective today; this is a repeated field so that
+  // multi-objective optimization does not require a breaking change.
+  repeated Objective objectives = 1;
+
+  // parameters is the search space.
+  repeated Parameter parameters = 2;
+
+  // algorithm selects the sampler.
+  SearchAlgorithm algorithm = 3;
+}
+
+message Objective {
+  // metric is the name of the metric reported by the training job.
+  string metric = 1;
+
+  // direction is whether the metric should be minimized or maximized.
+  ObjectiveDirection direction = 2;
+}
+
+enum ObjectiveDirection {
+  OBJECTIVE_DIRECTION_UNSPECIFIED = 0;
+  OBJECTIVE_DIRECTION_MINIMIZE = 1;
+  OBJECTIVE_DIRECTION_MAXIMIZE = 2;
+}
+
+message Parameter {
+  // name is the hyperparameter name.
+  string name = 1;
+
+  // search_space is the domain to sample from.
+  SearchSpace search_space = 2;
+}
+
+// SearchSpace mirrors the discriminated union in the CRD. Using a oneof rather
+// than a type enum plus a shared bounds message means an unsupported
+// combination, such as bounds on a categorical parameter, cannot be expressed
+// on the wire at all.
+message SearchSpace {
+  oneof space {
+    UniformSpace uniform = 1;
+    LogUniformSpace log_uniform = 2;
+    CategoricalSpace categorical = 3;
+  }
+}
+
+message UniformSpace {
+  // min and max are decimal strings, carried verbatim from the CRD, which
+  // encodes them as strings to avoid float parsing differences between the
+  // Go controller and a Python provider. A provider MUST parse them with a
+  // decimal-aware parser and MUST NOT round-trip them through float32.
+  string min = 1;
+  string max = 2;
+
+  // type is the underlying numeric type. An Int parameter is sampled over
+  // integers; a Float parameter over reals.
+  ParameterType type = 3;
+}
+
+message LogUniformSpace {
+  // min and max are decimal strings. min is guaranteed positive by CEL
+  // validation on the CRD.
+  string min = 1;
+  string max = 2;
+
+  // type is the underlying numeric type.
+  ParameterType type = 3;
+}
+
+message CategoricalSpace {
+  // choices is the set of values to sample from.
+  repeated string choices = 1;
+}
+
+enum ParameterType {
+  PARAMETER_TYPE_UNSPECIFIED = 0;
+  PARAMETER_TYPE_INT = 1;
+  PARAMETER_TYPE_FLOAT = 2;
+}
+
+// SearchAlgorithm mirrors the CRD union. A provider that receives an algorithm
+// it does not implement MUST fail Validate rather than silently substituting
+// another sampler.
+message SearchAlgorithm {
+  oneof algorithm {
+    RandomAlgorithm random = 1;
+    GridAlgorithm grid = 2;
+  }
+}
+
+message RandomAlgorithm {
+  // seed makes sampling reproducible. Absent means the provider chooses.
+  optional int64 seed = 1;
+}
+
+message GridAlgorithm {}
+
+// ---------------------------------------------------------------------------
+// Trial history
+// ---------------------------------------------------------------------------
+
+message TrialRecord {
+  // name is the TrainJob name. It is the identity of the trial and is stable
+  // across restarts of both the controller and the provider.
+  string name = 1;
+
+  // assignments is what was suggested for this trial.
+  repeated ParameterAssignment assignments = 2;
+
+  // state is the observed outcome.
+  TrialState state = 3;
+
+  // objective_value is the final value of the objective metric. It is set when
+  // state is SUCCEEDED or EARLY_STOPPED, and unset otherwise. Explicit
+  // presence matters: a metric of 0.0 is a legitimate result and must be
+  // distinguishable from "not reported".
+  optional string objective_value = 4;
+}
+
+enum TrialState {
+  TRIAL_STATE_UNSPECIFIED = 0;
+
+  // The trial is created or running. It has no result yet, but a provider
+  // should account for it so that parallel suggestions do not collapse onto
+  // the same region.
+  TRIAL_STATE_RUNNING = 1;
+
+  // The trial finished and reported the objective metric.
+  TRIAL_STATE_SUCCEEDED = 2;
+
+  // The trial finished without a usable objective value: the TrainJob failed,
+  // was evicted, or never reported the metric. A provider MUST record this as
+  // a failure rather than ignoring it, so the region is not re-proposed and no
+  // in-flight trial is leaked.
+  TRIAL_STATE_FAILED = 3;
+
+  // The trial was stopped before completion by a pruning decision. Reserved
+  // for the pruning work tracked in #3802; providers may treat it as FAILED
+  // until then.
+  TRIAL_STATE_EARLY_STOPPED = 4;
+}
+
+message ParameterAssignment {
+  // name is the hyperparameter name.
+  string name = 1;
+
+  // value is the assigned value, encoded as a string for the same reason the
+  // bounds are.
+  string value = 2;
+}

--- a/proposals/2605-optimization-job-crd/README.md
+++ b/proposals/2605-optimization-job-crd/README.md
@@ -435,6 +435,64 @@ The core successful conditions for the Phase 1 MVP are:
 - **Complete**: The conditions of the `TrialPolicy` have been satisfied (e.g., the desired `NumTrials` have successfully finished) and the best result has been recorded.
 - **Failed**: The `OptimizationJob` encountered a terminal error preventing further execution (e.g., the backend suggestion gRPC service crashed).
 
+### 7.5 gRPC API Schema
+
+This section defines the schema for the contract between the OptimizationJob controller and a search algorithm provider. The service is named `SearchAlgorithmService` to align with `spec.searchAlgorithm` in the CRD.
+
+The schema lives at `pkg/apis/optimizer/v1alpha1/search_algorithm.proto`.
+
+**Constraints the schema has to satisfy**
+
+Three properties this KEP already commits to are not expressible through the Katib `api.v1.beta1` messages, which is what shapes the design below.
+
+**A restarted provider cannot resume a job.** 7.3 specifies that the controller passes a full, point-in-time snapshot and that the provider calculates the next parameters and returns them, "forgetting" the interaction immediately. In the Optuna service, a completed trial is matched back to an Optuna trial number by string-joining its sorted assignments into a key such as `lr:0.01,batch:32` ([`base_service.py:105-108`](https://github.com/kubeflow/katib/blob/master/pkg/suggestion/v1beta1/optuna/base_service.py#L105-L108)). That index is populated only in `_ask`, and `optuna.create_study` is called with no storage backend ([`base_service.py:45`](https://github.com/kubeflow/katib/blob/master/pkg/suggestion/v1beta1/optuna/base_service.py#L45)), so both live in process memory. After a provider restart the controller replays history as specified, every trial misses the empty index, and `_tell` raises `ValueError("An unknown trial has been passed in the GetSuggestion request.")` ([`base_service.py:98-102`](https://github.com/kubeflow/katib/blob/master/pkg/suggestion/v1beta1/optuna/base_service.py#L98-L102)), failing the RPC. The controller is stateless; the provider is the only component that remembers, and it cannot be restarted.
+
+**Failed trials cannot be represented.** `Trial.convert` forwards only `SUCCEEDED` and `EARLYSTOPPED` ([`trial.py:40-52`](https://github.com/kubeflow/katib/blob/master/pkg/suggestion/v1beta1/internal/trial.py#L40-L52)), so a failed trial is never passed to `study.tell` and its Optuna trial stays `RUNNING` for the lifetime of the study. TPE is configured with `constant_liar=True` ([`service.py:113-114`](https://github.com/kubeflow/katib/blob/master/pkg/suggestion/v1beta1/optuna/service.py#L113-L114)), which treats a running trial as a pessimistic in-flight observation, so that region of the search space stays penalised. This is what #3743 needs to express.
+
+**`logUniform` reaches the sampler as `uniform`.** `FeasibleSpace` carries a `distribution` field. On the consumer side an unset distribution is normalised to `None` ([`search_space.py:83-91`](https://github.com/kubeflow/katib/blob/master/pkg/suggestion/v1beta1/internal/search_space.py#L83-L91)), and `None` shares a branch with explicit `UNIFORM` ([`base_service.py:115`](https://github.com/kubeflow/katib/blob/master/pkg/suggestion/v1beta1/optuna/base_service.py#L115)), producing `log=False`. A log-uniform search space is then sampled on a linear scale with no error raised. This is the same class of defect as kubeflow/katib#2666 and kubeflow/katib#2679.
+
+**Design**
+
+**Trial identity comes from the TrainJob name.** `SuggestRequest` carries `trial_names`, allocated by the controller before the call, and the provider returns one suggestion per name. This removes the assignment-string join: a trial is identified by the name of the TrainJob that runs it, which is stable across a restart of either component. It also makes the call idempotent, since a retried reconcile re-sends the same names.
+
+**History carries trial state.** `TrialRecord.state` distinguishes `RUNNING`, `SUCCEEDED`, `FAILED` and `EARLY_STOPPED`, so a provider can record a failure as a terminal state rather than leaving a trial in flight.
+
+**Search space and algorithm are `oneof`s, mirroring the CRD.** An unsupported combination, such as numeric bounds on a categorical parameter, cannot be expressed on the wire. The distribution defect above originates in a flat message where every field is always present.
+
+**Numeric bounds stay decimal strings.** The CRD encodes `min` and `max` as strings with a regex permitting exponent notation, to avoid float parsing differences between the Go controller and a Python provider. The schema carries them verbatim.
+
+`objective_value` uses explicit presence, since a metric of `0.0` is a valid result and has to be distinguishable from a trial that reported nothing.
+
+**Message size**
+
+gRPC defaults to a 4 MiB receive limit, and the send side is unlimited, so an oversized request fails at the receiver rather than the sender. `OptimizationJobSpec` caps `numTrials` at 100, which keeps `SuggestRequest` well inside that limit. If the cap is raised, `trials` is the field that grows, and a cursor would be preferable to raising the limit.
+
+**File placement and code generation**
+
+The schema is placed under `pkg/apis/optimizer/v1alpha1/` rather than `pkg/apis/trainer/v1alpha1/`. The latter declares `+k8s:deepcopy-gen=package` in `doc.go`, and `make generate` runs `controller-gen` over `./pkg/apis/...` recursively, so generated protobuf types placed there would have DeepCopy methods generated over `protoimpl.MessageState`. A sibling package with no generator markers is type-checked and produces nothing.
+
+`hack/update-codegen.sh` is unaffected, since `code-generator` discovers inputs by grepping for marker comments that `protoc-gen-go` output does not carry.
+
+Two mechanical notes for whoever wires up generation:
+
+- `make verify-boilerplate` checks generated `.go` files against
+  `boilerplate.go.txt`, and `protoc-gen-go` emits `//` line comments rather than
+  a `/* */` block, so the header has to be prepended after generation.
+  `hack/python-api/gen-api.sh` already does this for OpenAPI output.
+- `google.golang.org/grpc` is not currently a direct dependency of the module.
+
+Following Katib, generation would use `buf`. The schema passes `buf lint` with the `DEFAULT` rule set.
+
+**Open questions**
+
+1. Whether `SearchAlgorithmService` should also serve pruning methods, or
+   whether pruning belongs in a separate service. ASHA and Hyperband decide by
+   comparing a trial against others at the same rung, and that state lives in
+   the same Optuna study the sampler uses. Deferred per the discussion on #3828.
+2. Intermediate metrics are not in this schema. Optuna pruners are driven by
+   `trial.report(value, step)` and `should_prune()`, so #3802 will need a
+   per-trial `(step, value)` series added to `TrialRecord`.
+
 ## 8. Design Decisions & Open Discussions
 
 ### 8.1. Decision: Decoupling the gRPC Contract


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the gRPC API schema section to the KEP, per #3796.

Three things this KEP commits to are not expressible through the Katib `api.v1.beta1` messages, and the section walks through each with the relevant code:

- 7.3 specifies the provider "forgets" each interaction, but a restarted provider cannot resume a job. Trials are matched back to Optuna by string-joining their assignments, and that index lives only in process memory, so replaying history raises `ValueError("An unknown trial has been passed in the GetSuggestion request.")`.
- Failed trials cannot be represented. Only `SUCCEEDED` and `EARLYSTOPPED` are forwarded, so a failed trial stays `RUNNING` in the study, and TPE runs with `constant_liar=True`. This is what #3743 needs to express.
- `logUniform` reaches the sampler as `uniform`, since an unset distribution shares a branch with explicit `UNIFORM`.

The service is named `SearchAlgorithmService` per the discussion on #3828.

The schema is placed under `pkg/apis/optimizer/v1alpha1` rather than `pkg/apis/trainer/v1alpha1`, because the latter declares `+k8s:deepcopy-gen=package` and `make generate` runs controller-gen over `./pkg/apis/...` recursively. The section notes the two mechanical details for whoever wires up generation.

No codegen wiring in this PR, so `google.golang.org/grpc` is not yet a dependency. Happy to follow up with that once the schema looks right.

7.2 and 8.1 describe the adapter approach and would need revising if this is adopted. I left those alone, let me know how you would like to handle it.

I have a script that reproduces the restart failure and the leaked trial if that is useful.

**Which issue(s) this PR fixes**:

Part of #3796. Not using `Fixes` since the schema still needs codegen wiring and an implementation before that issue is done.

**Checklist:**

- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing

This is a proposal change, so there is nothing user facing to document yet.
