### PR TITLE
feat: Add slurm-bridge scheduling documentation

### DIFF
--- a/docs/operator-guides/index.md
+++ b/docs/operator-guides/index.md
@@ -78,7 +78,7 @@ Understand the plugin-based extension architecture
 :link: job-scheduling/index
 :link-type: doc
 
-Integrate with Volcano, Kueue, Coscheduling, and KAI Scheduler
+Integrate with Volcano, Kueue, Coscheduling, KAI Scheduler, and Slurm Bridge
 ::::
 
 :::::

--- a/docs/operator-guides/job-scheduling/index.md
+++ b/docs/operator-guides/job-scheduling/index.md
@@ -42,6 +42,13 @@ Job queueing and resource management with Kueue
 Gang scheduling with NVIDIA KAI Scheduler
 ::::
 
+::::{grid-item-card} Slurm Bridge
+:link: slurm-bridge
+:link-type: doc
+
+Schedule TrainJobs on hybrid Kubernetes and Slurm clusters
+::::
+
 :::::
 
 ----
@@ -55,4 +62,5 @@ coscheduling
 volcano
 Kueue <https://kueue.sigs.k8s.io/docs/tasks/run/trainjobs/>
 kai
+slurm-bridge
 ```

--- a/docs/operator-guides/job-scheduling/overview.md
+++ b/docs/operator-guides/job-scheduling/overview.md
@@ -26,3 +26,4 @@ supported plugins.
 - Learn how to configure advanced scheduling with [Volcano Scheduler](volcano.md).
 - Learn how to configure job queueing and resource management with [Kueue](https://kueue.sigs.k8s.io/docs/tasks/run/trainjobs/).
 - Learn how to configure gang scheduling with [KAI Scheduler](kai.md).
+- Learn how to schedule TrainJobs with [Slurm Bridge](slurm-bridge.md).

--- a/docs/operator-guides/job-scheduling/slurm-bridge.md
+++ b/docs/operator-guides/job-scheduling/slurm-bridge.md
@@ -1,0 +1,199 @@
+# Slurm Bridge
+
+This guide describes how to schedule Kubeflow TrainJobs with
+[Slurm Bridge](https://github.com/SlinkyProject/slurm-bridge) using Trainer's Coscheduling
+`PodGroupPolicy`.
+
+Trainer creates one `PodGroup` for the TrainJob and adds every generated Pod to
+that group. Slurm Bridge submits the group as one external Slurm job, waits for Slurm to allocate
+nodes, and then binds the Pods to those nodes.
+
+Slurm applies its configured topology, priority, and backfill policies to the job. When `kubelet`
+and `slurmd` run on the same compute nodes, Kubernetes and native Slurm workloads can share the
+same pool.
+
+This integration uses the scheduler-plugins `scheduling.x-k8s.io/v1alpha1` API. It does not require
+the native Kubernetes 1.36 Workload APIs or their feature gates.
+
+Slurm Bridge also supports the native Kubernetes PodGroup API on Kubernetes 1.36 and later. See the
+Slurm Bridge
+[PodGroup comparison](https://github.com/SlinkyProject/slurm-bridge/blob/main/docs/workload.md#podgroup-coscheduling)
+for the distinction between the two APIs.
+
+## Prerequisites
+
+- [Kubeflow Trainer installed](../installation.md), including JobSet.
+- [Slurm Bridge installed and connected to Slurm](https://github.com/SlinkyProject/slurm-bridge/blob/main/docs/quickstart.md).
+- `kubelet` and `slurmd` running on the compute nodes used by Slurm Bridge.
+- Matching Kubernetes and Slurm node names. If the names differ, label each Kubernetes Node with
+  `slinky.slurm.net/slurm-nodename: <slurm-node-name>`.
+
+Review the [Slurm Bridge compatibility requirements](https://github.com/SlinkyProject/slurm-bridge#compatibility)
+before selecting Kubernetes, Slurm, Slurm Bridge, and scheduler-plugins versions.
+
+## Install the Coscheduling API and Controller
+
+Install the scheduler-plugins `PodGroup` CRD and CoScheduling controller:
+
+```bash
+helm install --repo https://scheduler-plugins.sigs.k8s.io scheduler-plugins scheduler-plugins \
+  --namespace scheduler-plugins --create-namespace \
+  --set 'plugins.enabled={CoScheduling}' \
+  --set 'scheduler.replicaCount=0'
+```
+
+The scheduler replica count must remain zero. Slurm Bridge schedules the Pods; the
+scheduler-plugins installation supplies only the `PodGroup` API and controller required by the
+integration.
+
+Trainer discovers the scheduler-plugins API when its controller starts. Install the `PodGroup` CRD
+before installing Trainer or restart the Trainer controller after installing the CRD.
+
+Verify that the API is available:
+
+```bash
+kubectl api-resources --api-group=scheduling.x-k8s.io
+kubectl get pods -n scheduler-plugins
+```
+
+The API resource output should include `podgroups`.
+
+## Create a Slurm-enabled Runtime
+
+Create a dedicated runtime with the Coscheduling policy:
+
+```yaml
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: ClusterTrainingRuntime
+metadata:
+  name: torch-distributed-slurm
+  labels:
+    trainer.kubeflow.org/framework: torch
+spec:
+  mlPolicy:
+    numNodes: 1
+    torch: {}
+  podGroupPolicy:
+    coscheduling: {}
+  template:
+    spec:
+      replicatedJobs:
+        - name: node
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: trainer
+            spec:
+              template:
+                spec:
+                  containers:
+                    - name: node
+                      image: pytorch/pytorch:2.13.0-cuda13.0-cudnn9-runtime
+```
+
+```bash
+kubectl apply -f runtime.yaml
+```
+
+Trainer calculates the `PodGroup` member count and resources from the runtime.
+
+:::{note}
+Trainer sets a default `scheduleTimeoutSeconds` on the generated scheduler-plugins `PodGroup`.
+Slurm Bridge ignores that field, so it does not limit how long the external Slurm job can remain
+pending.
+:::
+
+## Route TrainJobs to Slurm Bridge
+
+Create a dedicated namespace for Slurm-scheduled TrainJobs:
+
+```bash
+kubectl create namespace trainer-slurm
+```
+
+Add the namespace to the Slurm Bridge Helm values:
+
+```yaml
+admission:
+  managedNamespaces:
+    - trainer-slurm
+```
+
+Apply the updated values when installing or upgrading Slurm Bridge. Its admission controller changes
+`spec.schedulerName` from `default-scheduler` to `slurm-bridge-scheduler` for Pods in the managed
+namespace. Pods that explicitly select another scheduler are not rewritten.
+
+## Run a TrainJob
+
+Create a TrainJob that uses the Slurm-enabled runtime:
+
+```yaml
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  name: pytorch-slurm
+  namespace: trainer-slurm
+spec:
+  runtimeRef:
+    apiGroup: trainer.kubeflow.org
+    kind: ClusterTrainingRuntime
+    name: torch-distributed-slurm
+  trainer:
+    numNodes: 2
+    command:
+      - python3
+      - -c
+      - |
+        import os
+        import time
+
+        print(f"Training node {os.environ['PET_NODE_RANK']} is running")
+        time.sleep(60)
+    resourcesPerNode:
+      requests:
+        cpu: "1"
+        memory: 1Gi
+      limits:
+        cpu: "1"
+        memory: 1Gi
+```
+
+```bash
+kubectl apply -f trainjob.yaml
+kubectl get podgroups.scheduling.x-k8s.io pytorch-slurm -n trainer-slurm
+```
+
+The generated `PodGroup` has the same name and namespace as the TrainJob.
+
+:::{note}
+Slurm Bridge uses exclusive whole-node allocations by default. Native Kubernetes CPU requests
+reserve CPU capacity in Slurm but do not constrain the container to Slurm's allocated CPU set. Use
+Slurm Bridge CPU DRA when aligned CPU isolation is required.
+:::
+
+## Verify the TrainJob
+
+Check the Trainer resources and scheduler-plugins PodGroup:
+
+```bash
+kubectl get trainjobs,jobsets,jobs -n trainer-slurm
+kubectl get podgroups.scheduling.x-k8s.io -n trainer-slurm
+```
+
+Inspect the scheduler, Slurm job ID, allocated Slurm node, and bound Kubernetes Node:
+
+```bash
+kubectl get pods \
+  -n trainer-slurm \
+  -l jobset.sigs.k8s.io/jobset-name=pytorch-slurm \
+  -o custom-columns='NAME:.metadata.name,SCHEDULER:.spec.schedulerName,SLURM-JOB:.metadata.labels.scheduler\.slinky\.slurm\.net/slurm-jobid,SLURM-NODE:.metadata.annotations.slinky\.slurm\.net/slurm-node,NODE:.spec.nodeName'
+```
+
+The `scheduler.slinky.slurm.net/slurm-jobid` label confirms that Slurm Bridge submitted the external
+job. Non-empty Slurm and Kubernetes node columns confirm allocation. Use `squeue -j <job-id>` while
+the external job is pending or running to see its entry in Slurm.
+
+## Next Steps
+
+- Review Slurm Bridge [workload and resource support](https://github.com/SlinkyProject/slurm-bridge/blob/main/docs/workload.md).
+- Review the [Slurm Bridge architecture](https://github.com/SlinkyProject/slurm-bridge/blob/main/docs/architecture.md).

--- a/docs/operator-guides/job-scheduling/slurm-bridge.md
+++ b/docs/operator-guides/job-scheduling/slurm-bridge.md
@@ -53,7 +53,21 @@ Verify that the API is available:
 
 ```bash
 kubectl api-resources --api-group=scheduling.x-k8s.io
