### PR TITLE
fix(framework): derive process counts from the resolved node resources

### DIFF
--- a/docs/user-guides/xgboost.md
+++ b/docs/user-guides/xgboost.md
@@ -41,8 +41,9 @@ DMLC_NUM_WORKER = numNodes × workersPerNode
 
 - **CPU training**: 1 worker per node. Each worker uses OpenMP to parallelize
  across all available CPU cores.
-- **GPU training**: 1 worker per GPU. The GPU count is derived from
- `resourcesPerNode` limits in the TrainJob.
+- **GPU training**: 1 worker per GPU. The GPU count is derived from the trainer
+ node resources, which merge the TrainJob's `resourcesPerNode` onto the ones
+ declared by the Runtime.
 
 ## Distributed Training Function
 

--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -2239,3 +2239,113 @@ func TestRuntimeInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestTrainingRuntimeNewObjectsResolvedNodeResources(t *testing.T) {
+	cases := map[string]struct {
+		runtimeResources   corev1.ResourceList
+		trainJobResources  corev1.ResourceList
+		wantNodeResources  corev1.ResourceList
+		wantNumProcPerNode string
+	}{
+		"GPUs declared by the Runtime survive a TrainJob override of other resources": {
+			runtimeResources: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("8"),
+				"nvidia.com/gpu":   resource.MustParse("4"),
+			},
+			trainJobResources: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("16Gi")},
+			wantNodeResources: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("8"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+				"nvidia.com/gpu":      resource.MustParse("4"),
+			},
+			wantNumProcPerNode: "auto",
+		},
+		"TrainJob CPUs override the Runtime ones": {
+			runtimeResources:  corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")},
+			trainJobResources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+			wantNodeResources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+			// No GPU anywhere, so torchrun gets one process per CPU.
+			wantNumProcPerNode: "2",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			var cancel func()
+			ctx, cancel = context.WithCancel(ctx)
+			t.Cleanup(cancel)
+
+			trainingRuntime := testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "torch-runtime").RuntimeSpec(
+				testingutil.MakeTrainingRuntimeSpecWrapper(testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "torch-runtime").Spec).
+					WithMLPolicy(
+						testingutil.MakeMLPolicyWrapper().
+							WithNumNodes(1).
+							WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().TorchPolicy().Obj()).
+							Obj(),
+					).
+					Container(constants.Node, constants.Node, "test:runtime", []string{"runtime"}, []string{"runtime"}, tc.runtimeResources).
+					Obj(),
+			).Obj()
+
+			trainerSpec := testingutil.MakeTrainJobTrainerWrapper().NumNodes(1).Obj()
+			trainerSpec.ResourcesPerNode = &corev1.ResourceRequirements{Requests: tc.trainJobResources}
+			trainJob := testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "torch-job").
+				UID("uid").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "torch-runtime").
+				Trainer(trainerSpec).
+				Obj()
+
+			clientBuilder := testingutil.NewClientBuilder().WithObjects(trainingRuntime)
+			c := clientBuilder.Build()
+			runtimeInstance, err := NewTrainingRuntime(ctx, c, testingutil.AsIndex(clientBuilder), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			objs, err := runtimeInstance.NewObjects(ctx, trainJob)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resultObjs, err := testingutil.ToObject(c.Scheme(), objs...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			nodeContainer := findTrainerNodeContainer(t, resultObjs)
+			if diff := cmp.Diff(tc.wantNodeResources, nodeContainer.Resources.Requests); len(diff) != 0 {
+				t.Errorf("Unexpected node container resources (-want,+got):\n%s", diff)
+			}
+			var gotNumProcPerNode string
+			for _, env := range nodeContainer.Env {
+				if env.Name == constants.TorchEnvNumProcPerNode {
+					gotNumProcPerNode = env.Value
+				}
+			}
+			if gotNumProcPerNode != tc.wantNumProcPerNode {
+				t.Errorf("Unexpected %s: got %q, want %q", constants.TorchEnvNumProcPerNode, gotNumProcPerNode, tc.wantNumProcPerNode)
+			}
+		})
+	}
+}
+
+func findTrainerNodeContainer(t *testing.T, objs []runtime.Object) corev1.Container {
+	t.Helper()
+	for _, obj := range objs {
+		jobSet, ok := obj.(*jobsetv1alpha2.JobSet)
+		if !ok {
+			continue
+		}
+		for _, rJob := range jobSet.Spec.ReplicatedJobs {
+			if rJob.Name != constants.Node {
+				continue
+			}
+			for _, container := range rJob.Template.Spec.Template.Spec.Containers {
+				if container.Name == constants.Node {
+					return container
+				}
+			}
+		}
+	}
+	t.Fatalf("JobSet does not have the %s container in the %s replicated job", constants.Node, constants.Node)
+	return corev1.Container{}
+}

--- a/pkg/runtime/framework/plugins/flux/flux.go
+++ b/pkg/runtime/framework/plugins/flux/flux.go
@@ -422,9 +422,6 @@ func (f *Flux) generateFluxEntrypoint(trainJob *trainer.TrainJob, info *runtime.
 
 	// Derive number of GPUs from resources. In Flux, -g is --gpus-per-task
 	resourcesPerNode := ptr.Deref(runtime.ExtractResourcePerNodeFromRuntime(info), corev1.ResourceRequirements{})
-	if jobTrainer := trainJob.Spec.Trainer; jobTrainer != nil && jobTrainer.ResourcesPerNode != nil {
-		resourcesPerNode = ptr.Deref(jobTrainer.ResourcesPerNode, corev1.ResourceRequirements{})
-	}
 	gpus := runtime.GetNumGPUPerNode(&resourcesPerNode)
 
 	// Resource file for cluster includes GPUs or not

--- a/pkg/runtime/framework/plugins/flux/flux_test.go
+++ b/pkg/runtime/framework/plugins/flux/flux_test.go
@@ -25,6 +25,7 @@ import (
 	gocmp "github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -687,6 +688,59 @@ func TestGetNumNodes(t *testing.T) {
 			info := &runtime.Info{TemplateSpec: runtime.TemplateSpec{PodSets: tc.podSets}}
 			if got := getNumNodes(info); got != tc.want {
 				t.Errorf("getNumNodes() = %d; want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGenerateFluxEntrypoint(t *testing.T) {
+	cases := map[string]struct {
+		nodeResources corev1.ResourceList
+		wantContains  []string
+		wantOmits     []string
+	}{
+		"GPUs declared by the Runtime are passed as gpus-per-task": {
+			nodeResources: corev1.ResourceList{
+				"example.com/gpu": resource.MustParse("4"),
+			},
+			wantContains: []string{"-g 4", "--gpu=0-3"},
+		},
+		"no GPU in the node resources": {
+			nodeResources: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("4"),
+			},
+			wantOmits: []string{"-g ", "--gpu="},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			info := runtime.NewInfo(
+				runtime.WithMLPolicySource(utiltesting.MakeMLPolicyWrapper().
+					WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().FluxPolicy(ptr.To[int32](1)).Obj()).
+					Obj(),
+				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(tc.nodeResources)),
+			)
+			// The TrainJob overrides memory only, so the GPUs can come from the Runtime alone.
+			trainJob := utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "flux-job").
+				Trainer(utiltesting.MakeTrainJobTrainerWrapper().
+					Container("image", nil, nil, corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("32Gi"),
+					}).
+					Obj()).
+				Obj()
+
+			got := (&Flux{}).generateFluxEntrypoint(trainJob, info, 1)
+			for _, want := range tc.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("generateFluxEntrypoint() does not contain %q:\n%s", want, got)
+				}
+			}
+			for _, omit := range tc.wantOmits {
+				if strings.Contains(got, omit) {
+					t.Errorf("generateFluxEntrypoint() contains %q for a node without GPUs:\n%s", omit, got)
+				}
 			}
 		})
 	}

--- a/pkg/runtime/framework/plugins/mpi/mpi.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi.go
@@ -130,9 +130,6 @@ func (m *MPI) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) er
 		// If numProcPerNode is set to 1 in runtime, we make it equal to number of GPUs.
 	} else if *info.RuntimePolicy.MLPolicySource.MPI.NumProcPerNode == 1 {
 		resourcesPerNode := ptr.Deref(runtime.ExtractResourcePerNodeFromRuntime(info), corev1.ResourceRequirements{})
-		if jobTrainer := trainJob.Spec.Trainer; jobTrainer != nil && jobTrainer.ResourcesPerNode != nil {
-			resourcesPerNode = ptr.Deref(jobTrainer.ResourcesPerNode, corev1.ResourceRequirements{})
-		}
 		if gpuQ := runtime.GetNumGPUPerNode(&resourcesPerNode); gpuQ > 1 {
 			info.RuntimePolicy.MLPolicySource.MPI.NumProcPerNode = ptr.To(int32(gpuQ))
 		}

--- a/pkg/runtime/framework/plugins/mpi/mpi_test.go
+++ b/pkg/runtime/framework/plugins/mpi/mpi_test.go
@@ -372,11 +372,14 @@ trainJob-node-1-1.trainJob slots=1
 					Obj(),
 			},
 		},
-		"numProcPerNode is set to number of GPUs in TrainJob": {
+		"numProcPerNode is set to number of GPUs in the resolved node resources": {
 			info: &runtime.Info{
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						"custom.com/gpu": resource.MustParse("5"),
+					}),
 					PodSets: []runtime.PodSet{
 						{
 							Name:  constants.Launcher,
@@ -410,7 +413,7 @@ trainJob-node-1-1.trainJob slots=1
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumNodes(1).
 						Container("test:trainjob", []string{"trainjob"}, []string{"trainjob"}, corev1.ResourceList{
-							"custom.com/gpu": resource.MustParse("5"),
+							corev1.ResourceMemory: resource.MustParse("32Gi"),
 						}).
 						Obj()).
 				Obj(),
@@ -418,6 +421,9 @@ trainJob-node-1-1.trainJob slots=1
 				Labels:      make(map[string]string),
 				Annotations: make(map[string]string),
 				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						"custom.com/gpu": resource.MustParse("5"),
+					}),
 					PodSets: []runtime.PodSet{
 						{
 							Name:  constants.Launcher,

--- a/pkg/runtime/framework/plugins/torch/torch.go
+++ b/pkg/runtime/framework/plugins/torch/torch.go
@@ -125,9 +125,6 @@ func (t *Torch) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) 
 
 	// Determine numProcPerNode based on the resourcesPerNode.
 	resourcesPerNode := ptr.Deref(runtime.ExtractResourcePerNodeFromRuntime(info), corev1.ResourceRequirements{})
-	if jobTrainer := trainJob.Spec.Trainer; jobTrainer != nil && jobTrainer.ResourcesPerNode != nil {
-		resourcesPerNode = ptr.Deref(jobTrainer.ResourcesPerNode, corev1.ResourceRequirements{})
-	}
 	gpuQ := runtime.GetNumGPUPerNode(&resourcesPerNode)
 	// If no GPU is set in resource, calculate numProcPerNode based on CPU.
 	if numProcPerNode.String() == "auto" && gpuQ == 0 {

--- a/pkg/runtime/framework/plugins/torch/torch_test.go
+++ b/pkg/runtime/framework/plugins/torch/torch_test.go
@@ -164,6 +164,9 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				})),
 			),
 			wantInfo: &runtime.Info{
 				Labels:      make(map[string]string),
@@ -174,6 +177,9 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("4"),
+					}),
 					PodSets: []runtime.PodSet{{
 						Name:              constants.Node,
 						Ancestor:          ptr.To(constants.AncestorTrainer),
@@ -310,6 +316,9 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2"),
+				})),
 			),
 			wantInfo: &runtime.Info{
 				Labels:      make(map[string]string),
@@ -320,6 +329,9 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("2"),
+					}),
 					PodSets: []runtime.PodSet{{
 						Name:              constants.Node,
 						Ancestor:          ptr.To(constants.AncestorTrainer),
@@ -384,6 +396,9 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("3"),
+				})),
 			),
 			wantInfo: &runtime.Info{
 				Labels:      make(map[string]string),
@@ -394,6 +409,9 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("3"),
+					}),
 					PodSets: []runtime.PodSet{{
 						Name:              constants.Node,
 						Ancestor:          ptr.To(constants.AncestorTrainer),
@@ -458,6 +476,9 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2.5"),
+				})),
 			),
 			wantInfo: &runtime.Info{
 				Labels:      make(map[string]string),
@@ -468,6 +489,9 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("2.5"),
+					}),
 					PodSets: []runtime.PodSet{{
 						Name:              constants.Node,
 						Ancestor:          ptr.To(constants.AncestorTrainer),
@@ -606,6 +630,9 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					"example.com/gpu": resource.MustParse("2"),
+				})),
 			),
 			wantInfo: &runtime.Info{
 				Labels:      make(map[string]string),
@@ -616,6 +643,9 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						"example.com/gpu": resource.MustParse("2"),
+					}),
 					PodSets: []runtime.PodSet{{
 						Name:              constants.Node,
 						Ancestor:          ptr.To(constants.AncestorTrainer),
@@ -755,6 +785,9 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2500m"),
+				})),
 			),
 			wantInfo: &runtime.Info{
 				Labels:      make(map[string]string),
@@ -765,6 +798,9 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("2500m"),
+					}),
 					PodSets: []runtime.PodSet{{
 						Name:              constants.Node,
 						Ancestor:          ptr.To(constants.AncestorTrainer),
@@ -829,6 +865,9 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				})),
 			),
 			wantInfo: &runtime.Info{
 				Labels:      make(map[string]string),
@@ -839,6 +878,9 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("4"),
+					}),
 					PodSets: []runtime.PodSet{{
 						Name:              constants.Node,
 						Ancestor:          ptr.To(constants.AncestorTrainer),
@@ -904,6 +946,10 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("6"),
+					"example.com/gpu":  resource.MustParse("2"),
+				})),
 			),
 			wantInfo: &runtime.Info{
 				Labels:      make(map[string]string),
@@ -914,6 +960,10 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("6"),
+						"example.com/gpu":  resource.MustParse("2"),
+					}),
 					PodSets: []runtime.PodSet{{
 						Name:              constants.Node,
 						Ancestor:          ptr.To(constants.AncestorTrainer),
@@ -956,6 +1006,88 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
+		"nproc_per_node=auto is preserved when GPUs come from the Runtime": {
+			trainJob: utiltesting.MakeTrainJobWrapper("default", "runtime-gpu-job").
+				Trainer(
+					utiltesting.MakeTrainJobTrainerWrapper().
+						Container("test:image", nil, nil, corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("32Gi"),
+						}).
+						Obj(),
+				).
+				Obj(),
+			info: runtime.NewInfo(
+				runtime.WithMLPolicySource(
+					utiltesting.MakeMLPolicyWrapper().
+						WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+							TorchPolicy().
+							Obj(),
+						).
+						Obj(),
+				),
+				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
+					WithContainers(corev1ac.Container().WithName(constants.Node)),
+				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("6"),
+					"example.com/gpu":  resource.MustParse("2"),
+				})),
+			),
+			wantInfo: &runtime.Info{
+				Labels:      make(map[string]string),
+				Annotations: make(map[string]string),
+				RuntimePolicy: runtime.RuntimePolicy{
+					MLPolicySource: utiltesting.MakeMLPolicySourceWrapper().
+						TorchPolicy().
+						Obj(),
+				},
+				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("6"),
+						"example.com/gpu":  resource.MustParse("2"),
+					}),
+					PodSets: []runtime.PodSet{{
+						Name:              constants.Node,
+						Ancestor:          ptr.To(constants.AncestorTrainer),
+						Count:             ptr.To[int32](1),
+						SinglePodRequests: make(corev1.ResourceList),
+						Containers: []runtime.Container{{
+							Name: constants.Node,
+							Ports: []corev1ac.ContainerPortApplyConfiguration{{
+								ContainerPort: ptr.To[int32](constants.ContainerTrainerPort),
+							}},
+							Env: []corev1ac.EnvVarApplyConfiguration{
+								{
+									Name:  ptr.To(constants.TorchEnvNumNodes),
+									Value: ptr.To("1"),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvNumProcPerNode),
+									Value: ptr.To("auto"),
+								},
+								{
+									Name: ptr.To(constants.TorchEnvNodeRank),
+									ValueFrom: &corev1ac.EnvVarSourceApplyConfiguration{
+										FieldRef: &corev1ac.ObjectFieldSelectorApplyConfiguration{
+											FieldPath: ptr.To(constants.JobCompletionIndexFieldPath),
+										},
+									},
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvMasterAddr),
+									Value: ptr.To("runtime-gpu-job-node-0-0.runtime-gpu-job"),
+								},
+								{
+									Name:  ptr.To(constants.TorchEnvMasterPort),
+									Value: ptr.To(fmt.Sprintf("%d", constants.ContainerTrainerPort)),
+								},
+							},
+						}},
+					}},
+				},
+				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
+			},
+		},
 		"nproc_per_node=cpu with fractional CPU": {
 			trainJob: utiltesting.MakeTrainJobWrapper("default", "cpu-frac-job").
 				Trainer(
@@ -978,6 +1110,9 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("3.7"),
+				})),
 			),
 			wantInfo: &runtime.Info{
 				Labels:      make(map[string]string),
@@ -988,6 +1123,9 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("3.7"),
+					}),
 					PodSets: []runtime.PodSet{{
 						Name:              constants.Node,
 						Ancestor:          ptr.To(constants.AncestorTrainer),
@@ -1059,6 +1197,11 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 2, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+					"example.com/gpu":     resource.MustParse("4"),
+				})),
 			),
 			wantInfo: &runtime.Info{
 				Labels: map[string]string{
@@ -1072,6 +1215,11 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("16Gi"),
+						"example.com/gpu":     resource.MustParse("4"),
+					}),
 					PodSets: []runtime.PodSet{{
 						Name:              constants.Node,
 						Ancestor:          ptr.To(constants.AncestorTrainer),
@@ -1153,6 +1301,11 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+					"example.com/gpu":     resource.MustParse("4"),
+				})),
 			),
 			wantInfo: &runtime.Info{
 				Labels:      make(map[string]string),
@@ -1163,6 +1316,11 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("16Gi"),
+						"example.com/gpu":     resource.MustParse("4"),
+					}),
 					PodSets: []runtime.PodSet{{
 						Name:              constants.Node,
 						Ancestor:          ptr.To(constants.AncestorTrainer),
@@ -1604,6 +1762,10 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 						corev1ac.Container().WithName(constants.Node),
 					),
 				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("8"),
+					"example.com/gpu":  resource.MustParse("4"),
+				})),
 			),
 			trainJob: utiltesting.MakeTrainJobWrapper("default", "test-job").
 				Trainer(
@@ -1641,6 +1803,10 @@ func TestTorchEnforceMLPolicy(t *testing.T) {
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("8"),
+						"example.com/gpu":  resource.MustParse("4"),
+					}),
 					PodSets: []runtime.PodSet{{
 						Name:              constants.Node,
 						Ancestor:          ptr.To(constants.AncestorTrainer),
@@ -2451,6 +2617,41 @@ func TestTorchValidate(t *testing.T) {
 					fmt.Sprintf("must have gpu resource with value 1 for %v model when using QLoRA", "llama3_2/1B"),
 				),
 			},
+		},
+		"qlora on a single Runtime-declared GPU is accepted": {
+			info: runtime.NewInfo(
+				runtime.WithMLPolicySource(utiltesting.MakeMLPolicyWrapper().
+					WithMLPolicySource(*utiltesting.MakeMLPolicySourceWrapper().
+						TorchPolicy().
+						Obj(),
+					).
+					Obj(),
+				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					"example.com/gpu": resource.MustParse("1"),
+				})),
+			),
+			newObj: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				Trainer(utiltesting.MakeTrainJobTrainerWrapper().
+					NumNodes(int32(1)).
+					Container(
+						"ghcr.io/kubeflow/trainer/torchtune-trainer",
+						[]string{"tune", "run"},
+						[]string{
+							"model.lora_attn_modules=[q_proj, v_proj, output_proj]",
+							"model.quantize_base=True",
+						},
+						corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("32Gi"),
+						},
+					).
+					Obj(),
+				).
+				RuntimeRef(
+					trainer.SchemeGroupVersion.WithKind(trainer.ClusterTrainingRuntimeKind),
+					"torchtune-llama3.2-1b",
+				).
+				Obj(),
 		},
 		"lora is not supported for multi-node training in torchtune": {
 			info: runtime.NewInfo(

--- a/pkg/runtime/framework/plugins/torch/torchtune.go
+++ b/pkg/runtime/framework/plugins/torch/torchtune.go
@@ -55,9 +55,6 @@ func validateTorchTune(runtimeInfo *runtime.Info, newObj *trainer.TrainJob) (adm
 		numProcPerNode = intstr.FromInt32(*newObj.Spec.Trainer.NumProcPerNode)
 	}
 	resourcesPerNode := ptr.Deref(runtime.ExtractResourcePerNodeFromRuntime(runtimeInfo), corev1.ResourceRequirements{})
-	if jobTrainer := newObj.Spec.Trainer; jobTrainer != nil && jobTrainer.ResourcesPerNode != nil {
-		resourcesPerNode = ptr.Deref(jobTrainer.ResourcesPerNode, corev1.ResourceRequirements{})
-	}
 	_, config := getRecipeAndConfig(numNodes, numProcPerNode, runtime.GetNumGPUPerNode(&resourcesPerNode), newObj)
 	if strings.Contains(config, constants.TorchTuneQLoRAFinetuneDistributedConfigSuffix) {
 		if model == constants.TORCHTUNE_MODEL_QWEN2_5_1_5B {

--- a/pkg/runtime/framework/plugins/xgboost/xgboost.go
+++ b/pkg/runtime/framework/plugins/xgboost/xgboost.go
@@ -100,13 +100,7 @@ func (x *XGBoost) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob
 			// Auto-derive numWorkersPerNode from GPU resources.
 			// GPU training: 1 worker per GPU | CPU training: 1 worker per node.
 			numWorkersPerNode := int32(1)
-			// Step 1: Get resources from Runtime (ClusterTrainingRuntime template).
 			resourcesPerNode := ptr.Deref(runtime.ExtractResourcePerNodeFromRuntime(info), corev1.ResourceRequirements{})
-			// Step 2: Override with TrainJob resources if specified.
-			if jobTrainer := trainJob.Spec.Trainer; jobTrainer != nil && jobTrainer.ResourcesPerNode != nil {
-				resourcesPerNode = ptr.Deref(jobTrainer.ResourcesPerNode, corev1.ResourceRequirements{})
-			}
-			// Step 3: Derive GPU count from the final resolved resources.
 			if gpuCount := runtime.GetNumGPUPerNode(&resourcesPerNode); gpuCount > 0 {
 				numWorkersPerNode = int32(gpuCount)
 			}

--- a/pkg/runtime/framework/plugins/xgboost/xgboost_test.go
+++ b/pkg/runtime/framework/plugins/xgboost/xgboost_test.go
@@ -27,11 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	batchv1ac "k8s.io/client-go/applyconfigurations/batch/v1"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
-	jobsetv1alpha2ac "sigs.k8s.io/jobset/client-go/applyconfiguration/jobset/v1alpha2"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
@@ -427,6 +425,11 @@ func TestXGBoostEnforceMLPolicy(t *testing.T) {
 				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("32Gi"),
+					"example.com/gpu":     resource.MustParse("4"),
+				})),
 			),
 			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "gpu-job").
 				Trainer(
@@ -449,6 +452,11 @@ func TestXGBoostEnforceMLPolicy(t *testing.T) {
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("8"),
+						corev1.ResourceMemory: resource.MustParse("32Gi"),
+						"example.com/gpu":     resource.MustParse("4"),
+					}),
 					PodSets: []runtime.PodSet{{
 						Name:              constants.Node,
 						Ancestor:          ptr.To(constants.AncestorTrainer),
@@ -634,30 +642,9 @@ func TestXGBoostEnforceMLPolicy(t *testing.T) {
 				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
-				runtime.WithTemplateSpecObjApply(
-					jobsetv1alpha2ac.JobSetSpec().
-						WithReplicatedJobs(
-							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.Node).
-								WithTemplate(batchv1ac.JobTemplateSpec().
-									WithSpec(batchv1ac.JobSpec().
-										WithTemplate(corev1ac.PodTemplateSpec().
-											WithSpec(corev1ac.PodSpec().
-												WithContainers(
-													corev1ac.Container().
-														WithName(constants.Node).
-														WithResources(corev1ac.ResourceRequirements().
-															WithRequests(corev1.ResourceList{
-																"example.com/gpu": resource.MustParse("2"),
-															}),
-														),
-												),
-											),
-										),
-									),
-								),
-						),
-				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					"example.com/gpu": resource.MustParse("2"),
+				})),
 			),
 			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "runtime-res-job").
 				Trainer(
@@ -708,28 +695,9 @@ func TestXGBoostEnforceMLPolicy(t *testing.T) {
 							},
 						}},
 					}},
-					ObjApply: jobsetv1alpha2ac.JobSetSpec().
-						WithReplicatedJobs(
-							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.Node).
-								WithTemplate(batchv1ac.JobTemplateSpec().
-									WithSpec(batchv1ac.JobSpec().
-										WithTemplate(corev1ac.PodTemplateSpec().
-											WithSpec(corev1ac.PodSpec().
-												WithContainers(
-													corev1ac.Container().
-														WithName(constants.Node).
-														WithResources(corev1ac.ResourceRequirements().
-															WithRequests(corev1.ResourceList{
-																"example.com/gpu": resource.MustParse("2"),
-															}),
-														),
-												),
-											),
-										),
-									),
-								),
-						),
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						"example.com/gpu": resource.MustParse("2"),
+					}),
 				},
 				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
@@ -747,6 +715,9 @@ func TestXGBoostEnforceMLPolicy(t *testing.T) {
 				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					"example.com/gpu": resource.MustParse("4"),
+				})),
 			),
 			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "trainjob-res").
 				Trainer(
@@ -767,6 +738,9 @@ func TestXGBoostEnforceMLPolicy(t *testing.T) {
 						Obj(),
 				},
 				TemplateSpec: runtime.TemplateSpec{
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						"example.com/gpu": resource.MustParse("4"),
+					}),
 					PodSets: []runtime.PodSet{{
 						Name:              constants.Node,
 						Ancestor:          ptr.To(constants.AncestorTrainer),
@@ -805,7 +779,7 @@ func TestXGBoostEnforceMLPolicy(t *testing.T) {
 				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
-		"resources set in both Runtime and TrainJob": {
+		"GPUs from the Runtime are honored when TrainJob overrides other resources": {
 			info: runtime.NewInfo(
 				runtime.WithMLPolicySource(
 					utiltesting.MakeMLPolicyWrapper().
@@ -818,37 +792,16 @@ func TestXGBoostEnforceMLPolicy(t *testing.T) {
 				runtime.WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 1, corev1.PodSpec{}, corev1ac.PodSpec().
 					WithContainers(corev1ac.Container().WithName(constants.Node)),
 				),
-				runtime.WithTemplateSpecObjApply(
-					jobsetv1alpha2ac.JobSetSpec().
-						WithReplicatedJobs(
-							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.Node).
-								WithTemplate(batchv1ac.JobTemplateSpec().
-									WithSpec(batchv1ac.JobSpec().
-										WithTemplate(corev1ac.PodTemplateSpec().
-											WithSpec(corev1ac.PodSpec().
-												WithContainers(
-													corev1ac.Container().
-														WithName(constants.Node).
-														WithResources(corev1ac.ResourceRequirements().
-															WithRequests(corev1.ResourceList{
-																"example.com/gpu": resource.MustParse("1"),
-															}),
-														),
-												),
-											),
-										),
-									),
-								),
-						),
-				),
+				runtime.WithTemplateSpecObjApply(utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+					"example.com/gpu": resource.MustParse("3"),
+				})),
 			),
 			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "both-res-job").
 				Trainer(
 					utiltesting.MakeTrainJobTrainerWrapper().
 						NumNodes(2).
 						Container("xgboost/xgboost:latest", nil, nil, corev1.ResourceList{
-							"example.com/gpu": resource.MustParse("3"),
+							corev1.ResourceMemory: resource.MustParse("32Gi"),
 						}).
 						Obj(),
 				).
@@ -896,28 +849,9 @@ func TestXGBoostEnforceMLPolicy(t *testing.T) {
 							},
 						}},
 					}},
