### PR TITLE
fix(controller): reject oversized chunked status requests

### DIFF
--- a/pkg/statusserver/server.go
+++ b/pkg/statusserver/server.go
@@ -165,6 +165,11 @@ func (s *Server) handleTrainJobRuntimeStatus(w http.ResponseWriter, r *http.Requ
 	var updateRequest trainer.UpdateTrainJobStatusRequest
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&updateRequest); err != nil {
+		var maxBytesError *http.MaxBytesError
+		if errors.As(err, &maxBytesError) {
+			badRequest(w, s.log, "Payload too large", metav1.StatusReasonRequestEntityTooLarge, http.StatusRequestEntityTooLarge)
+			return
+		}
 		s.log.V(5).Error(err, "Failed to parse runtime status", "namespace", namespace, "trainJobName", trainJobName)
 		badRequest(w, s.log, "Invalid payload", metav1.StatusReasonInvalid, http.StatusUnprocessableEntity)
 		return

--- a/pkg/statusserver/server_test.go
+++ b/pkg/statusserver/server_test.go
@@ -139,6 +139,7 @@ func TestServerErrorResponses(t *testing.T) {
 	cases := map[string]struct {
 		url          string
 		body         string
+		chunked      bool
 		authorized   bool
 		wantResponse *metav1.Status
 	}{
@@ -175,6 +176,19 @@ func TestServerErrorResponses(t *testing.T) {
 				Code:    http.StatusRequestEntityTooLarge,
 			},
 		},
+		"oversized chunked payload fails with 413 payload too large error": {
+			url: "/apis/trainer.kubeflow.org/v1alpha1/namespaces/default/trainjobs/test-job/status",
+			// Generate ~1MB payload (exceeds 64kB limit) without a Content-Length header.
+			body:       `{"trainerStatus": {"metrics": [` + strings.Repeat(`{"name":"m","value":"0.5"},`, 40000) + `]}}`,
+			chunked:    true,
+			authorized: true,
+			wantResponse: &metav1.Status{
+				Status:  metav1.StatusFailure,
+				Message: "Payload too large",
+				Reason:  metav1.StatusReasonRequestEntityTooLarge,
+				Code:    http.StatusRequestEntityTooLarge,
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -197,6 +211,10 @@ func TestServerErrorResponses(t *testing.T) {
 			req, err := http.NewRequest("POST", ts.URL+tc.url, bytes.NewReader([]byte(tc.body)))
 			if err != nil {
 				t.Fatalf("Failed to create request: %v", err)
+			}
+			if tc.chunked {
+				req.ContentLength = -1
+				req.TransferEncoding = []string{"chunked"}
 			}
 			resp, err := http.DefaultClient.Do(req)
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

The status server enforces a 64 KiB request-body limit. Requests with a known `Content-Length` already receive HTTP 413 when oversized, but chunked requests reach JSON decoding, where `*http.MaxBytesError` was previously reported as HTTP 422 `Invalid payload`.

This change recognizes that size-limit error and returns the existing HTTP 413 `Payload too large` response consistently. A regression test sends an oversized request using chunked transfer encoding through the HTTP server.

**Which issue(s) this PR fixes**:
Fixes #3972

**Testing:**

- `go test -v ./pkg/statusserver -run '^TestServerErrorResponses$/oversized_chunked_payload' -count=1`
- `go test ./pkg/statusserver/... -count=1`
- `go vet ./pkg/statusserver/...`
- `make test`
- `make vet`

**Local lint note:**

- `make golangci-lint LINT_PKG=./pkg/statusserver/...` reports the existing Windows CRLF/gci condition for all files in the package, including untouched files.

**Checklist:**

- [x] Docs are not required; this makes the existing request-size limit response consistent for chunked bodies.