### PR TITLE
fix(controller): validate TrainJob updates against the runtime snapshot

### DIFF
--- a/pkg/runtime/core/clustertrainingruntime.go
+++ b/pkg/runtime/core/clustertrainingruntime.go
@@ -98,14 +98,33 @@ func (r *ClusterTrainingRuntime) EventHandlerRegistrars() []runtime.ReconcilerBu
 
 func (r *ClusterTrainingRuntime) ValidateObjects(ctx context.Context, old, new *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
 	clusterTrainingRuntime := &trainer.ClusterTrainingRuntime{}
-	if err := r.client.Get(ctx, client.ObjectKey{
-		Name: new.Spec.RuntimeRef.Name,
-	}, clusterTrainingRuntime); err != nil {
-		return nil, field.ErrorList{
-			field.Invalid(field.NewPath("spec", "RuntimeRef"), new.Spec.RuntimeRef,
-				fmt.Sprintf("%v: specified clusterTrainingRuntime must be created before the TrainJob is created", err)),
+	// On update, resolve the runtime from the snapshot the TrainJob was built from, so that
+	// editing or deleting the live ClusterTrainingRuntime cannot retroactively break validation
+	// for an already-reconciled TrainJob (e.g. on resume from suspend). Fall back to the live
+	// object when no snapshot exists yet, matching NewObjects.
+	useSnapshot := false
+	if old != nil {
+		if err := getRuntimeSnapshot(ctx, r.client, new, clusterTrainingRuntime); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, field.ErrorList{
+					field.InternalError(field.NewPath("spec", "RuntimeRef"), fmt.Errorf("unable to get runtime snapshot: %w", err)),
+				}
+			}
+		} else {
+			useSnapshot = true
 		}
 	}
+	if !useSnapshot {
+		if err := r.client.Get(ctx, client.ObjectKey{
+			Name: new.Spec.RuntimeRef.Name,
+		}, clusterTrainingRuntime); err != nil {
+			return nil, field.ErrorList{
+				field.Invalid(field.NewPath("spec", "RuntimeRef"), new.Spec.RuntimeRef,
+					fmt.Sprintf("%v: specified clusterTrainingRuntime must be created before the TrainJob is created", err)),
+			}
+		}
+	}
+
 	var warnings admission.Warnings
 	if trainingruntime.IsSupportDeprecated(clusterTrainingRuntime.Labels) {
 		warnings = append(warnings, fmt.Sprintf(
@@ -114,6 +133,7 @@ func (r *ClusterTrainingRuntime) ValidateObjects(ctx context.Context, old, new *
 			constants.RuntimeDeprecationPolicyURL,
 		))
 	}
+
 	info, _ := r.newRuntimeInfo(new, clusterTrainingRuntime.Spec.Template, clusterTrainingRuntime.Spec.MLPolicy, clusterTrainingRuntime.Spec.PodGroupPolicy)
 	fwWarnings, errs := r.framework.RunCustomValidationPlugins(ctx, info, old, new)
 	if len(fwWarnings) != 0 {

--- a/pkg/runtime/core/clustertrainingruntime.go
+++ b/pkg/runtime/core/clustertrainingruntime.go
@@ -97,27 +97,26 @@ func (r *ClusterTrainingRuntime) EventHandlerRegistrars() []runtime.ReconcilerBu
 }
 
 func (r *ClusterTrainingRuntime) ValidateObjects(ctx context.Context, old, new *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
+	// Resolve the runtime from the snapshot the TrainJob was built from, so that editing or
+	// deleting the live ClusterTrainingRuntime cannot retroactively break validation for an
+	// already-reconciled TrainJob (e.g. on resume from suspend). Fall back to the live object
+	// when no snapshot exists yet, matching NewObjects.
 	clusterTrainingRuntime := &trainer.ClusterTrainingRuntime{}
-	// On update, resolve the runtime from the snapshot the TrainJob was built from, so that
-	// editing or deleting the live ClusterTrainingRuntime cannot retroactively break validation
-	// for an already-reconciled TrainJob (e.g. on resume from suspend). Fall back to the live
-	// object when no snapshot exists yet, matching NewObjects.
-	useSnapshot := false
-	if old != nil {
-		if err := getRuntimeSnapshot(ctx, r.client, new, clusterTrainingRuntime); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return nil, field.ErrorList{
-					field.InternalError(field.NewPath("spec", "RuntimeRef"), fmt.Errorf("unable to get runtime snapshot: %w", err)),
-				}
+	if err := getRuntimeSnapshot(ctx, r.client, new, clusterTrainingRuntime); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, field.ErrorList{
+				field.InternalError(field.NewPath("spec", "RuntimeRef"), fmt.Errorf("unable to get runtime snapshot: %w", err)),
 			}
-		} else {
-			useSnapshot = true
 		}
-	}
-	if !useSnapshot {
+		clusterTrainingRuntime = &trainer.ClusterTrainingRuntime{}
 		if err := r.client.Get(ctx, client.ObjectKey{
 			Name: new.Spec.RuntimeRef.Name,
 		}, clusterTrainingRuntime); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, field.ErrorList{
+					field.InternalError(field.NewPath("spec", "RuntimeRef"), fmt.Errorf("unable to get clusterTrainingRuntime: %w", err)),
+				}
+			}
 			return nil, field.ErrorList{
 				field.Invalid(field.NewPath("spec", "RuntimeRef"), new.Spec.RuntimeRef,
 					fmt.Sprintf("%v: specified clusterTrainingRuntime must be created before the TrainJob is created", err)),

--- a/pkg/runtime/core/clustertrainingruntime.go
+++ b/pkg/runtime/core/clustertrainingruntime.go
@@ -97,10 +97,8 @@ func (r *ClusterTrainingRuntime) EventHandlerRegistrars() []runtime.ReconcilerBu
 }
 
 func (r *ClusterTrainingRuntime) ValidateObjects(ctx context.Context, old, new *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
-	// Resolve the runtime from the snapshot the TrainJob was built from, so that editing or
-	// deleting the live ClusterTrainingRuntime cannot retroactively break validation for an
-	// already-reconciled TrainJob (e.g. on resume from suspend). Fall back to the live object
-	// when no snapshot exists yet, matching NewObjects.
+	// Validate against the snapshot the TrainJob was built from, falling back to the live
+	// runtime when no snapshot exists yet, as NewObjects does.
 	clusterTrainingRuntime := &trainer.ClusterTrainingRuntime{}
 	if err := getRuntimeSnapshot(ctx, r.client, new, clusterTrainingRuntime); err != nil {
 		if !apierrors.IsNotFound(err) {

--- a/pkg/runtime/core/trainingruntime.go
+++ b/pkg/runtime/core/trainingruntime.go
@@ -310,10 +310,8 @@ func (r *TrainingRuntime) EventHandlerRegistrars() []runtime.ReconcilerBuilder {
 }
 
 func (r *TrainingRuntime) ValidateObjects(ctx context.Context, old, new *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
-	// Resolve the runtime from the snapshot the TrainJob was built from, so that editing or
-	// deleting the live TrainingRuntime cannot retroactively break validation for an
-	// already-reconciled TrainJob (e.g. on resume from suspend). Fall back to the live object
-	// when no snapshot exists yet, matching NewObjects.
+	// Validate against the snapshot the TrainJob was built from, falling back to the live
+	// runtime when no snapshot exists yet, as NewObjects does.
 	trainingRuntime := &trainer.TrainingRuntime{}
 	if err := getRuntimeSnapshot(ctx, r.client, new, trainingRuntime); err != nil {
 		if !apierrors.IsNotFound(err) {

--- a/pkg/runtime/core/trainingruntime.go
+++ b/pkg/runtime/core/trainingruntime.go
@@ -310,28 +310,27 @@ func (r *TrainingRuntime) EventHandlerRegistrars() []runtime.ReconcilerBuilder {
 }
 
 func (r *TrainingRuntime) ValidateObjects(ctx context.Context, old, new *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
-	trainingRuntime := &trainer.TrainingRuntime{}
-	// On update, resolve the runtime from the snapshot the TrainJob was built from, so that
-	// editing or deleting the live TrainingRuntime cannot retroactively break validation for an
+	// Resolve the runtime from the snapshot the TrainJob was built from, so that editing or
+	// deleting the live TrainingRuntime cannot retroactively break validation for an
 	// already-reconciled TrainJob (e.g. on resume from suspend). Fall back to the live object
 	// when no snapshot exists yet, matching NewObjects.
-	useSnapshot := false
-	if old != nil {
-		if err := getRuntimeSnapshot(ctx, r.client, new, trainingRuntime); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return nil, field.ErrorList{
-					field.InternalError(field.NewPath("spec", "runtimeRef"), fmt.Errorf("unable to get runtime snapshot: %w", err)),
-				}
+	trainingRuntime := &trainer.TrainingRuntime{}
+	if err := getRuntimeSnapshot(ctx, r.client, new, trainingRuntime); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, field.ErrorList{
+				field.InternalError(field.NewPath("spec", "runtimeRef"), fmt.Errorf("unable to get runtime snapshot: %w", err)),
 			}
-		} else {
-			useSnapshot = true
 		}
-	}
-	if !useSnapshot {
+		trainingRuntime = &trainer.TrainingRuntime{}
 		if err := r.client.Get(ctx, client.ObjectKey{
 			Namespace: new.Namespace,
 			Name:      new.Spec.RuntimeRef.Name,
 		}, trainingRuntime); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, field.ErrorList{
+					field.InternalError(field.NewPath("spec", "runtimeRef"), fmt.Errorf("unable to get trainingRuntime: %w", err)),
+				}
+			}
 			return nil, field.ErrorList{
 				field.Invalid(field.NewPath("spec", "runtimeRef"), new.Spec.RuntimeRef,
 					fmt.Sprintf("%v: specified trainingRuntime must be created before the TrainJob is created", err)),

--- a/pkg/runtime/core/trainingruntime.go
+++ b/pkg/runtime/core/trainingruntime.go
@@ -311,13 +311,31 @@ func (r *TrainingRuntime) EventHandlerRegistrars() []runtime.ReconcilerBuilder {
 
 func (r *TrainingRuntime) ValidateObjects(ctx context.Context, old, new *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
 	trainingRuntime := &trainer.TrainingRuntime{}
-	if err := r.client.Get(ctx, client.ObjectKey{
-		Namespace: new.Namespace,
-		Name:      new.Spec.RuntimeRef.Name,
-	}, trainingRuntime); err != nil {
-		return nil, field.ErrorList{
-			field.Invalid(field.NewPath("spec", "runtimeRef"), new.Spec.RuntimeRef,
-				fmt.Sprintf("%v: specified trainingRuntime must be created before the TrainJob is created", err)),
+	// On update, resolve the runtime from the snapshot the TrainJob was built from, so that
+	// editing or deleting the live TrainingRuntime cannot retroactively break validation for an
+	// already-reconciled TrainJob (e.g. on resume from suspend). Fall back to the live object
+	// when no snapshot exists yet, matching NewObjects.
+	useSnapshot := false
+	if old != nil {
+		if err := getRuntimeSnapshot(ctx, r.client, new, trainingRuntime); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, field.ErrorList{
+					field.InternalError(field.NewPath("spec", "runtimeRef"), fmt.Errorf("unable to get runtime snapshot: %w", err)),
+				}
+			}
+		} else {
+			useSnapshot = true
+		}
+	}
+	if !useSnapshot {
+		if err := r.client.Get(ctx, client.ObjectKey{
+			Namespace: new.Namespace,
+			Name:      new.Spec.RuntimeRef.Name,
+		}, trainingRuntime); err != nil {
+			return nil, field.ErrorList{
+				field.Invalid(field.NewPath("spec", "runtimeRef"), new.Spec.RuntimeRef,
+					fmt.Sprintf("%v: specified trainingRuntime must be created before the TrainJob is created", err)),
+			}
 		}
 	}
 	info, _ := r.newRuntimeInfo(new, trainingRuntime.Spec.Template, trainingRuntime.Spec.MLPolicy, trainingRuntime.Spec.PodGroupPolicy) // ignoring the error here as the runtime configured should be valid

--- a/test/integration/controller/trainjob_controller_test.go
+++ b/test/integration/controller/trainjob_controller_test.go
@@ -2771,28 +2771,41 @@ alpha-node-0-1.alpha slots=8
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			// setupSnapshottedTrainJob creates the runtime and a suspended TrainJob referencing
-			// it, then waits for the TrainJob's runtime snapshot to be created.
-			setupSnapshottedTrainJob := func(runtimeObj client.Object, job *trainer.TrainJob) {
-				ginkgo.By("Creating the runtime and a suspended TrainJob with a dataset initializer")
-				gomega.Expect(k8sClient.Create(ctx, runtimeObj)).Should(gomega.Succeed())
+			ginkgo.It("Should validate an updated TrainJob against the snapshot and not the current TrainingRuntime", func() {
+				ginkgo.By("Creating the TrainingRuntime and a suspended TrainJob with a dataset initializer")
+				gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(runtimeObj), runtimeObj)).Should(gomega.Succeed())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), trainingRuntime)).Should(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-				gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+				gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
 
 				ginkgo.By("Waiting for the runtime snapshot to be created")
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKey{
-						Name:      job.Name + "-runtime-snapshot",
-						Namespace: job.Namespace,
+						Name:      trainJob.Name + "-runtime-snapshot",
+						Namespace: trainJob.Namespace,
 					}, &corev1.ConfigMap{})).Should(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			}
 
-			// resumeAndExpectRunning unsuspends the TrainJob, which is only admitted if
-			// validation used the snapshot, and verifies the JobSet is resumed.
-			resumeAndExpectRunning := func() {
+				ginkgo.By("Removing the dataset initializer volumeMount to make the live runtime invalid for this TrainJob")
+				gomega.Eventually(func(g gomega.Gomega) {
+					gotRuntime := &trainer.TrainingRuntime{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), gotRuntime)).Should(gomega.Succeed())
+					for i := range gotRuntime.Spec.Template.Spec.ReplicatedJobs {
+						rJob := &gotRuntime.Spec.Template.Spec.ReplicatedJobs[i]
+						if rJob.Name != constants.DatasetInitializer {
+							continue
+						}
+						containers := rJob.Template.Spec.Template.Spec.Containers
+						for j := range containers {
+							if containers[j].Name == constants.DatasetInitializer {
+								containers[j].VolumeMounts = nil
+							}
+						}
+					}
+					g.Expect(k8sClient.Update(ctx, gotRuntime)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
 				ginkgo.By("Resuming the TrainJob should succeed using the runtime snapshot")
 				gomega.Eventually(func(g gomega.Gomega) {
 					gotTrainJob := &trainer.TrainJob{}
@@ -2807,75 +2820,138 @@ alpha-node-0-1.alpha slots=8
 					g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
 					g.Expect(*jobSet.Spec.Suspend).Should(gomega.BeFalse())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			}
+			})
 
-			// removeDatasetInitializerVolumeMounts drops the volumeMount the JobSet plugin
-			// requires when the TrainJob declares a dataset initializer, making the runtime
-			// invalid for this TrainJob.
-			removeDatasetInitializerVolumeMounts := func(spec *trainer.TrainingRuntimeSpec) {
-				for i := range spec.Template.Spec.ReplicatedJobs {
-					rJob := &spec.Template.Spec.ReplicatedJobs[i]
-					if rJob.Name != constants.DatasetInitializer {
-						continue
-					}
-					containers := rJob.Template.Spec.Template.Spec.Containers
-					for j := range containers {
-						if containers[j].Name != constants.DatasetInitializer {
+			ginkgo.It("Should validate an updated TrainJob against the snapshot and not the current ClusterTrainingRuntime", func() {
+				ginkgo.By("Creating the ClusterTrainingRuntime and a suspended TrainJob with a dataset initializer")
+				clusterTrainingRuntime := testingutil.MakeClusterTrainingRuntimeWrapper(trainJob.Spec.RuntimeRef.Name).Obj()
+				gomega.Expect(k8sClient.Create(ctx, clusterTrainingRuntime)).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterTrainingRuntime), clusterTrainingRuntime)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				trainJob.Spec.RuntimeRef.Kind = ptr.To(trainer.ClusterTrainingRuntimeKind)
+				gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+
+				ginkgo.By("Waiting for the runtime snapshot to be created")
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{
+						Name:      trainJob.Name + "-runtime-snapshot",
+						Namespace: trainJob.Namespace,
+					}, &corev1.ConfigMap{})).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Removing the dataset initializer volumeMount to make the live runtime invalid for this TrainJob")
+				gomega.Eventually(func(g gomega.Gomega) {
+					gotRuntime := &trainer.ClusterTrainingRuntime{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterTrainingRuntime), gotRuntime)).Should(gomega.Succeed())
+					for i := range gotRuntime.Spec.Template.Spec.ReplicatedJobs {
+						rJob := &gotRuntime.Spec.Template.Spec.ReplicatedJobs[i]
+						if rJob.Name != constants.DatasetInitializer {
 							continue
 						}
-						containers[j].VolumeMounts = nil
+						containers := rJob.Template.Spec.Template.Spec.Containers
+						for j := range containers {
+							if containers[j].Name == constants.DatasetInitializer {
+								containers[j].VolumeMounts = nil
+							}
+						}
 					}
-				}
-			}
+					g.Expect(k8sClient.Update(ctx, gotRuntime)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-			ginkgo.DescribeTable("Should validate an updated TrainJob against the snapshot and not the current runtime",
-				func(makeRuntime func() client.Object, kind string, invalidate func(client.Object)) {
-					runtimeObj := makeRuntime()
-					trainJob.Spec.RuntimeRef.Kind = ptr.To(kind)
-					setupSnapshottedTrainJob(runtimeObj, trainJob)
+				ginkgo.By("Resuming the TrainJob should succeed using the runtime snapshot")
+				gomega.Eventually(func(g gomega.Gomega) {
+					gotTrainJob := &trainer.TrainJob{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, gotTrainJob)).Should(gomega.Succeed())
+					gotTrainJob.Spec.Suspend = ptr.To(false)
+					g.Expect(k8sClient.Update(ctx, gotTrainJob)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-					ginkgo.By("Making the live runtime invalid for this TrainJob")
-					gomega.Eventually(func(g gomega.Gomega) {
-						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(runtimeObj), runtimeObj)).Should(gomega.Succeed())
-						invalidate(runtimeObj)
-						g.Expect(k8sClient.Update(ctx, runtimeObj)).Should(gomega.Succeed())
-					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				ginkgo.By("Verifying the JobSet is resumed")
+				gomega.Eventually(func(g gomega.Gomega) {
+					jobSet := &jobsetv1alpha2.JobSet{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
+					g.Expect(*jobSet.Spec.Suspend).Should(gomega.BeFalse())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
 
-					resumeAndExpectRunning()
-				},
-				ginkgo.Entry("TrainingRuntime", func() client.Object { return trainingRuntime }, trainer.TrainingRuntimeKind,
-					func(obj client.Object) {
-						removeDatasetInitializerVolumeMounts(&obj.(*trainer.TrainingRuntime).Spec)
-					}),
-				ginkgo.Entry("ClusterTrainingRuntime", func() client.Object {
-					return testingutil.MakeClusterTrainingRuntimeWrapper(trainJob.Spec.RuntimeRef.Name).Obj()
-				}, trainer.ClusterTrainingRuntimeKind,
-					func(obj client.Object) {
-						removeDatasetInitializerVolumeMounts(&obj.(*trainer.ClusterTrainingRuntime).Spec)
-					}),
-			)
+			ginkgo.It("Should validate an updated TrainJob against the snapshot after the TrainingRuntime is deleted", func() {
+				ginkgo.By("Creating the TrainingRuntime and a suspended TrainJob with a dataset initializer")
+				gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), trainingRuntime)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
 
-			ginkgo.DescribeTable("Should validate an updated TrainJob against the snapshot after the runtime is deleted",
-				func(makeRuntime func() client.Object, kind string, emptyRuntime func() client.Object) {
-					runtimeObj := makeRuntime()
-					trainJob.Spec.RuntimeRef.Kind = ptr.To(kind)
-					setupSnapshottedTrainJob(runtimeObj, trainJob)
+				ginkgo.By("Waiting for the runtime snapshot to be created")
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{
+						Name:      trainJob.Name + "-runtime-snapshot",
+						Namespace: trainJob.Namespace,
+					}, &corev1.ConfigMap{})).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-					ginkgo.By("Deleting the referenced runtime")
-					gomega.Expect(k8sClient.Delete(ctx, runtimeObj)).Should(gomega.Succeed())
-					gomega.Eventually(func(g gomega.Gomega) {
-						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(runtimeObj), emptyRuntime())).Should(testingutil.BeNotFoundError())
-					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				ginkgo.By("Deleting the referenced TrainingRuntime")
+				gomega.Expect(k8sClient.Delete(ctx, trainingRuntime)).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), &trainer.TrainingRuntime{})).Should(testingutil.BeNotFoundError())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-					resumeAndExpectRunning()
-				},
-				ginkgo.Entry("TrainingRuntime", func() client.Object { return trainingRuntime }, trainer.TrainingRuntimeKind,
-					func() client.Object { return &trainer.TrainingRuntime{} }),
-				ginkgo.Entry("ClusterTrainingRuntime", func() client.Object {
-					return testingutil.MakeClusterTrainingRuntimeWrapper(trainJob.Spec.RuntimeRef.Name).Obj()
-				}, trainer.ClusterTrainingRuntimeKind,
-					func() client.Object { return &trainer.ClusterTrainingRuntime{} }),
-			)
+				ginkgo.By("Resuming the TrainJob should succeed using the runtime snapshot")
+				gomega.Eventually(func(g gomega.Gomega) {
+					gotTrainJob := &trainer.TrainJob{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, gotTrainJob)).Should(gomega.Succeed())
+					gotTrainJob.Spec.Suspend = ptr.To(false)
+					g.Expect(k8sClient.Update(ctx, gotTrainJob)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Verifying the JobSet is resumed")
+				gomega.Eventually(func(g gomega.Gomega) {
+					jobSet := &jobsetv1alpha2.JobSet{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
+					g.Expect(*jobSet.Spec.Suspend).Should(gomega.BeFalse())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.It("Should validate an updated TrainJob against the snapshot after the ClusterTrainingRuntime is deleted", func() {
+				ginkgo.By("Creating the ClusterTrainingRuntime and a suspended TrainJob with a dataset initializer")
+				clusterTrainingRuntime := testingutil.MakeClusterTrainingRuntimeWrapper(trainJob.Spec.RuntimeRef.Name).Obj()
+				gomega.Expect(k8sClient.Create(ctx, clusterTrainingRuntime)).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterTrainingRuntime), clusterTrainingRuntime)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				trainJob.Spec.RuntimeRef.Kind = ptr.To(trainer.ClusterTrainingRuntimeKind)
+				gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+
+				ginkgo.By("Waiting for the runtime snapshot to be created")
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{
+						Name:      trainJob.Name + "-runtime-snapshot",
+						Namespace: trainJob.Namespace,
+					}, &corev1.ConfigMap{})).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Deleting the referenced ClusterTrainingRuntime")
+				gomega.Expect(k8sClient.Delete(ctx, clusterTrainingRuntime)).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterTrainingRuntime), &trainer.ClusterTrainingRuntime{})).Should(testingutil.BeNotFoundError())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Resuming the TrainJob should succeed using the runtime snapshot")
+				gomega.Eventually(func(g gomega.Gomega) {
+					gotTrainJob := &trainer.TrainJob{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, gotTrainJob)).Should(gomega.Succeed())
+					gotTrainJob.Spec.Suspend = ptr.To(false)
+					g.Expect(k8sClient.Update(ctx, gotTrainJob)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Verifying the JobSet is resumed")
+				gomega.Eventually(func(g gomega.Gomega) {
+					jobSet := &jobsetv1alpha2.JobSet{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
+					g.Expect(*jobSet.Spec.Suspend).Should(gomega.BeFalse())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
 		})
 
 	})

--- a/test/integration/controller/trainjob_controller_test.go
+++ b/test/integration/controller/trainjob_controller_test.go
@@ -79,6 +79,9 @@ var _ = ginkgo.Describe("TrainJob controller", ginkgo.Ordered, func() {
 
 		ginkgo.AfterEach(func() {
 			gomega.Expect(k8sClient.DeleteAllOf(ctx, &trainer.TrainJob{}, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			// ClusterTrainingRuntimes are cluster-scoped, so they must be cleaned up explicitly
+			// to avoid leaking between tests.
+			gomega.Expect(k8sClient.DeleteAllOf(ctx, &trainer.ClusterTrainingRuntime{})).Should(gomega.Succeed())
 		})
 
 		ginkgo.BeforeEach(func() {
@@ -2768,82 +2771,28 @@ alpha-node-0-1.alpha slots=8
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			ginkgo.It("Should allow resuming a suspended TrainJob after the live TrainingRuntime loses the dataset-initializer volumeMount", func() {
-				ginkgo.By("Creating TrainingRuntime and suspended TrainJob with a dataset initializer")
-				gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
+			// setupSnapshottedTrainJob creates the runtime and a suspended TrainJob referencing
+			// it, then waits for the TrainJob's runtime snapshot to be created.
+			setupSnapshottedTrainJob := func(runtimeObj client.Object, job *trainer.TrainJob) {
+				ginkgo.By("Creating the runtime and a suspended TrainJob with a dataset initializer")
+				gomega.Expect(k8sClient.Create(ctx, runtimeObj)).Should(gomega.Succeed())
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), trainingRuntime)).Should(gomega.Succeed())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(runtimeObj), runtimeObj)).Should(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-				gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+				gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
 
 				ginkgo.By("Waiting for the runtime snapshot to be created")
-				snapshotKey := client.ObjectKey{
-					Name:      trainJob.Name + "-runtime-snapshot",
-					Namespace: trainJob.Namespace,
-				}
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, snapshotKey, &corev1.ConfigMap{})).Should(gomega.Succeed())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{
+						Name:      job.Name + "-runtime-snapshot",
+						Namespace: job.Namespace,
+					}, &corev1.ConfigMap{})).Should(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			}
 
-				ginkgo.By("Removing the dataset-initializer volumeMount from the live TrainingRuntime")
-				gomega.Eventually(func(g gomega.Gomega) {
-					updatedRuntime := &trainer.TrainingRuntime{}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), updatedRuntime)).Should(gomega.Succeed())
-					for i := range updatedRuntime.Spec.Template.Spec.ReplicatedJobs {
-						rJob := &updatedRuntime.Spec.Template.Spec.ReplicatedJobs[i]
-						if rJob.Name != constants.DatasetInitializer {
-							continue
-						}
-						containers := rJob.Template.Spec.Template.Spec.Containers
-						for j := range containers {
-							if containers[j].Name != constants.DatasetInitializer {
-								continue
-							}
-							containers[j].VolumeMounts = nil
-						}
-					}
-					g.Expect(k8sClient.Update(ctx, updatedRuntime)).Should(gomega.Succeed())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-				ginkgo.By("Resuming the TrainJob should succeed using the runtime snapshot, not the now-broken live runtime")
-				gomega.Eventually(func(g gomega.Gomega) {
-					gotTrainJob := &trainer.TrainJob{}
-					g.Expect(k8sClient.Get(ctx, trainJobKey, gotTrainJob)).Should(gomega.Succeed())
-					gotTrainJob.Spec.Suspend = ptr.To(false)
-					g.Expect(k8sClient.Update(ctx, gotTrainJob)).Should(gomega.Succeed())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-				ginkgo.By("Verifying the JobSet is resumed")
-				gomega.Eventually(func(g gomega.Gomega) {
-					jobSet := &jobsetv1alpha2.JobSet{}
-					g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
-					g.Expect(*jobSet.Spec.Suspend).Should(gomega.BeFalse())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.It("Should allow resuming a suspended TrainJob after the referenced TrainingRuntime is deleted", func() {
-				ginkgo.By("Creating TrainingRuntime and suspended TrainJob")
-				gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), trainingRuntime)).Should(gomega.Succeed())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-				gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
-
-				ginkgo.By("Waiting for the runtime snapshot to be created")
-				snapshotKey := client.ObjectKey{
-					Name:      trainJob.Name + "-runtime-snapshot",
-					Namespace: trainJob.Namespace,
-				}
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, snapshotKey, &corev1.ConfigMap{})).Should(gomega.Succeed())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-				ginkgo.By("Deleting the referenced TrainingRuntime")
-				gomega.Expect(k8sClient.Delete(ctx, trainingRuntime)).Should(gomega.Succeed())
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), &trainer.TrainingRuntime{})).Should(testingutil.BeNotFoundError())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
+			// resumeAndExpectRunning unsuspends the TrainJob, which is only admitted if
+			// validation used the snapshot, and verifies the JobSet is resumed.
+			resumeAndExpectRunning := func() {
 				ginkgo.By("Resuming the TrainJob should succeed using the runtime snapshot")
 				gomega.Eventually(func(g gomega.Gomega) {
 					gotTrainJob := &trainer.TrainJob{}
@@ -2858,7 +2807,75 @@ alpha-node-0-1.alpha slots=8
 					g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
 					g.Expect(*jobSet.Spec.Suspend).Should(gomega.BeFalse())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
+			}
+
+			// removeDatasetInitializerVolumeMounts drops the volumeMount the JobSet plugin
+			// requires when the TrainJob declares a dataset initializer, making the runtime
+			// invalid for this TrainJob.
+			removeDatasetInitializerVolumeMounts := func(spec *trainer.TrainingRuntimeSpec) {
+				for i := range spec.Template.Spec.ReplicatedJobs {
+					rJob := &spec.Template.Spec.ReplicatedJobs[i]
+					if rJob.Name != constants.DatasetInitializer {
+						continue
+					}
+					containers := rJob.Template.Spec.Template.Spec.Containers
+					for j := range containers {
+						if containers[j].Name != constants.DatasetInitializer {
+							continue
+						}
+						containers[j].VolumeMounts = nil
+					}
+				}
+			}
+
+			ginkgo.DescribeTable("Should validate an updated TrainJob against the snapshot and not the current runtime",
+				func(makeRuntime func() client.Object, kind string, invalidate func(client.Object)) {
+					runtimeObj := makeRuntime()
+					trainJob.Spec.RuntimeRef.Kind = ptr.To(kind)
+					setupSnapshottedTrainJob(runtimeObj, trainJob)
+
+					ginkgo.By("Making the live runtime invalid for this TrainJob")
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(runtimeObj), runtimeObj)).Should(gomega.Succeed())
+						invalidate(runtimeObj)
+						g.Expect(k8sClient.Update(ctx, runtimeObj)).Should(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+					resumeAndExpectRunning()
+				},
+				ginkgo.Entry("TrainingRuntime", func() client.Object { return trainingRuntime }, trainer.TrainingRuntimeKind,
+					func(obj client.Object) {
+						removeDatasetInitializerVolumeMounts(&obj.(*trainer.TrainingRuntime).Spec)
+					}),
+				ginkgo.Entry("ClusterTrainingRuntime", func() client.Object {
+					return testingutil.MakeClusterTrainingRuntimeWrapper(trainJob.Spec.RuntimeRef.Name).Obj()
+				}, trainer.ClusterTrainingRuntimeKind,
+					func(obj client.Object) {
+						removeDatasetInitializerVolumeMounts(&obj.(*trainer.ClusterTrainingRuntime).Spec)
+					}),
+			)
+
+			ginkgo.DescribeTable("Should validate an updated TrainJob against the snapshot after the runtime is deleted",
+				func(makeRuntime func() client.Object, kind string, emptyRuntime func() client.Object) {
+					runtimeObj := makeRuntime()
+					trainJob.Spec.RuntimeRef.Kind = ptr.To(kind)
+					setupSnapshottedTrainJob(runtimeObj, trainJob)
+
+					ginkgo.By("Deleting the referenced runtime")
+					gomega.Expect(k8sClient.Delete(ctx, runtimeObj)).Should(gomega.Succeed())
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(runtimeObj), emptyRuntime())).Should(testingutil.BeNotFoundError())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+					resumeAndExpectRunning()
+				},
+				ginkgo.Entry("TrainingRuntime", func() client.Object { return trainingRuntime }, trainer.TrainingRuntimeKind,
+					func() client.Object { return &trainer.TrainingRuntime{} }),
+				ginkgo.Entry("ClusterTrainingRuntime", func() client.Object {
+					return testingutil.MakeClusterTrainingRuntimeWrapper(trainJob.Spec.RuntimeRef.Name).Obj()
+				}, trainer.ClusterTrainingRuntimeKind,
+					func() client.Object { return &trainer.ClusterTrainingRuntime{} }),
+			)
 		})
 
 	})

--- a/test/integration/controller/trainjob_controller_test.go
+++ b/test/integration/controller/trainjob_controller_test.go
@@ -2767,6 +2767,98 @@ alpha-node-0-1.alpha slots=8
 					g.Expect(cm.Data).Should(gomega.HaveKey("runtime"))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
+
+			ginkgo.It("Should allow resuming a suspended TrainJob after the live TrainingRuntime loses the dataset-initializer volumeMount", func() {
+				ginkgo.By("Creating TrainingRuntime and suspended TrainJob with a dataset initializer")
+				gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), trainingRuntime)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+
+				ginkgo.By("Waiting for the runtime snapshot to be created")
+				snapshotKey := client.ObjectKey{
+					Name:      trainJob.Name + "-runtime-snapshot",
+					Namespace: trainJob.Namespace,
+				}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, snapshotKey, &corev1.ConfigMap{})).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Removing the dataset-initializer volumeMount from the live TrainingRuntime")
+				gomega.Eventually(func(g gomega.Gomega) {
+					updatedRuntime := &trainer.TrainingRuntime{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), updatedRuntime)).Should(gomega.Succeed())
+					for i := range updatedRuntime.Spec.Template.Spec.ReplicatedJobs {
+						rJob := &updatedRuntime.Spec.Template.Spec.ReplicatedJobs[i]
+						if rJob.Name != constants.DatasetInitializer {
+							continue
+						}
+						containers := rJob.Template.Spec.Template.Spec.Containers
+						for j := range containers {
+							if containers[j].Name != constants.DatasetInitializer {
+								continue
+							}
+							containers[j].VolumeMounts = nil
+						}
+					}
+					g.Expect(k8sClient.Update(ctx, updatedRuntime)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Resuming the TrainJob should succeed using the runtime snapshot, not the now-broken live runtime")
+				gomega.Eventually(func(g gomega.Gomega) {
+					gotTrainJob := &trainer.TrainJob{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, gotTrainJob)).Should(gomega.Succeed())
+					gotTrainJob.Spec.Suspend = ptr.To(false)
+					g.Expect(k8sClient.Update(ctx, gotTrainJob)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Verifying the JobSet is resumed")
+				gomega.Eventually(func(g gomega.Gomega) {
+					jobSet := &jobsetv1alpha2.JobSet{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
+					g.Expect(*jobSet.Spec.Suspend).Should(gomega.BeFalse())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.It("Should allow resuming a suspended TrainJob after the referenced TrainingRuntime is deleted", func() {
+				ginkgo.By("Creating TrainingRuntime and suspended TrainJob")
+				gomega.Expect(k8sClient.Create(ctx, trainingRuntime)).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), trainingRuntime)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				gomega.Expect(k8sClient.Create(ctx, trainJob)).Should(gomega.Succeed())
+
+				ginkgo.By("Waiting for the runtime snapshot to be created")
+				snapshotKey := client.ObjectKey{
+					Name:      trainJob.Name + "-runtime-snapshot",
+					Namespace: trainJob.Namespace,
+				}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, snapshotKey, &corev1.ConfigMap{})).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Deleting the referenced TrainingRuntime")
+				gomega.Expect(k8sClient.Delete(ctx, trainingRuntime)).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(trainingRuntime), &trainer.TrainingRuntime{})).Should(testingutil.BeNotFoundError())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Resuming the TrainJob should succeed using the runtime snapshot")
+				gomega.Eventually(func(g gomega.Gomega) {
+					gotTrainJob := &trainer.TrainJob{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, gotTrainJob)).Should(gomega.Succeed())
+					gotTrainJob.Spec.Suspend = ptr.To(false)
+					g.Expect(k8sClient.Update(ctx, gotTrainJob)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Verifying the JobSet is resumed")
+				gomega.Eventually(func(g gomega.Gomega) {
+					jobSet := &jobsetv1alpha2.JobSet{}
+					g.Expect(k8sClient.Get(ctx, trainJobKey, jobSet)).Should(gomega.Succeed())
+					g.Expect(*jobSet.Spec.Suspend).Should(gomega.BeFalse())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
 		})
 
 	})


### PR DESCRIPTION
## What this PR does / why we need it

`TrainingRuntime.ValidateObjects` and `ClusterTrainingRuntime.ValidateObjects` always fetched the **live** `(Cluster)TrainingRuntime`, while `NewObjects` reconciles from the runtime snapshot created per KEP-2599. That inconsistency means editing or deleting a runtime can retroactively break validation for an already-reconciled TrainJob.

Since `spec.suspend` and `spec.runtimePatches` are the only mutable TrainJob spec fields, this surfaces on resume:

* **Runtime edited** — a platform admin removes the `dataset-initializer` volumeMount; resuming the TrainJob is rejected with `must have volumeMount with name - initializer ...`, even though reconciliation would have used the still-valid snapshot.
* **Runtime deleted** — since KEP-2599 removed the runtime finalizers, the runtime can be deleted while TrainJobs still reference it. Any update is then rejected with `specified trainingRuntime must be created before the TrainJob is created`, leaving the TrainJob stuck: reconciliation works from the snapshot, but admission never lets the update through.

Both are the workflow KEP-2599 set out to make safe ("platform admins are able to update, add or remove `TrainingRuntimes` ... without impacting existing running or paused `TrainJobs`").

## Changes

* On update (`old != nil`), resolve the runtime from the snapshot, falling back to the live object when no snapshot exists yet (pre-snapshot TrainJobs), mirroring `NewObjects`. Create (`old == nil`) is unchanged — no snapshot exists, so it reads live as before.
* The existence check, the deprecation-label warning and `RunCustomValidationPlugins` all read from that single resolved runtime. Per [@robert-bell's review](https://github.com/kubeflow/trainer/issues/3923#issuecomment-5326615133), the deprecation label is checked on the snapshot rather than the live object, since the live object may have been deleted.
* Integration coverage for both scenarios: resuming after the live runtime is mutated into an invalid state, and resuming after the runtime is deleted.

## Validation

* `go build ./...`
* `go vet ./...`

Fixes #3923