### PR TITLE
chore(docs): Add project board section to the Contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,33 @@ Before using AI agents, please review the
 [Kubeflow AI Policy](https://www.kubeflow.org/docs/about/ai_policy/) to understand
 the guidelines and responsibilities for such contributions.
 
+## Project Board
+
+The Kubeflow Trainer community uses the
+[Kubeflow Trainer project board](https://github.com/orgs/kubeflow/projects/85/views/2)
+to track ongoing work and to triage incoming issues. The board gives maintainers and
+contributors visibility into upcoming workstreams and into the pull requests that need
+attention.
+
+The board currently tracks:
+
+- Bugs that have been reported and triaged.
+- Open issues, including the ones that are ready to be picked up by new contributors.
+- Progress on [Kubeflow Enhancement Proposals (KEPs)](#kubeflow-enhancement-proposal-kep).
+- Pull requests that are tracked for the upcoming release.
+
+If you are looking for something to work on, start with the board and pick an issue that
+is not assigned yet. Comment on the issue to let the community know that you are working
+on it before you open a pull request.
+
+When you open an issue or a pull request, a maintainer adds it to the board during triage.
+Please keep the status of your items up to date so that the board reflects the real state
+of the work.
+
+The board is still a work in progress. If you have feedback on how it can be improved,
+share it in the [`#kubeflow-trainer` Slack channel](https://www.kubeflow.org/docs/about/community/#kubeflow-slack)
+or open an issue in this repository.
+
 ## Requirements
 
 - [Go](https://golang.org/) (1.26 or later)


### PR DESCRIPTION
## What this PR does / why we need it

Adds a `## Project Board` section to `CONTRIBUTING.md` documenting the [Kubeflow Trainer project board](https://github.com/orgs/kubeflow/projects/85/views/2).

The board tracks bugs, open issues, KEP progress, and release PRs, but it is not referenced anywhere in the repository, so contributors currently have no way to discover it. The new section:

- Links to the board and describes what it tracks.
- Tells new contributors to use it to find unassigned work, and to comment on an issue before opening a PR.
- Notes that maintainers add issues and PRs to the board during triage, and asks contributors to keep item status up to date.
- Points people at the `#kubeflow-trainer` Slack channel for feedback, since the board is still a work in progress.

Docs-only change; no code or CI impact.

## Which issue(s) this PR fixes

Fixes #3979

## Checklist

- [x] Docs included if any changes are user facing