-					ObjApply: jobsetv1alpha2ac.JobSetSpec().
-						WithReplicatedJobs(
-							jobsetv1alpha2ac.ReplicatedJob().
-								WithName(constants.Node).
-								WithTemplate(batchv1ac.JobTemplateSpec().
-									WithSpec(batchv1ac.JobSpec().
-										WithTemplate(corev1ac.PodTemplateSpec().
-											WithSpec(corev1ac.PodSpec().
-												WithContainers(
-													corev1ac.Container().
-														WithName(constants.Node).
-														WithResources(corev1ac.ResourceRequirements().
-															WithRequests(corev1.ResourceList{
-																"example.com/gpu": resource.MustParse("1"),
-															}),
-														),
-												),
-											),
-										),
-									),
-								),
-						),
+					ObjApply: utiltesting.MakeJobSetSpecApplyWithNodeResources(corev1.ResourceList{
+						"example.com/gpu": resource.MustParse("3"),
+					}),
 				},
 				Scheduler: &runtime.Scheduler{PodLabels: make(map[string]string)},
 			},

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -260,6 +260,8 @@ func RuntimeRefToRuntimeRegistryKey(runtimeRef trainer.RuntimeRef) string {
 }
 
 // ExtractResourcePerNodeFromRuntime extracts the Trainer resource per node from the Info object.
+// The TrainJob `.spec.trainer.resourcesPerNode` override is already merged into the Info template
+// before plugins run, so callers must not re-apply it on top of the returned resources.
 func ExtractResourcePerNodeFromRuntime(info *Info) *corev1.ResourceRequirements {
 	if jobSetSpec, ok := TemplateSpecApply[jobsetv1alpha2ac.JobSetSpecApplyConfiguration](info); ok {
 		for _, rJob := range jobSetSpec.ReplicatedJobs {

--- a/pkg/util/testing/wrapper.go
+++ b/pkg/util/testing/wrapper.go
@@ -24,8 +24,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	batchv1ac "k8s.io/client-go/applyconfigurations/batch/v1"
+	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/utils/ptr"
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+	jobsetv1alpha2ac "sigs.k8s.io/jobset/client-go/applyconfiguration/jobset/v1alpha2"
 	schedulerpluginsv1alpha1 "sigs.k8s.io/scheduler-plugins/apis/scheduling/v1alpha1"
 	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 
@@ -1540,4 +1543,26 @@ func (s *SecretWrapper) ControllerReference(gvk schema.GroupVersionKind, name, u
 
 func (s *SecretWrapper) Obj() *corev1.Secret {
 	return &s.Secret
+}
+
+// MakeJobSetSpecApplyWithNodeResources returns the JobSetSpec ApplyConfiguration that Info carries for a
+// trainer node container requesting res. The Runtime resources and the TrainJob
+// `.spec.trainer.resourcesPerNode` override are already merged into it by the time plugins run.
+func MakeJobSetSpecApplyWithNodeResources(res corev1.ResourceList) *jobsetv1alpha2ac.JobSetSpecApplyConfiguration {
+	return jobsetv1alpha2ac.JobSetSpec().WithReplicatedJobs(
+		jobsetv1alpha2ac.ReplicatedJob().
+			WithName(constants.Node).
+			WithTemplate(batchv1ac.JobTemplateSpec().
+				WithSpec(batchv1ac.JobSpec().
+					WithTemplate(corev1ac.PodTemplateSpec().
+						WithSpec(corev1ac.PodSpec().
+							WithContainers(corev1ac.Container().
+								WithName(constants.Node).
+								WithResources(corev1ac.ResourceRequirements().WithRequests(res)),
+							),
+						),
+					),
+				),
+			),
+	)
 }


### PR DESCRIPTION
## Summary

A TrainJob's `.spec.trainer.resourcesPerNode` is merged onto the Runtime's trainer container resources before the ML-policy plugins run, but each plugin re-read the raw override instead of the merged result. Whatever the Runtime declared on its own — GPUs above all — disappeared from the process-count derivation while the pods still received it.

A TrainJob that raises only memory, against a Runtime declaring 4 GPUs, gets a pod with all four GPUs and `PET_NPROC_PER_NODE=1`. Torch, MPI, XGBoost and Flux each fall back to one process per node, and torchtune selects a distributed recipe for what is single-device training.

## Tests

Every affected site gains a case where the GPUs exist only in the Runtime, and `pkg/runtime/core` gains an end-to-end test pinning the merge-before-plugins ordering the fix relies on. None of them pass without the change.

## Checklist

- [x] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing

---

Assisted-by: Claude Code (Opus 5). Built, linted and tested locally — unit tests plus the envtest integration suites — before submission.