+```
+
+```console
+NAME            SHORTNAMES   APIVERSION                     NAMESPACED   KIND
+elasticquotas   eq,eqs       scheduling.x-k8s.io/v1alpha1   true         ElasticQuota
+podgroups       pg,pgs       scheduling.x-k8s.io/v1alpha1   true         PodGroup
+```
+
+```bash
 kubectl get pods -n scheduler-plugins
+```
+
+```console
+NAME                                           READY   STATUS    RESTARTS   AGE
+scheduler-plugins-controller-7469c866f-ngc7t   1/1     Running   0          21m
 ```
 
 The API resource output should include `podgroups`.
@@ -183,7 +197,26 @@ Check the Trainer resources and scheduler-plugins PodGroup:
 
 ```bash
 kubectl get trainjobs,jobsets,jobs -n trainer-slurm
+```
+
+```console
+NAME                                          STATE      AGE
+trainjob.trainer.kubeflow.org/pytorch-slurm   Complete   76s
+
+NAME                                   TERMINALSTATE   RESTARTS   COMPLETED   SUSPENDED   AGE
+jobset.jobset.x-k8s.io/pytorch-slurm   Completed       0          True        false       76s
+
+NAME                             STATUS     COMPLETIONS   DURATION   AGE
+job.batch/pytorch-slurm-node-0   Complete   2/2           71s        76s
+```
+
+```bash
 kubectl get podgroups.scheduling.x-k8s.io -n trainer-slurm
+```
+
+```console
+NAME            PHASE      MINMEMBER   RUNNING   SUCCEEDED   FAILED   AGE
+pytorch-slurm   Finished   2                     2                    81s
 ```
 
 Inspect the scheduler, Slurm job ID, allocated Slurm node, and bound Kubernetes Node:
@@ -193,6 +226,12 @@ kubectl get pods \
   -n trainer-slurm \
   -l jobset.sigs.k8s.io/jobset-name=pytorch-slurm \
   -o custom-columns='NAME:.metadata.name,SCHEDULER:.spec.schedulerName,SLURM-JOB:.metadata.labels.scheduler\.slinky\.slurm\.net/slurm-jobid,SLURM-NODE:.metadata.annotations.slinky\.slurm\.net/slurm-node,NODE:.spec.nodeName'
+```
+
+```console
+NAME                           SCHEDULER                SLURM-JOB   SLURM-NODE                   NODE
+pytorch-slurm-node-0-0-6cv72   slurm-bridge-scheduler   2           trainer-guide-3951-worker4   trainer-guide-3951-worker4
+pytorch-slurm-node-0-1-kjn4j   slurm-bridge-scheduler   2           trainer-guide-3951-worker5   trainer-guide-3951-worker5
 ```
 
 The `scheduler.slinky.slurm.net/slurm-jobid` label confirms that Slurm Bridge submitted the external

