### PR TITLE
fix(test): download valid Volcano CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ HELM_CHART_TESTING_VERSION ?= v3.12.0
 HELM_DOCS_VERSION ?= v1.14.2
 YQ_VERSION ?= v4.45.1
 KUBE_LINTER_VERSION ?= v0.7.1
+VOLCANO_VERSION ?= v1.13.1
 
 # Container runtime (docker or podman)
 CONTAINER_RUNTIME ?=
@@ -156,14 +157,12 @@ scheduler-plugins-crd: ## Copy the CRDs from the Scheduler Plugins repository to
 	mkdir -p $(EXTERNAL_CRDS_DIR)/scheduler-plugins/
 	cp -f $(SCHEDULER_PLUGINS_ROOT)/manifests/coscheduling/* $(EXTERNAL_CRDS_DIR)/scheduler-plugins
 
-VOLCANO_APIS_ROOT = $(shell go list -m -f "{{.Dir}}" volcano.sh/apis)
-VOLCANO_VERSION = $(shell basename $(VOLCANO_APIS_ROOT) | cut -d'@' -f2)
 VOLCANO_CRD_URL = https://raw.githubusercontent.com/volcano-sh/volcano/$(VOLCANO_VERSION)/config/crd/volcano/bases/scheduling.volcano.sh_podgroups.yaml
 
 .PHONY: volcano-crd
 volcano-crd: ## Copy the CRDs from Volcano repository to the manifests/external-crds directory.
 	mkdir -p $(EXTERNAL_CRDS_DIR)/volcano/
-	curl -sSL $(VOLCANO_CRD_URL) -o $(EXTERNAL_CRDS_DIR)/volcano/scheduling.volcano.sh_podgroups.yaml
+	curl -fsSL $(VOLCANO_CRD_URL) -o $(EXTERNAL_CRDS_DIR)/volcano/scheduling.volcano.sh_podgroups.yaml
 
 # Instructions for code generation.
 .PHONY: manifests


### PR DESCRIPTION
**What this PR does / why we need it**:

`make volcano-crd` derived a pseudo-version from the separate `volcano.sh/apis` module and used it as a ref in `volcano-sh/volcano`. That ref does not exist, so the raw GitHub request returned 404. Because curl did not fail on HTTP errors, the target exited successfully after writing `404: Not Found` as the CRD fixture.

This change pins the integration-test CRD to the matching official Volcano `v1.13.1` release while keeping `VOLCANO_VERSION` overrideable. It also enables curl's fail-on-HTTP-error behavior so invalid versions stop the target instead of producing a bogus YAML file.

**Which issue(s) this PR fixes**:
Fixes #3929

**Testing:**

- Reproduced current behavior: target exited 0 with a 14-byte `404: Not Found` file
- `make volcano-crd EXTERNAL_CRDS_DIR=<temp-dir>` downloaded a 7,432-byte PodGroup CRD
- Invalid `VOLCANO_VERSION` override failed with curl error 22 and nonzero make status
- `make test`
- `make vet`
- Direct envtest run loaded and installed `podgroups.scheduling.volcano.sh`; 28 controller specs passed before the existing Windows process-teardown limitation caused suite failures

**Checklist:**

- [x] Docs are not required; this fixes an integration-test dependency download.