### PR TITLE
fix(framework): prevent initializer STORAGE_URI env from overriding storageUri

### DIFF
--- a/pkg/runtime/framework/plugins/jobset/builder.go
+++ b/pkg/runtime/framework/plugins/jobset/builder.go
@@ -55,12 +55,12 @@ func (b *Builder) Initializer(trainJob *trainer.TrainJob) *Builder {
 				if *container.Name == constants.DatasetInitializer && trainJob.Spec.Initializer != nil && trainJob.Spec.Initializer.Dataset != nil {
 					env := &b.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.Containers[j].Env
 					// Update the dataset initializer envs.
+					apply.UpsertEnvVars(env, apply.EnvVars(trainJob.Spec.Initializer.Dataset.Env...)...)
 					if storageUri := trainJob.Spec.Initializer.Dataset.StorageUri; storageUri != nil {
 						apply.UpsertEnvVars(env, *corev1ac.EnvVar().
 							WithName(jobsetplgconsts.InitializerEnvStorageUri).
 							WithValue(*storageUri))
 					}
-					apply.UpsertEnvVars(env, apply.EnvVars(trainJob.Spec.Initializer.Dataset.Env...)...)
 					// Update the dataset initializer secret reference.
 					if trainJob.Spec.Initializer.Dataset.SecretRef != nil {
 						b.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.Containers[j].
@@ -81,12 +81,12 @@ func (b *Builder) Initializer(trainJob *trainer.TrainJob) *Builder {
 				if *container.Name == constants.ModelInitializer && trainJob.Spec.Initializer != nil && trainJob.Spec.Initializer.Model != nil {
 					env := &b.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.Containers[j].Env
 					// Update the model initializer envs.
+					apply.UpsertEnvVars(env, apply.EnvVars(trainJob.Spec.Initializer.Model.Env...)...)
 					if storageUri := trainJob.Spec.Initializer.Model.StorageUri; storageUri != nil {
 						apply.UpsertEnvVars(env, *corev1ac.EnvVar().
 							WithName(jobsetplgconsts.InitializerEnvStorageUri).
 							WithValue(*storageUri))
 					}
-					apply.UpsertEnvVars(env, apply.EnvVars(trainJob.Spec.Initializer.Model.Env...)...)
 					// Update the model initializer secret reference.
 					if trainJob.Spec.Initializer.Model.SecretRef != nil {
 						b.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.Containers[j].

--- a/pkg/runtime/framework/plugins/jobset/builder_test.go
+++ b/pkg/runtime/framework/plugins/jobset/builder_test.go
@@ -252,12 +252,12 @@ func TestBuilderInitializer(t *testing.T) {
 															Value: ptr.To("keep-me"),
 														},
 														{
-															Name:  ptr.To(jobsetplgconsts.InitializerEnvStorageUri),
-															Value: ptr.To("hf://my-org/my-dataset"),
-														},
-														{
 															Name:  ptr.To("CUSTOM_FROM_USER"),
 															Value: ptr.To("user-value"),
+														},
+														{
+															Name:  ptr.To(jobsetplgconsts.InitializerEnvStorageUri),
+															Value: ptr.To("hf://my-org/my-dataset"),
 														},
 													},
 												},
@@ -268,6 +268,110 @@ func TestBuilderInitializer(t *testing.T) {
 								ObjectMetaApplyConfiguration: &metav1ac.ObjectMetaApplyConfiguration{
 									Labels: map[string]string{
 										constants.LabelTrainJobAncestor: constants.DatasetInitializer,
+									},
+								},
+							},
+							Name:     ptr.To("initializer-job"),
+							Replicas: ptr.To[int32](1),
+						},
+					},
+				},
+			},
+		},
+		"dataset initializer storageUri takes precedence over STORAGE_URI in env": {
+			jobSet: makeJobSet(constants.DatasetInitializer, constants.DatasetInitializer, 2, "initializer-job"),
+			trainJob: &trainer.TrainJob{
+				Spec: trainer.TrainJobSpec{
+					Initializer: &trainer.Initializer{
+						Dataset: &trainer.DatasetInitializer{
+							StorageUri: ptr.To("hf://tatsu-lab/alpaca"),
+							Env: []corev1.EnvVar{
+								{
+									Name:  jobsetplgconsts.InitializerEnvStorageUri,
+									Value: "hf://other/repo",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantJobSet: &jobsetv1alpha2ac.JobSetApplyConfiguration{
+				Spec: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
+					ReplicatedJobs: []jobsetv1alpha2ac.ReplicatedJobApplyConfiguration{
+						{
+							Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+								Spec: &batchv1ac.JobSpecApplyConfiguration{
+									Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+										Spec: &corev1ac.PodSpecApplyConfiguration{
+											Containers: []corev1ac.ContainerApplyConfiguration{
+												{
+													Name: ptr.To(constants.DatasetInitializer),
+													Env: []corev1ac.EnvVarApplyConfiguration{
+														{
+															Name:  ptr.To(jobsetplgconsts.InitializerEnvStorageUri),
+															Value: ptr.To("hf://tatsu-lab/alpaca"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								ObjectMetaApplyConfiguration: &metav1ac.ObjectMetaApplyConfiguration{
+									Labels: map[string]string{
+										constants.LabelTrainJobAncestor: constants.DatasetInitializer,
+									},
+								},
+							},
+							Name:     ptr.To("initializer-job"),
+							Replicas: ptr.To[int32](1),
+						},
+					},
+				},
+			},
+		},
+		"model initializer storageUri takes precedence over STORAGE_URI in env": {
+			jobSet: makeJobSet(constants.ModelInitializer, constants.ModelInitializer, 2, "initializer-job"),
+			trainJob: &trainer.TrainJob{
+				Spec: trainer.TrainJobSpec{
+					Initializer: &trainer.Initializer{
+						Model: &trainer.ModelInitializer{
+							StorageUri: ptr.To("hf://meta-llama/Llama-3"),
+							Env: []corev1.EnvVar{
+								{
+									Name:  jobsetplgconsts.InitializerEnvStorageUri,
+									Value: "hf://other/model",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantJobSet: &jobsetv1alpha2ac.JobSetApplyConfiguration{
+				Spec: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
+					ReplicatedJobs: []jobsetv1alpha2ac.ReplicatedJobApplyConfiguration{
+						{
+							Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+								Spec: &batchv1ac.JobSpecApplyConfiguration{
+									Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+										Spec: &corev1ac.PodSpecApplyConfiguration{
+											Containers: []corev1ac.ContainerApplyConfiguration{
+												{
+													Name: ptr.To(constants.ModelInitializer),
+													Env: []corev1ac.EnvVarApplyConfiguration{
+														{
+															Name:  ptr.To(jobsetplgconsts.InitializerEnvStorageUri),
+															Value: ptr.To("hf://meta-llama/Llama-3"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								ObjectMetaApplyConfiguration: &metav1ac.ObjectMetaApplyConfiguration{
+									Labels: map[string]string{
+										constants.LabelTrainJobAncestor: constants.ModelInitializer,
 									},
 								},
 							},

--- a/pkg/runtime/framework/plugins/jobset/jobset.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -57,6 +58,27 @@ var (
 	runtimeRefPath     = field.NewPath("spec").Child("runtimeRef")
 	runtimePatchesPath = field.NewPath("spec").Child("runtimePatches")
 )
+
+func validateInitializerStorageUriEnv(storageUri *string, env []corev1.EnvVar, envPath *field.Path) field.ErrorList {
+	if storageUri == nil {
+		return nil
+	}
+	for _, envVar := range env {
+		if envVar.Name == jobsetplgconsts.InitializerEnvStorageUri {
+			return field.ErrorList{
+				field.Invalid(
+					envPath,
+					env,
+					fmt.Sprintf(
+						"must not set %q in env when storageUri is configured",
+						jobsetplgconsts.InitializerEnvStorageUri,
+					),
+				),
+			}
+		}
+	}
+	return nil
+}
 
 type JobSet struct {
 	client     client.Client
@@ -137,6 +159,11 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 				allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volumeMount with name - %s in container %s of the %s job", jobsetplgconsts.VolumeNameInitializer, constants.DatasetInitializer, constants.DatasetInitializer)))
 			}
 		}
+		allErrs = append(allErrs, validateInitializerStorageUriEnv(
+			newObj.Spec.Initializer.Dataset.StorageUri,
+			newObj.Spec.Initializer.Dataset.Env,
+			field.NewPath("spec").Child("initializer").Child("dataset").Child("env"),
+		)...)
 	}
 
 	if newObj.Spec.Initializer != nil && newObj.Spec.Initializer.Model != nil {
@@ -167,6 +194,11 @@ func (j *JobSet) Validate(ctx context.Context, info *runtime.Info, oldObj, newOb
 				allErrs = append(allErrs, field.Invalid(runtimeRefPath, newObj.Spec.RuntimeRef, fmt.Sprintf("must have volumeMount with name - %s in container %s of the %s job", jobsetplgconsts.VolumeNameInitializer, constants.ModelInitializer, constants.ModelInitializer)))
 			}
 		}
+		allErrs = append(allErrs, validateInitializerStorageUriEnv(
+			newObj.Spec.Initializer.Model.StorageUri,
+			newObj.Spec.Initializer.Model.Env,
+			field.NewPath("spec").Child("initializer").Child("model").Child("env"),
+		)...)
 	}
 
 	allErrs = append(allErrs, j.checkRuntimePatchesImmutability(ctx, oldObj, newObj)...)

--- a/pkg/runtime/framework/plugins/jobset/jobset_test.go
+++ b/pkg/runtime/framework/plugins/jobset/jobset_test.go
@@ -834,6 +834,181 @@ func TestValidate(t *testing.T) {
 					Model:   &trainer.ModelInitializer{},
 				}).Obj(),
 		},
+		"must not set STORAGE_URI in dataset env when storageUri is configured": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
+						VolumeClaimPolicies: []jobsetv1alpha2ac.VolumeClaimPolicyApplyConfiguration{
+							{
+								Templates: []corev1.PersistentVolumeClaim{
+									{
+										ObjectMeta: metav1.ObjectMeta{
+											Name: jobsetplgconsts.VolumeNameInitializer,
+										},
+									},
+								},
+							},
+						},
+						ReplicatedJobs: []jobsetv1alpha2ac.ReplicatedJobApplyConfiguration{
+							{
+								Name: ptr.To(constants.DatasetInitializer),
+								Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+									Spec: &batchv1ac.JobSpecApplyConfiguration{
+										Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+											Spec: &corev1ac.PodSpecApplyConfiguration{
+												Containers: []corev1ac.ContainerApplyConfiguration{
+													*corev1ac.Container().
+														WithName(constants.DatasetInitializer).
+														WithVolumeMounts(corev1ac.VolumeMount().
+															WithName(jobsetplgconsts.VolumeNameInitializer)),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newObj: utiltesting.MakeTrainJobWrapper("default", "test").
+				Initializer(&trainer.Initializer{
+					Dataset: utiltesting.MakeTrainJobDatasetInitializerWrapper().
+						StorageUri("hf://tatsu-lab/alpaca").
+						Env(corev1.EnvVar{
+							Name:  jobsetplgconsts.InitializerEnvStorageUri,
+							Value: "hf://other/repo",
+						}).
+						Obj(),
+				}).Obj(),
+			wantError: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec").Child("initializer").Child("dataset").Child("env"),
+					utiltesting.MakeTrainJobDatasetInitializerWrapper().
+						StorageUri("hf://tatsu-lab/alpaca").
+						Env(corev1.EnvVar{
+							Name:  jobsetplgconsts.InitializerEnvStorageUri,
+							Value: "hf://other/repo",
+						}).
+						Obj().Env,
+					fmt.Sprintf(
+						"must not set %q in env when storageUri is configured",
+						jobsetplgconsts.InitializerEnvStorageUri,
+					),
+				),
+			},
+		},
+		"must not set STORAGE_URI in model env when storageUri is configured": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
+						VolumeClaimPolicies: []jobsetv1alpha2ac.VolumeClaimPolicyApplyConfiguration{
+							{
+								Templates: []corev1.PersistentVolumeClaim{
+									{
+										ObjectMeta: metav1.ObjectMeta{
+											Name: jobsetplgconsts.VolumeNameInitializer,
+										},
+									},
+								},
+							},
+						},
+						ReplicatedJobs: []jobsetv1alpha2ac.ReplicatedJobApplyConfiguration{
+							{
+								Name: ptr.To(constants.ModelInitializer),
+								Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+									Spec: &batchv1ac.JobSpecApplyConfiguration{
+										Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+											Spec: &corev1ac.PodSpecApplyConfiguration{
+												Containers: []corev1ac.ContainerApplyConfiguration{
+													*corev1ac.Container().
+														WithName(constants.ModelInitializer).
+														WithVolumeMounts(corev1ac.VolumeMount().
+															WithName(jobsetplgconsts.VolumeNameInitializer)),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newObj: utiltesting.MakeTrainJobWrapper("default", "test").
+				Initializer(&trainer.Initializer{
+					Model: utiltesting.MakeTrainJobModelInitializerWrapper().
+						StorageUri("hf://meta-llama/Llama-3").
+						Env(corev1.EnvVar{
+							Name:  jobsetplgconsts.InitializerEnvStorageUri,
+							Value: "hf://other/model",
+						}).
+						Obj(),
+				}).Obj(),
+			wantError: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec").Child("initializer").Child("model").Child("env"),
+					utiltesting.MakeTrainJobModelInitializerWrapper().
+						StorageUri("hf://meta-llama/Llama-3").
+						Env(corev1.EnvVar{
+							Name:  jobsetplgconsts.InitializerEnvStorageUri,
+							Value: "hf://other/model",
+						}).
+						Obj().Env,
+					fmt.Sprintf(
+						"must not set %q in env when storageUri is configured",
+						jobsetplgconsts.InitializerEnvStorageUri,
+					),
+				),
+			},
+		},
+		"dataset initializer with STORAGE_URI env only passes when storageUri is unset": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
+						VolumeClaimPolicies: []jobsetv1alpha2ac.VolumeClaimPolicyApplyConfiguration{
+							{
+								Templates: []corev1.PersistentVolumeClaim{
+									{
+										ObjectMeta: metav1.ObjectMeta{
+											Name: jobsetplgconsts.VolumeNameInitializer,
+										},
+									},
+								},
+							},
+						},
+						ReplicatedJobs: []jobsetv1alpha2ac.ReplicatedJobApplyConfiguration{
+							{
+								Name: ptr.To(constants.DatasetInitializer),
+								Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+									Spec: &batchv1ac.JobSpecApplyConfiguration{
+										Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+											Spec: &corev1ac.PodSpecApplyConfiguration{
+												Containers: []corev1ac.ContainerApplyConfiguration{
+													*corev1ac.Container().
+														WithName(constants.DatasetInitializer).
+														WithVolumeMounts(corev1ac.VolumeMount().
+															WithName(jobsetplgconsts.VolumeNameInitializer)),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			newObj: utiltesting.MakeTrainJobWrapper("default", "test").
+				Initializer(&trainer.Initializer{
+					Dataset: utiltesting.MakeTrainJobDatasetInitializerWrapper().
+						Env(corev1.EnvVar{
+							Name:  jobsetplgconsts.InitializerEnvStorageUri,
+							Value: "hf://only/env",
+						}).
+						Obj(),
+				}).Obj(),
+		},
 		"must have volumeMount with name - initializer in the dataset initializer container": {
 			info: &runtime.Info{
 				TemplateSpec: runtime.TemplateSpec{


### PR DESCRIPTION
## Summary
- Apply user initializer env first, then upsert `STORAGE_URI` from `storageUri` so the structured field is the runtime source of truth
- Reject `STORAGE_URI` in `initializer.dataset.env` / `initializer.model.env` at admission when `storageUri` is also configured (same pattern as reserved MPI/torch trainer envs)
- Allow `STORAGE_URI` in env only when `storageUri` is unset

Fixes #3955

## Test plan
- [x] `go test ./pkg/runtime/framework/plugins/jobset/... -run 'TestBuilderInitializer|TestValidate'`
- [x] Builder: conflicting `STORAGE_URI` in env is overridden by `storageUri`
- [x] Validate: dataset/model TrainJobs with both fields rejected at admission
- [x] Validate: `STORAGE_URI`-only env (no `storageUri`) still passes