--- a/docs/operator-guides/job-scheduling/slurm-bridge.md
+++ b/docs/operator-guides/job-scheduling/slurm-bridge.md
@@ -22,7 +22,7 @@ for the distinction between the two APIs.
 
 ## Prerequisites
 
-- [Kubeflow Trainer installed](../installation.md), including JobSet.
+- [Kubeflow Trainer installed](../installation.md).
 - [Slurm Bridge installed and connected to Slurm](https://github.com/SlinkyProject/slurm-bridge/blob/main/docs/quickstart.md).
 - `kubelet` and `slurmd` running on the compute nodes used by Slurm Bridge.
 - Matching Kubernetes and Slurm node names. If the names differ, label each Kubernetes Node with
@@ -111,17 +111,22 @@ Create a dedicated namespace for Slurm-scheduled TrainJobs:
 kubectl create namespace trainer-slurm
 ```
 
-Add the namespace to the Slurm Bridge Helm values:
+Add the namespace to an existing Slurm Bridge helm installation:
 
-```yaml
-admission:
-  managedNamespaces:
-    - trainer-slurm
+```bash
+helm upgrade slurm-bridge oci://ghcr.io/slinkyproject/charts/slurm-bridge \
+  --namespace slurm \
+  --reuse-values \
+  --set 'admission.managedNamespaces={trainer-slurm}'
 ```
 
-Apply the updated values when installing or upgrading Slurm Bridge. Its admission controller changes
-`spec.schedulerName` from `default-scheduler` to `slurm-bridge-scheduler` for Pods in the managed
-namespace. Pods that explicitly select another scheduler are not rewritten.
+See the
+[Slurm Bridge Helm values](https://github.com/SlinkyProject/slurm-bridge/blob/main/helm/slurm-bridge/values.yaml)
+for additional configuration options.
+
+The Slurm Bridge admission controller changes `spec.schedulerName` from `default-scheduler` to
+`slurm-bridge-scheduler` for Pods in the managed namespace. Pods that explicitly select another
+scheduler are not rewritten.
 
 ## Run a TrainJob
 
@@ -168,7 +173,8 @@ The generated `PodGroup` has the same name and namespace as the TrainJob.
 :::{note}
 Slurm Bridge uses exclusive whole-node allocations by default. Native Kubernetes CPU requests
 reserve CPU capacity in Slurm but do not constrain the container to Slurm's allocated CPU set. Use
-Slurm Bridge CPU DRA when aligned CPU isolation is required.
+[Slurm Bridge CPU DRA](https://github.com/SlinkyProject/slurm-bridge/blob/main/docs/workload.md#cpu-dra)
+when aligned CPU isolation is required.
 :::
 
 ## Verify the TrainJob


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow Trainer, check the developer guide:
    https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Add a guide for scheduling train jobs with slurm-bridge.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Related to #2249  - but may not close it. This guide describes using slurm as the scheduler for TrainJobs, but not a full runtime. 

**Checklist:**

- [x] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing
