### PR TITLE
fix(api): show accurate TrainJob State after resume and add Suspended printer column

### DIFF
--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
@@ -32,9 +32,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[-1:].type
+    - jsonPath: .status.conditions[?(@.status=="True")].type
       name: State
       type: string
+    - jsonPath: .spec.suspend
+      name: Suspended
+      type: boolean
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -29,9 +29,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[-1:].type
+    - jsonPath: .status.conditions[?(@.status=="True")].type
       name: State
       type: string
+    - jsonPath: .spec.suspend
+      name: Suspended
+      type: boolean
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -31,7 +31,8 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.conditions[-1:].type`
+// +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.conditions[?(@.status=="True")].type`
+// +kubebuilder:printcolumn:name="Suspended",type=boolean,JSONPath=`.spec.suspend`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:validation:XValidation:rule="self.metadata.name.matches('^[a-z]([-a-z0-9]*[a-z0-9])?$')", message="metadata.name must match RFC 1035 DNS label format"
 // +kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 63", message="metadata.name must be no more than 63 characters"

--- a/pkg/apis/trainer/v1alpha1/trainjob_types_test.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2024 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestTrainJobPrinterColumnConditions(t *testing.T) {
+	cases := map[string]struct {
+		trainJob      *TrainJob
+		wantState     string
+		wantSuspended bool
+	}{
+		"newly created running TrainJob with no conditions": {
+			trainJob: &TrainJob{
+				Spec: TrainJobSpec{
+					Suspend: ptr.To(false),
+				},
+				Status: TrainJobStatus{},
+			},
+			wantState:     "",
+			wantSuspended: false,
+		},
+		"suspended TrainJob": {
+			trainJob: &TrainJob{
+				Spec: TrainJobSpec{
+					Suspend: ptr.To(true),
+				},
+				Status: TrainJobStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    TrainJobSuspended,
+							Status:  metav1.ConditionTrue,
+							Reason:  TrainJobSuspendedReason,
+							Message: "TrainJob is suspended",
+						},
+					},
+				},
+			},
+			wantState:     TrainJobSuspended,
+			wantSuspended: true,
+		},
+		"resumed TrainJob with Suspended condition False": {
+			trainJob: &TrainJob{
+				Spec: TrainJobSpec{
+					Suspend: ptr.To(false),
+				},
+				Status: TrainJobStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    TrainJobSuspended,
+							Status:  metav1.ConditionFalse,
+							Reason:  TrainJobResumedReason,
+							Message: "TrainJob is resumed",
+						},
+					},
+				},
+			},
+			wantState:     "",
+			wantSuspended: false,
+		},
+		"completed TrainJob after resume": {
+			trainJob: &TrainJob{
+				Spec: TrainJobSpec{
+					Suspend: ptr.To(false),
+				},
+				Status: TrainJobStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    TrainJobSuspended,
+							Status:  metav1.ConditionFalse,
+							Reason:  TrainJobResumedReason,
+							Message: "TrainJob is resumed",
+						},
+						{
+							Type:    TrainJobComplete,
+							Status:  metav1.ConditionTrue,
+							Reason:  "AllJobsCompleted",
+							Message: "All jobs completed successfully",
+						},
+					},
+				},
+			},
+			wantState:     TrainJobComplete,
+			wantSuspended: false,
+		},
+		"failed TrainJob after resume": {
+			trainJob: &TrainJob{
+				Spec: TrainJobSpec{
+					Suspend: ptr.To(false),
+				},
+				Status: TrainJobStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    TrainJobSuspended,
+							Status:  metav1.ConditionFalse,
+							Reason:  TrainJobResumedReason,
+							Message: "TrainJob is resumed",
+						},
+						{
+							Type:    TrainJobFailed,
+							Status:  metav1.ConditionTrue,
+							Reason:  TrainJobDeadlineExceededReason,
+							Message: "Deadline exceeded",
+						},
+					},
+				},
+			},
+			wantState:     TrainJobFailed,
+			wantSuspended: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Test active condition resolution matching .status.conditions[?(@.status=="True")].type
+			var gotState string
+			for _, cond := range tc.trainJob.Status.Conditions {
+				if cond.Status == metav1.ConditionTrue {
+					gotState = cond.Type
+					break
+				}
+			}
+			if gotState != tc.wantState {
+				t.Errorf("active condition type = %q, want %q", gotState, tc.wantState)
+			}
+
+			// Test suspended spec resolution matching .spec.suspend
+			gotSuspended := ptr.Deref(tc.trainJob.Spec.Suspend, false)
+			if gotSuspended != tc.wantSuspended {
+				t.Errorf("spec.suspend = %v, want %v", gotSuspended, tc.wantSuspended)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What this PR does / why we need it

Fixes #3666.

Previously, the `TrainJob` CustomResourceDefinition `State` printer column was configured with:
```go
// +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.conditions[-1:].type`
```
This extracted the type of the last condition in `.status.conditions` without evaluating whether `status == "True"`. When a `TrainJob `is suspended, the condition `{type: "Suspended", status: "True", reason: "Suspended"} `is recorded. Upon resuming the `TrainJob ``(spec.suspend: false)`, the controller updates the condition in place to` {type: "Suspended", status: "False", reason: "Resumed"}.` Because` .status.conditions[-1:].`type does not check `status`, `kubectl get trainjobs` continued to display` STATE=Suspended` even though the `TrainJob `was resumed and running.

This PR:

1.Updates the State printer column to only match active conditions:
```go
// +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.conditions[?(@.status=="True")].type`
```
2. Adds a dedicated `Suspended `printer column mapped to `.spec.suspend` **(type=boolean)** to clearly indicate the workload's suspension state (aligned with JobSet / Kubernetes workload conventions).
3. Regenerates the Kustomize and Helm CRD manifests.
4. Adds unit tests in` pkg/apis/trainer/v1alpha1/trainjob_types_test.go `verifying condition resolution and printer column outputs across all lifecycle phases (created, suspended, resumed, complete, and failed).

**Special notes for your reviewer**

**State column now shows:**

-   Running / resumed: `""` (empty / `<none>`)
-   Suspended: `"Suspended"`
-   Completed`: "Complete"`
-   Failed: `"Failed"`

**`Suspended `column now shows `true / false` reflecting `.spec.suspend`.**
