### PR TITLE
fix(controller): preserve runtime logger context

### DIFF
--- a/pkg/controller/clustertrainingruntime_controller.go
+++ b/pkg/controller/clustertrainingruntime_controller.go
@@ -59,8 +59,8 @@ func (r *ClusterTrainingRuntimeReconciler) Reconcile(ctx context.Context, reques
 	if err := r.client.Get(ctx, request.NamespacedName, &clRuntime); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	log := r.log.WithValues("clusterTrainingRuntime", klog.KObj(&clRuntime))
-	ctrl.LoggerInto(ctx, log)
+	log := ctrl.LoggerFrom(ctx).WithValues("clusterTrainingRuntime", klog.KObj(&clRuntime))
+	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(2).Info("Reconciling ClusterTrainingRuntime")
 
 	prevClRuntime := clRuntime.DeepCopy()

--- a/pkg/controller/clustertrainingruntime_controller_test.go
+++ b/pkg/controller/clustertrainingruntime_controller_test.go
@@ -18,13 +18,16 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/go-logr/logr/funcr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2/ktesting"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
@@ -36,6 +39,7 @@ func TestReconcile_ClusterTrainingRuntimeReconciler(t *testing.T) {
 	cases := map[string]struct {
 		clTrainingRuntime     *trainer.ClusterTrainingRuntime
 		wantClTrainingRuntime *trainer.ClusterTrainingRuntime
+		wantRuntimeLogValue   string
 	}{
 		"remove existing finalizer during reconciliation": {
 			clTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
@@ -43,6 +47,7 @@ func TestReconcile_ClusterTrainingRuntimeReconciler(t *testing.T) {
 				Obj(),
 			wantClTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
 				Obj(),
+			wantRuntimeLogValue: `"clusterTrainingRuntime"={"name"="runtime"}`,
 		},
 		"no action when runtime has no finalizer": {
 			clTrainingRuntime: utiltesting.MakeClusterTrainingRuntimeWrapper("runtime").
@@ -54,13 +59,17 @@ func TestReconcile_ClusterTrainingRuntimeReconciler(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
-			var cancel func()
-			ctx, cancel = context.WithCancel(ctx)
-			t.Cleanup(cancel)
-			cli := utiltesting.NewClientBuilder().
-				WithObjects(tc.clTrainingRuntime).
-				Build()
+			var logBuffer strings.Builder
+			logger := funcr.New(func(_, args string) { logBuffer.WriteString(args) }, funcr.Options{})
+			ctx := ctrl.LoggerInto(context.Background(), logger)
+			clientBuilder := utiltesting.NewClientBuilder().WithObjects(tc.clTrainingRuntime)
+			clientBuilder.WithInterceptorFuncs(interceptor.Funcs{
+				Patch: func(ctx context.Context, cli client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					ctrl.LoggerFrom(ctx).Info("Patching ClusterTrainingRuntime")
+					return cli.Patch(ctx, obj, patch, opts...)
+				},
+			})
+			cli := clientBuilder.Build()
 			r := NewClusterTrainingRuntimeReconciler(cli, nil)
 			clRuntimeKey := client.ObjectKeyFromObject(tc.clTrainingRuntime)
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: clRuntimeKey})
@@ -76,6 +85,9 @@ func TestReconcile_ClusterTrainingRuntimeReconciler(t *testing.T) {
 				cmpopts.IgnoreFields(metav1.TypeMeta{}, "Kind", "APIVersion"),
 			); len(diff) != 0 {
 				t.Errorf("Unexpected ClusterTrainingRuntime: (-want, +got): \n%s", diff)
+			}
+			if tc.wantRuntimeLogValue != "" && !strings.Contains(logBuffer.String(), tc.wantRuntimeLogValue) {
+				t.Errorf("Patch context log = %q, want it to contain %q", logBuffer.String(), tc.wantRuntimeLogValue)
 			}
 		})
 	}

--- a/pkg/controller/trainingruntime_controller.go
+++ b/pkg/controller/trainingruntime_controller.go
@@ -60,7 +60,7 @@ func (r *TrainingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	log := ctrl.LoggerFrom(ctx).WithValues("trainingRuntime", klog.KObj(&runtime))
-	ctrl.LoggerInto(ctx, log)
+	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(2).Info("Reconciling TrainingRuntime")
 
 	prevRuntime := runtime.DeepCopy()

--- a/pkg/controller/trainingruntime_controller_test.go
+++ b/pkg/controller/trainingruntime_controller_test.go
@@ -18,13 +18,16 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/go-logr/logr/funcr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2/ktesting"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
@@ -36,6 +39,7 @@ func TestReconcile_TrainingRuntimeReconciler(t *testing.T) {
 	cases := map[string]struct {
 		trainingRuntime     *trainer.TrainingRuntime
 		wantTrainingRuntime *trainer.TrainingRuntime
+		wantRuntimeLogValue string
 	}{
 		"remove existing finalizer during reconciliation": {
 			trainingRuntime: utiltesting.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "runtime").
@@ -45,6 +49,7 @@ func TestReconcile_TrainingRuntimeReconciler(t *testing.T) {
 				metav1.NamespaceDefault,
 				"runtime",
 			).Obj(),
+			wantRuntimeLogValue: `"trainingRuntime"={"name"="runtime" "namespace"="default"}`,
 		},
 		"no action when runtime has no finalizer": {
 			trainingRuntime: utiltesting.MakeTrainingRuntimeWrapper(
@@ -60,13 +65,17 @@ func TestReconcile_TrainingRuntimeReconciler(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
-			var cancel func()
-			ctx, cancel = context.WithCancel(ctx)
-			t.Cleanup(cancel)
-			cli := utiltesting.NewClientBuilder().
-				WithObjects(tc.trainingRuntime).
-				Build()
+			var logBuffer strings.Builder
+			logger := funcr.New(func(_, args string) { logBuffer.WriteString(args) }, funcr.Options{})
+			ctx := ctrl.LoggerInto(context.Background(), logger)
+			clientBuilder := utiltesting.NewClientBuilder().WithObjects(tc.trainingRuntime)
+			clientBuilder.WithInterceptorFuncs(interceptor.Funcs{
+				Patch: func(ctx context.Context, cli client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					ctrl.LoggerFrom(ctx).Info("Patching TrainingRuntime")
+					return cli.Patch(ctx, obj, patch, opts...)
+				},
+			})
+			cli := clientBuilder.Build()
 			r := NewTrainingRuntimeReconciler(cli, nil)
 			runtimeKey := client.ObjectKeyFromObject(tc.trainingRuntime)
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: runtimeKey})
@@ -82,6 +91,9 @@ func TestReconcile_TrainingRuntimeReconciler(t *testing.T) {
 				cmpopts.IgnoreFields(metav1.TypeMeta{}, "Kind", "APIVersion"),
 			); len(diff) != 0 {
 				t.Errorf("Unexpected TrainingRuntime: (-want, +got): \n%s", diff)
+			}
+			if tc.wantRuntimeLogValue != "" && !strings.Contains(logBuffer.String(), tc.wantRuntimeLogValue) {
+				t.Errorf("Patch context log = %q, want it to contain %q", logBuffer.String(), tc.wantRuntimeLogValue)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- retain the enriched logger context in both runtime reconcilers
- derive the cluster runtime logger from the incoming reconcile context
- verify object-scoped logger values reach downstream client patches

Fixes #3991

## Testing

- `go test ./pkg/controller -run TestReconcile_ -count=1`
- `go test ./pkg/controller/... -count=1`
- `go vet ./pkg/controller/...`
- `make test`
- `./bin/golangci-lint run --timeout 5m pkg/controller/trainingruntime_controller.go pkg/controller/trainingruntime_controller_test.go pkg/controller/clustertrainingruntime_controller.go pkg/controller/clustertrainingruntime_controller_test.go`

Package-wide targeted lint also reports pre-existing `gci` findings in unchanged `pkg/controller/setup.go` and `pkg/controller/trainjob_controller.go`.

## Checklist

- [ ] [Docs](https://trainer.kubeflow.org/docs/) included if any changes are user facing

AI assistance disclosure: OpenAI Codex assisted with repository inspection, implementation, tests, and drafting; I reviewed and verified the changes.