### PR TITLE
feat(framework): make plugin phase execution order deterministic

### DIFF
--- a/pkg/runtime/framework/core/framework.go
+++ b/pkg/runtime/framework/core/framework.go
@@ -19,6 +19,7 @@ package core
 import (
 	"context"
 	"errors"
+	"slices"
 
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -57,7 +58,16 @@ func New(ctx context.Context, c client.Client, r fwkplugins.Registry, indexer cl
 		return nil, err
 	}
 
-	for name, factory := range r {
+	// Instantiate plugins in a deterministic order for consistency across restarts.
+	// The order is arbitrary.
+	names := make([]string, 0, len(r))
+	for name := range r {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	for _, name := range names {
+		factory := r[name]
 		plugin, err := factory(ctx, c, indexer, cfg)
 		if err != nil {
 			return nil, err

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -19,6 +19,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -186,6 +187,43 @@ func TestNew(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewPluginOrderIsDeterministic(t *testing.T) {
+	// Verify the implementation detail that plugins are executed in name order.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	clientBuilder := testingutil.NewClientBuilder()
+	registry := fwkplugins.NewRegistry()
+
+	fwk, err := New(ctx, clientBuilder.Build(), registry, testingutil.AsIndex(clientBuilder), nil)
+	if err != nil {
+		t.Fatalf("Failed to create framework: %v", err)
+	}
+
+	assertSorted := func(phase string, names []string) {
+		if !slices.IsSorted(names) {
+			t.Errorf("%s plugins are not in canonical name-sorted order: %v", phase, names)
+		}
+	}
+
+	mlNames := make([]string, len(fwk.enforceMLPlugins))
+	for i, p := range fwk.enforceMLPlugins {
+		mlNames[i] = p.(framework.Plugin).Name()
+	}
+	assertSorted("enforceMLPlugins", mlNames)
+
+	buildNames := make([]string, len(fwk.componentBuilderPlugins))
+	for i, p := range fwk.componentBuilderPlugins {
+		buildNames[i] = p.(framework.Plugin).Name()
+	}
+	assertSorted("componentBuilderPlugins", buildNames)
+
+	validationNames := make([]string, len(fwk.customValidationPlugins))
+	for i, p := range fwk.customValidationPlugins {
+		validationNames[i] = p.(framework.Plugin).Name()
+	}
+	assertSorted("customValidationPlugins", validationNames)
 }
 
 func TestRunEnforceMLPolicyPlugins(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

`Framework.New()` built each plugin phase by ranging over the registry map, whose iteration order Go randomizes, so per-phase plugin execution order was not stable across controller starts. Phases increasingly rely on sequential PodSpec mutation with last-write-wins helpers (`UpsertEnvVars`, `UpsertVolumes`, `UpsertVolumeMounts`, `UpsertPort`), so a stable order is a prerequisite for defining cross-plugin precedence or conflict semantics.

This sorts registry names before instantiating plugins, so every phase slice is populated in a reproducible, name-sorted order. This is the minimal deterministic baseline; explicit priority metadata can be added later if semantic precedence is needed.

Existing tests are unaffected because they normalize with `cmpopts.SortSlices`, which is why the prior map randomness was hidden. Adds `TestNewPluginOrderingDeterministic` to assert phase slices are name-sorted.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #3957

**Checklist:**

- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing
