### PR TITLE
fix(controller): reject trailing JSON in status updates

### DIFF
--- a/pkg/statusserver/server.go
+++ b/pkg/statusserver/server.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"time"
@@ -169,6 +170,15 @@ func (s *Server) handleTrainJobRuntimeStatus(w http.ResponseWriter, r *http.Requ
 		if errors.As(err, &maxBytesError) {
 			badRequest(w, s.log, "Payload too large", metav1.StatusReasonRequestEntityTooLarge, http.StatusRequestEntityTooLarge)
 			return
+		}
+		s.log.V(5).Error(err, "Failed to parse runtime status", "namespace", namespace, "trainJobName", trainJobName)
+		badRequest(w, s.log, "Invalid payload", metav1.StatusReasonInvalid, http.StatusUnprocessableEntity)
+		return
+	}
+	var trailingJSON json.RawMessage
+	if err := decoder.Decode(&trailingJSON); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = errors.New("multiple JSON values")
 		}
 		s.log.V(5).Error(err, "Failed to parse runtime status", "namespace", namespace, "trainJobName", trainJobName)
 		badRequest(w, s.log, "Invalid payload", metav1.StatusReasonInvalid, http.StatusUnprocessableEntity)

--- a/pkg/statusserver/server.go
+++ b/pkg/statusserver/server.go
@@ -162,23 +162,12 @@ func (s *Server) handleTrainJobRuntimeStatus(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Parse request body
 	var updateRequest trainer.UpdateTrainJobStatusRequest
-	decoder := json.NewDecoder(r.Body)
-	if err := decoder.Decode(&updateRequest); err != nil {
+	if err := decodeSingleJSONValue(r.Body, &updateRequest); err != nil {
 		var maxBytesError *http.MaxBytesError
 		if errors.As(err, &maxBytesError) {
 			badRequest(w, s.log, "Payload too large", metav1.StatusReasonRequestEntityTooLarge, http.StatusRequestEntityTooLarge)
 			return
-		}
-		s.log.V(5).Error(err, "Failed to parse runtime status", "namespace", namespace, "trainJobName", trainJobName)
-		badRequest(w, s.log, "Invalid payload", metav1.StatusReasonInvalid, http.StatusUnprocessableEntity)
-		return
-	}
-	var trailingJSON json.RawMessage
-	if err := decoder.Decode(&trailingJSON); !errors.Is(err, io.EOF) {
-		if err == nil {
-			err = errors.New("multiple JSON values")
 		}
 		s.log.V(5).Error(err, "Failed to parse runtime status", "namespace", namespace, "trainJobName", trainJobName)
 		badRequest(w, s.log, "Invalid payload", metav1.StatusReasonInvalid, http.StatusUnprocessableEntity)
@@ -228,6 +217,20 @@ func (s *Server) handleTrainJobRuntimeStatus(w http.ResponseWriter, r *http.Requ
 	if err := json.NewEncoder(w).Encode(updateRequest); err != nil {
 		s.log.Error(err, "Failed to write TrainJob status", "namespace", namespace, "name", trainJobName)
 	}
+}
+
+func decodeSingleJSONValue(r io.Reader, value any) error {
+	decoder := json.NewDecoder(r)
+	if err := decoder.Decode(value); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return err
+	}
+	return nil
 }
 
 // handleDefault is the default handler for unknown requests.

--- a/pkg/statusserver/server.go
+++ b/pkg/statusserver/server.go
@@ -163,7 +163,7 @@ func (s *Server) handleTrainJobRuntimeStatus(w http.ResponseWriter, r *http.Requ
 	}
 
 	var updateRequest trainer.UpdateTrainJobStatusRequest
-	if err := decodeSingleJSONValue(r.Body, &updateRequest); err != nil {
+	if err := decodeRequestPayload(r.Body, &updateRequest); err != nil {
 		var maxBytesError *http.MaxBytesError
 		if errors.As(err, &maxBytesError) {
 			badRequest(w, s.log, "Payload too large", metav1.StatusReasonRequestEntityTooLarge, http.StatusRequestEntityTooLarge)
@@ -219,11 +219,12 @@ func (s *Server) handleTrainJobRuntimeStatus(w http.ResponseWriter, r *http.Requ
 	}
 }
 
-func decodeSingleJSONValue(r io.Reader, value any) error {
+func decodeRequestPayload(r io.Reader, payload *trainer.UpdateTrainJobStatusRequest) error {
 	decoder := json.NewDecoder(r)
-	if err := decoder.Decode(value); err != nil {
+	if err := decoder.Decode(payload); err != nil {
 		return err
 	}
+	// Ensure there is no additional data in the request body.
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
 		if err == nil {
 			return errors.New("multiple JSON values")

--- a/pkg/statusserver/server_test.go
+++ b/pkg/statusserver/server_test.go
@@ -164,6 +164,28 @@ func TestServerErrorResponses(t *testing.T) {
 				Code:    http.StatusUnprocessableEntity,
 			},
 		},
+		"multiple JSON values fail with 422 unprocessable entity": {
+			url:        "/apis/trainer.kubeflow.org/v1alpha1/namespaces/default/trainjobs/test-job/status",
+			body:       `{}{}`,
+			authorized: true,
+			wantResponse: &metav1.Status{
+				Status:  metav1.StatusFailure,
+				Message: "Invalid payload",
+				Reason:  metav1.StatusReasonInvalid,
+				Code:    http.StatusUnprocessableEntity,
+			},
+		},
+		"trailing invalid data fails with 422 unprocessable entity": {
+			url:        "/apis/trainer.kubeflow.org/v1alpha1/namespaces/default/trainjobs/test-job/status",
+			body:       `{} invalid payload`,
+			authorized: true,
+			wantResponse: &metav1.Status{
+				Status:  metav1.StatusFailure,
+				Message: "Invalid payload",
+				Reason:  metav1.StatusReasonInvalid,
+				Code:    http.StatusUnprocessableEntity,
+			},
+		},
 		"oversized payload fails with 413 payload too large error": {
 			url: "/apis/trainer.kubeflow.org/v1alpha1/namespaces/default/trainjobs/test-job/status",
 			// Generate ~1MB payload (exceeds 64kB limit)

--- a/pkg/statusserver/server_test.go
+++ b/pkg/statusserver/server_test.go
@@ -186,6 +186,17 @@ func TestServerErrorResponses(t *testing.T) {
 				Code:    http.StatusUnprocessableEntity,
 			},
 		},
+		"trailing closing delimiter fails with 422 unprocessable entity": {
+			url:        "/apis/trainer.kubeflow.org/v1alpha1/namespaces/default/trainjobs/test-job/status",
+			body:       `{}]`,
+			authorized: true,
+			wantResponse: &metav1.Status{
+				Status:  metav1.StatusFailure,
+				Message: "Invalid payload",
+				Reason:  metav1.StatusReasonInvalid,
+				Code:    http.StatusUnprocessableEntity,
+			},
+		},
 		"oversized payload fails with 413 payload too large error": {
 			url: "/apis/trainer.kubeflow.org/v1alpha1/namespaces/default/trainjobs/test-job/status",
 			// Generate ~1MB payload (exceeds 64kB limit)


### PR DESCRIPTION
**What this PR does / why we need it**:

The status server previously decoded only the first JSON value in a request body. As a result, payloads containing a valid status update followed by a second JSON value or malformed trailing data were silently accepted.

This change requires the decoder to reach end-of-input after the first value and returns the existing HTTP 422 `Invalid payload` response otherwise. Regression tests cover both an additional JSON value and malformed trailing content.

**Which issue(s) this PR fixes**:
Fixes #3970

**Testing:**

- `go test -v ./pkg/statusserver -run '^TestServerErrorResponses$' -count=1`
- `go test ./pkg/statusserver/... -count=1`
- `go vet ./pkg/statusserver/...`
- `make test`
- `make vet`

**Checklist:**

- [x] Docs are not required; this rejects malformed request bodies without changing supported API behavior.