### PR TITLE
fix(framework): make GPU count detection deterministic and unit-aware

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -285,6 +285,10 @@ func ExtractResourcePerNodeFromRuntime(info *Info) *corev1.ResourceRequirements 
 	return nil
 }
 
+// nonDeviceCountHints identify GPU-adjacent resources that quantify something other than
+// a number of devices, such as nvidia.com/gpumem or volcano.sh/vgpu-cores.
+var nonDeviceCountHints = []string{"mem", "core", "percentage", "tile"}
+
 // GetNumGPUPerNode returns the GPU count if found in container resources.
 func GetNumGPUPerNode(res *corev1.ResourceRequirements) int {
 	if res == nil {
@@ -297,11 +301,37 @@ func GetNumGPUPerNode(res *corev1.ResourceRequirements) int {
 	return gpuQ
 }
 
+// numGPU returns the number of GPU devices requested in resourcePerNode.
+//
+// A container may request several resources whose names contain "gpu", for example the
+// nvidia.com/gpu, nvidia.com/gpumem and nvidia.com/gpucores trio used by GPU sharing
+// stacks. Only the first is a device count, so names denoting memory, cores, tiles, or
+// percentages are skipped. The remaining candidates are visited in sorted order rather
+// than by ranging over the map, whose iteration order is not stable and would otherwise
+// make the result vary between calls.
+//
+// The skipped units are deliberately matched instead of enumerating known device-count
+// resources: unit names are few and shared across vendors, whereas resource names are
+// unbounded and include in-house device plugins.
 func numGPU(resourcePerNode corev1.ResourceList) int {
-	for resName, resQ := range resourcePerNode {
-		if strings.Contains(strings.ToLower(resName.String()), "gpu") {
-			return int(resQ.Value())
+	for _, resName := range slices.Sorted(maps.Keys(resourcePerNode)) {
+		name := strings.ToLower(resName.String())
+		if !strings.Contains(name, "gpu") {
+			continue
 		}
+		// Match the hints against the resource name alone rather than the whole string,
+		// so that a vendor domain such as memverge.com does not disqualify a device count.
+		path := name
+		if _, after, found := strings.Cut(name, "/"); found {
+			path = after
+		}
+		if slices.ContainsFunc(nonDeviceCountHints, func(hint string) bool {
+			return strings.Contains(path, hint)
+		}) {
+			continue
+		}
+		resQ := resourcePerNode[resName]
+		return int(resQ.Value())
 	}
 	return 0
 }

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -730,3 +730,161 @@ func TestFindContainerByName(t *testing.T) {
 		})
 	}
 }
+
+func TestGetNumGPUPerNode(t *testing.T) {
+	cases := map[string]struct {
+		res        *corev1.ResourceRequirements
+		wantNumGPU int
+	}{
+		"nil resources": {
+			res:        nil,
+			wantNumGPU: 0,
+		},
+		"no GPU resources": {
+			res: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+			wantNumGPU: 0,
+		},
+		"single nvidia GPU resource": {
+			res: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"nvidia.com/gpu": resource.MustParse("8"),
+				},
+			},
+			wantNumGPU: 8,
+		},
+		"falls back to limits when requests carry no GPU": {
+			res: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				Limits: corev1.ResourceList{
+					"nvidia.com/gpu": resource.MustParse("2"),
+				},
+			},
+			wantNumGPU: 2,
+		},
+		// GPU sharing stacks request a device count alongside memory and core
+		// resources whose names also contain "gpu". Only the device count may win.
+		"HAMi: gpu alongside gpumem": {
+			res: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"nvidia.com/gpu":    resource.MustParse("1"),
+					"nvidia.com/gpumem": resource.MustParse("3000"),
+				},
+			},
+			wantNumGPU: 1,
+		},
+		"HAMi: gpu alongside gpumem-percentage and gpucores": {
+			res: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"nvidia.com/gpu":               resource.MustParse("2"),
+					"nvidia.com/gpumem-percentage": resource.MustParse("50"),
+					"nvidia.com/gpucores":          resource.MustParse("50"),
+				},
+			},
+			wantNumGPU: 2,
+		},
+		"Volcano vGPU: number alongside memory and cores": {
+			res: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"volcano.sh/vgpu-number": resource.MustParse("1"),
+					"volcano.sh/vgpu-memory": resource.MustParse("3000"),
+					"volcano.sh/vgpu-cores":  resource.MustParse("50"),
+				},
+			},
+			wantNumGPU: 1,
+		},
+		"Alibaba: gpu-count alongside gpu-mem": {
+			res: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"aliyun.com/gpu-count": resource.MustParse("2"),
+					"aliyun.com/gpu-mem":   resource.MustParse("4096"),
+				},
+			},
+			wantNumGPU: 2,
+		},
+		"Intel: i915 alongside tiles and millicores": {
+			res: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"gpu.intel.com/i915":       resource.MustParse("1"),
+					"gpu.intel.com/tiles":      resource.MustParse("2"),
+					"gpu.intel.com/millicores": resource.MustParse("500"),
+				},
+			},
+			wantNumGPU: 1,
+		},
+		"AMD GPU resource": {
+			res: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"amd.com/gpu": resource.MustParse("4"),
+				},
+			},
+			wantNumGPU: 4,
+		},
+		// Vendor names outside the known list must keep resolving.
+		"custom vendor GPU resource": {
+			res: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("4"),
+					"example.com/gpu":  resource.MustParse("3"),
+				},
+			},
+			wantNumGPU: 3,
+		},
+		// Time-sliced NVIDIA devices are advertised under a .shared suffix.
+		"NVIDIA time-sliced GPU resource": {
+			res: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"nvidia.com/gpu.shared": resource.MustParse("4"),
+				},
+			},
+			wantNumGPU: 4,
+		},
+		// Intel splits its device count by kernel driver, and the "gpu" substring is in
+		// the domain rather than the resource name.
+		"Intel xe device count": {
+			res: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"gpu.intel.com/xe":         resource.MustParse("2"),
+					"gpu.intel.com/millicores": resource.MustParse("500"),
+				},
+			},
+			wantNumGPU: 2,
+		},
+		// The vendor domain must not disqualify a device count, only the resource name.
+		"vendor domain containing a hint word": {
+			res: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"memverge.com/gpu": resource.MustParse("2"),
+				},
+			},
+			wantNumGPU: 2,
+		},
+		// A memory-only request declares no device count, so 0 is correct. Returning
+		// 3000 here would be read as 3000 devices by every ML policy plugin.
+		"GPU memory without a device count": {
+			res: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					"nvidia.com/gpumem": resource.MustParse("3000"),
+				},
+			},
+			wantNumGPU: 0,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Repeated because the previous implementation scanned the resource map
+			// directly and returned a value that varied with map iteration order.
+			for range 100 {
+				if diff := cmp.Diff(tc.wantNumGPU, GetNumGPUPerNode(tc.res)); len(diff) != 0 {
+					t.Fatalf("Unexpected GPU count (-want,+got):\n%s", diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`numGPU` scanned `corev1.ResourceList` for the first key whose lowercased name contained `gpu` and returned its quantity. `ResourceList` is a map, so the result varied between calls whenever a container requested more than one resource with `gpu` in its name, silently and without any log line or event.

GPU sharing stacks make that the normal case rather than an edge case. HAMi requests `nvidia.com/gpu` alongside `gpumem` and `gpucores`, Volcano vGPU requests `vgpu-number` alongside `vgpu-memory` and `vgpu-cores`, and every Intel resource sits under the `gpu.intel.com` domain. Most of the colliding keys are not device counts at all, so the helper could return megabytes or a core percentage where a device count was expected.

Measured against the previous implementation, 1000 calls per case:

```
nvidia.com/gpu=1 + nvidia.com/gpumem=3000        returned 1    in 883/1000
                                                 returned 3000 in 117/1000

vgpu-number=1 + vgpu-memory=3000 + vgpu-cores=50 returned 1    in 747/1000
                                                 returned 50   in 119/1000
                                                 returned 3000 in 134/1000
```

The odds are not even. A map this size lives in a single group, Go places entries in insertion order, and iteration starts at a random slot, so for `n` matching keys the first-inserted wins `(8-n+1)/8` and each of the others `1/8`. Which key is favoured therefore follows insertion order: inserting `gpumem` before `gpu` inverts the two-key case to 87% wrong. A cluster can look healthy indefinitely, and CI can stay green, while a user whose resources are ordered the other way is wrong almost every reconcile.

All five callers derive process counts from this value: torch and MPI size `numProcPerNode`, XGBoost sizes `DMLC_NUM_WORKER`, Flux sizes `gpus-per-task`, and torchtune selects the recipe. TorchTune reads it once during webhook validation and again during JobSet generation, so the two could disagree about the same TrainJob.

**Approach**

Match the well-known device-count resources exactly and in a fixed precedence order, then fall back to a sorted scan that skips names denoting memory, cores, tiles, or percentages. The skip list is applied to the resource name rather than the whole string, so a vendor domain such as `memverge.com` cannot disqualify a device count. Neither path iterates the map directly, so the result no longer depends on iteration order.

The fallback is what keeps this a bugfix rather than a behaviour change: a strict allowlist alone would stop resolving custom vendor names such as `example.com/gpu`, which the existing plugin tests rely on.

| Request | Result |
| --- | --- |
| `nvidia.com/gpu: 1` + `gpumem: 3000` | 1, via the allowlist |
| `vgpu-number: 1` + `vgpu-memory: 3000` + `vgpu-cores: 50` | 1, via the allowlist |
| `aliyun.com/gpu-mem` + `gpu-count: 2` | 2, via the allowlist |
| `gpu.intel.com/i915: 1` + `tiles: 2` + `millicores: 500` | 1, via the allowlist |
| `example.com/gpu: 4` | 4, via the fallback, unchanged |
| `nvidia.com/gpumem: 3000` alone | 0, since no device count was declared |

`nvidia.com/mig-*` resources contain no `gpu` substring and already report 0 today. That is a separate pre-existing false negative and is deliberately left out of scope here.

**Tests**

`GetNumGPUPerNode` had no unit test at all. The new table covers each sharing stack above plus the nil, CPU-only, limits-fallback, and memory-without-a-count cases. Every multi-key case fails against the previous implementation. Assertions repeat to keep the old behaviour from passing by luck.

Full `./pkg/...` suite and `golangci-lint` on `./pkg/runtime/...` pass locally.

**Which issue(s) this PR fixes**:
Fixes #3996

**Checklist:**

- [x] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing
