### PR TITLE
chore(ci): add kep scope for PR titles

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -48,6 +48,7 @@ jobs:
             examples
             framework
             initializer
+            kep
             manifests
             runtimes
             scripts


### PR DESCRIPTION
KEP changes under `proposals/` have no matching scope in the semantic PR title check, so proposal PRs get filed under an unrelated scope or none at all. This adds `kep` to the allowed scopes in the title-check workflow.

_This PR was created using AI tools._