### PR TITLE
feat(runtimes): add deprecation warning for TrainingRuntime

### DIFF
--- a/pkg/runtime/core/trainingruntime.go
+++ b/pkg/runtime/core/trainingruntime.go
@@ -320,6 +320,18 @@ func (r *TrainingRuntime) ValidateObjects(ctx context.Context, old, new *trainer
 				fmt.Sprintf("%v: specified trainingRuntime must be created before the TrainJob is created", err)),
 		}
 	}
+	var warnings admission.Warnings
+	if trainingruntimeutil.IsSupportDeprecated(trainingRuntime.Labels) {
+		warnings = append(warnings, fmt.Sprintf(
+			"Referenced TrainingRuntime \"%s\" is deprecated and will be removed in a future release of Kubeflow Trainer. See runtime deprecation policy: %s",
+			trainingRuntime.Name,
+			constants.RuntimeDeprecationPolicyURL,
+		))
+	}
 	info, _ := r.newRuntimeInfo(new, trainingRuntime.Spec.Template, trainingRuntime.Spec.MLPolicy, trainingRuntime.Spec.PodGroupPolicy) // ignoring the error here as the runtime configured should be valid
-	return r.framework.RunCustomValidationPlugins(ctx, info, old, new)
+	fwWarnings, errs := r.framework.RunCustomValidationPlugins(ctx, info, old, new)
+	if len(fwWarnings) != 0 {
+		warnings = append(warnings, fwWarnings...)
+	}
+	return warnings, errs
 }

--- a/pkg/webhooks/trainingruntime_webhook.go
+++ b/pkg/webhooks/trainingruntime_webhook.go
@@ -29,6 +29,7 @@ import (
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
+	trainingruntime "github.com/kubeflow/trainer/v2/pkg/util/trainingruntime"
 )
 
 const (
@@ -60,7 +61,15 @@ func setupWebhookForTrainingRuntime(mgr ctrl.Manager) error {
 func (w *TrainingRuntimeValidator) ValidateCreate(ctx context.Context, obj *trainer.TrainingRuntime) (admission.Warnings, error) {
 	log := ctrl.LoggerFrom(ctx).WithName("trainingruntime-webhook")
 	log.V(5).Info("Validating create", "trainingRuntime", klog.KObj(obj))
-	return nil, validateReplicatedJobs(obj.Spec.Template.Spec.ReplicatedJobs).ToAggregate()
+	var warnings admission.Warnings
+	if trainingruntime.IsSupportDeprecated(obj.Labels) {
+		warnings = append(warnings, fmt.Sprintf(
+			"TrainingRuntime \"%s\" is deprecated and will be removed in a future release of Kubeflow Trainer. See runtime deprecation policy: %s",
+			obj.Name,
+			constants.RuntimeDeprecationPolicyURL,
+		))
+	}
+	return warnings, validateReplicatedJobs(obj.Spec.Template.Spec.ReplicatedJobs).ToAggregate()
 }
 
 func validateReplicatedJobs(rJobs []jobsetv1alpha2.ReplicatedJob) field.ErrorList {

--- a/pkg/webhooks/trainingruntime_webhook_test.go
+++ b/pkg/webhooks/trainingruntime_webhook_test.go
@@ -17,17 +17,65 @@ limitations under the License.
 package webhooks
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/klog/v2/ktesting"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	"github.com/kubeflow/trainer/v2/pkg/constants"
 	testingutil "github.com/kubeflow/trainer/v2/pkg/util/testing"
 )
+
+func TestTrainingRuntimeValidateCreate(t *testing.T) {
+	cases := map[string]struct {
+		labels   map[string]string
+		warnings admission.Warnings
+	}{
+		"no deprecation label": {
+			labels:   nil,
+			warnings: nil,
+		},
+		"support=deprecated": {
+			labels: map[string]string{constants.LabelSupport: constants.SupportDeprecated},
+			warnings: admission.Warnings{
+				"TrainingRuntime \"test-runtime\" is deprecated and will be removed in a future release of Kubeflow Trainer. See runtime deprecation policy: " + constants.RuntimeDeprecationPolicyURL,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			t.Cleanup(cancel)
+
+			obj := testingutil.MakeTrainingRuntimeWrapper("default", "test-runtime").Obj()
+			// Set valid replicas to avoid validation errors
+			for i := range obj.Spec.Template.Spec.ReplicatedJobs {
+				obj.Spec.Template.Spec.ReplicatedJobs[i].Replicas = 1
+			}
+
+			if len(tc.labels) != 0 {
+				obj.Labels = tc.labels
+			}
+
+			validator := &TrainingRuntimeValidator{}
+			warnings, err := validator.ValidateCreate(ctx, obj)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.warnings, warnings); diff != "" {
+				t.Fatalf("unexpected warnings (-want, +got): %s", diff)
+			}
+		})
+	}
+}
 
 func TestValidateReplicatedJobs(t *testing.T) {
 	cases := map[string]struct {

--- a/pkg/webhooks/trainjob_webhook_test.go
+++ b/pkg/webhooks/trainjob_webhook_test.go
@@ -315,6 +315,7 @@ func TestValidateCreate(t *testing.T) {
 	cases := map[string]struct {
 		obj                    *trainer.TrainJob
 		clusterTrainingRuntime *trainer.ClusterTrainingRuntime
+		trainingRuntime        *trainer.TrainingRuntime
 		wantError              field.ErrorList
 		wantWarnings           admission.Warnings
 	}{
@@ -369,6 +370,26 @@ func TestValidateCreate(t *testing.T) {
 			wantError:    nil,
 			wantWarnings: admission.Warnings{"Referenced ClusterTrainingRuntime \"test-runtime\" is deprecated and will be removed in a future release of Kubeflow Trainer. See runtime deprecation policy: " + constants.RuntimeDeprecationPolicyURL},
 		},
+		"deprecated namespaced TrainingRuntime referenced": {
+			obj: testingutil.MakeTrainJobWrapper("default", "valid-job-name").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
+				Obj(),
+			trainingRuntime: testingutil.MakeTrainingRuntimeWrapper("default", "test-runtime").
+				Label(constants.LabelSupport, constants.SupportDeprecated).
+				Obj(),
+			wantError:    nil,
+			wantWarnings: admission.Warnings{"Referenced TrainingRuntime \"test-runtime\" is deprecated and will be removed in a future release of Kubeflow Trainer. See runtime deprecation policy: " + constants.RuntimeDeprecationPolicyURL},
+		},
+		"non-deprecated namespaced TrainingRuntime referenced": {
+			obj: testingutil.MakeTrainJobWrapper("default", "valid-job-name").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "test-runtime").
+				Obj(),
+			trainingRuntime: testingutil.MakeTrainingRuntimeWrapper("default", "test-runtime").
+				Label(constants.LabelSupport, "stable").
+				Obj(),
+			wantError:    nil,
+			wantWarnings: nil,
+		},
 	}
 
 	for name, tc := range cases {
@@ -382,6 +403,9 @@ func TestValidateCreate(t *testing.T) {
 			clientBuilder := testingutil.NewClientBuilder()
 			if tc.clusterTrainingRuntime != nil {
 				clientBuilder = clientBuilder.WithObjects(tc.clusterTrainingRuntime)
+			}
+			if tc.trainingRuntime != nil {
+				clientBuilder = clientBuilder.WithObjects(tc.trainingRuntime)
 			}
 
 			runtimes, err := runtimecore.New(context.Background(), clientBuilder.Build(), testingutil.AsIndex(clientBuilder), nil)


### PR DESCRIPTION
## What this PR does / Why we need it

This PR adds deprecation warning support for TrainingRuntime to match the existing behavior in ClusterTrainingRuntime, ensuring consistent deprecation warnings across both runtime types.

Fixes #3965

## Description

**Problem**: ClusterTrainingRuntime emits deprecation warnings when a deprecated runtime is referenced, but TrainingRuntime does not have this check, leading to inconsistent behavior.

**Solution**: Added deprecation check in TrainingRuntime.ValidateObjects() that:
- Checks if runtime has label trainer.kubeflow.org/support: deprecated
- Emits admission warning with deprecation message
- Follows the exact same pattern as ClusterTrainingRuntime implementation

## Changes

**Modified**: pkg/runtime/core/trainingruntime.go
- Added deprecation label check using trainingruntimeutil.IsSupportDeprecated()
- Emits warning message with runtime name and deprecation policy URL
- Merges framework warnings with deprecation warnings

## Implementation Details

The implementation follows the reference pattern in ClusterTrainingRuntime.ValidateObjects() (lines 110-117 in clustertrainingruntime.go).


## Testing

Note: Comprehensive test coverage will be added after PR #3892 (ValidateObjects tests infrastructure) is merged.


## Related

- Reference implementation: pkg/runtime/core/clustertrainingruntime.go
- Helper function: pkg/util/trainingruntime.IsSupportDeprecated()
- Issue: #3965
