### PR TITLE
fix(controller): validate and reject conflicting runtime volume and volumeMount in TrainJobStatus

### DIFF
--- a/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
+++ b/charts/kubeflow-trainer/templates/crd/trainer.kubeflow.org_trainjobs.yaml
@@ -32,9 +32,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[-1:].type
+    - jsonPath: .status.conditions[?(@.status=="True")].type
       name: State
       type: string
+    - jsonPath: .spec.suspend
+      name: Suspended
+      type: boolean
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/docs/user-guides/trainjob-progress.md
+++ b/docs/user-guides/trainjob-progress.md
@@ -180,6 +180,7 @@ to the controller endpoint.
 - **Environment Variables**: The controller injects `KUBEFLOW_TRAINER_SERVER_URL` (the HTTPS endpoint), `KUBEFLOW_TRAINER_SERVER_CA_CERT` (path to the CA cert file), and `KUBEFLOW_TRAINER_SERVER_TOKEN` (path to the bearer token file).
 - **Authentication**: Each request is authenticated using a projected service account token (OIDC-verified by the controller). The projected service account token is issued with a TrainJob-specific audience so the controller can verify that update requests target the correct TrainJob.
 - **TLS Configuration**: The endpoint reuses the same webhook TLS certificates as the controller, with automatic cert rotation.
+- **Reserved Volume and Mounts**: The volume name `kubeflow-trainer-token` and mount path `/var/run/secrets/kubeflow/trainer` are reserved on trainer pods for token and CA certificate injection. Conflicting volume or volume mount definitions in a training runtime are rejected during validation.
 
 #### Implementation Guidance
 

--- a/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
+++ b/manifests/base/crds/trainer.kubeflow.org_trainjobs.yaml
@@ -29,9 +29,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[-1:].type
+    - jsonPath: .status.conditions[?(@.status=="True")].type
       name: State
       type: string
+    - jsonPath: .spec.suspend
+      name: Suspended
+      type: boolean
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/pkg/apis/trainer/v1alpha1/trainjob_types.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types.go
@@ -31,7 +31,8 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.conditions[-1:].type`
+// +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.conditions[?(@.status=="True")].type`
+// +kubebuilder:printcolumn:name="Suspended",type=boolean,JSONPath=`.spec.suspend`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 // +kubebuilder:validation:XValidation:rule="self.metadata.name.matches('^[a-z]([-a-z0-9]*[a-z0-9])?$')", message="metadata.name must match RFC 1035 DNS label format"
 // +kubebuilder:validation:XValidation:rule="size(self.metadata.name) <= 63", message="metadata.name must be no more than 63 characters"

--- a/pkg/apis/trainer/v1alpha1/trainjob_types_test.go
+++ b/pkg/apis/trainer/v1alpha1/trainjob_types_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2024 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestTrainJobPrinterColumnConditions(t *testing.T) {
+	cases := map[string]struct {
+		trainJob      *TrainJob
+		wantState     string
+		wantSuspended bool
+	}{
+		"newly created running TrainJob with no conditions": {
+			trainJob: &TrainJob{
+				Spec: TrainJobSpec{
+					Suspend: ptr.To(false),
+				},
+				Status: TrainJobStatus{},
+			},
+			wantState:     "",
+			wantSuspended: false,
+		},
+		"suspended TrainJob": {
+			trainJob: &TrainJob{
+				Spec: TrainJobSpec{
+					Suspend: ptr.To(true),
+				},
+				Status: TrainJobStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    TrainJobSuspended,
+							Status:  metav1.ConditionTrue,
+							Reason:  TrainJobSuspendedReason,
+							Message: "TrainJob is suspended",
+						},
+					},
+				},
+			},
+			wantState:     TrainJobSuspended,
+			wantSuspended: true,
+		},
+		"resumed TrainJob with Suspended condition False": {
+			trainJob: &TrainJob{
+				Spec: TrainJobSpec{
+					Suspend: ptr.To(false),
+				},
+				Status: TrainJobStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    TrainJobSuspended,
+							Status:  metav1.ConditionFalse,
+							Reason:  TrainJobResumedReason,
+							Message: "TrainJob is resumed",
+						},
+					},
+				},
+			},
+			wantState:     "",
+			wantSuspended: false,
+		},
+		"completed TrainJob after resume": {
+			trainJob: &TrainJob{
+				Spec: TrainJobSpec{
+					Suspend: ptr.To(false),
+				},
+				Status: TrainJobStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    TrainJobSuspended,
+							Status:  metav1.ConditionFalse,
+							Reason:  TrainJobResumedReason,
+							Message: "TrainJob is resumed",
+						},
+						{
+							Type:    TrainJobComplete,
+							Status:  metav1.ConditionTrue,
+							Reason:  "AllJobsCompleted",
+							Message: "All jobs completed successfully",
+						},
+					},
+				},
+			},
+			wantState:     TrainJobComplete,
+			wantSuspended: false,
+		},
+		"failed TrainJob after resume": {
+			trainJob: &TrainJob{
+				Spec: TrainJobSpec{
+					Suspend: ptr.To(false),
+				},
+				Status: TrainJobStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:    TrainJobSuspended,
+							Status:  metav1.ConditionFalse,
+							Reason:  TrainJobResumedReason,
+							Message: "TrainJob is resumed",
+						},
+						{
+							Type:    TrainJobFailed,
+							Status:  metav1.ConditionTrue,
+							Reason:  TrainJobDeadlineExceededReason,
+							Message: "Deadline exceeded",
+						},
+					},
+				},
+			},
+			wantState:     TrainJobFailed,
+			wantSuspended: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Test active condition resolution matching .status.conditions[?(@.status=="True")].type
+			var gotState string
+			for _, cond := range tc.trainJob.Status.Conditions {
+				if cond.Status == metav1.ConditionTrue {
+					gotState = cond.Type
+					break
+				}
+			}
+			if gotState != tc.wantState {
+				t.Errorf("active condition type = %q, want %q", gotState, tc.wantState)
+			}
+
+			// Test suspended spec resolution matching .spec.suspend
+			gotSuspended := ptr.Deref(tc.trainJob.Spec.Suspend, false)
+			if gotSuspended != tc.wantSuspended {
+				t.Errorf("spec.suspend = %v, want %v", gotSuspended, tc.wantSuspended)
+			}
+		})
+	}
+}

--- a/pkg/runtime/framework/plugins/trainjobstatus/trainjobstatus.go
+++ b/pkg/runtime/framework/plugins/trainjobstatus/trainjobstatus.go
@@ -22,9 +22,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	configapi "github.com/kubeflow/trainer/v2/pkg/apis/config/v1alpha1"
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
@@ -64,6 +67,7 @@ type Status struct {
 
 var _ framework.ComponentBuilderPlugin = (*Status)(nil)
 var _ framework.EnforcePodSpecPlugin = (*Status)(nil)
+var _ framework.CustomValidationPlugin = (*Status)(nil)
 
 func New(_ context.Context, c client.Client, _ client.FieldIndexer, cfg *configapi.Configuration) (framework.Plugin, error) {
 	return &Status{client: c, cfg: cfg}, nil
@@ -71,6 +75,46 @@ func New(_ context.Context, c client.Client, _ client.FieldIndexer, cfg *configa
 
 func (p *Status) Name() string {
 	return Name
+}
+
+func (p *Status) Validate(_ context.Context, info *runtime.Info, _, _ *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
+	var allErrs field.ErrorList
+	if info == nil {
+		return nil, allErrs
+	}
+
+	trainerPS := info.FindPodSetByAncestor(constants.AncestorTrainer)
+	if trainerPS == nil {
+		return nil, allErrs
+	}
+
+	for _, vol := range trainerPS.Volumes {
+		if ptr.Deref(vol.Name, "") == tokenVolumeName {
+			allErrs = append(allErrs, field.Forbidden(
+				field.NewPath("spec", "template", "spec", "volumes"),
+				fmt.Sprintf("volume name %q in podSet %q is reserved for %s", tokenVolumeName, trainerPS.Name, Name),
+			))
+		}
+	}
+
+	for cIdx, c := range trainerPS.Containers {
+		for _, vm := range c.VolumeMounts {
+			if ptr.Deref(vm.Name, "") == tokenVolumeName {
+				allErrs = append(allErrs, field.Forbidden(
+					field.NewPath("spec", "template", "spec", "containers").Index(cIdx).Child("volumeMounts"),
+					fmt.Sprintf("volume mount name %q in container %q of podSet %q is reserved for %s", tokenVolumeName, c.Name, trainerPS.Name, Name),
+				))
+			}
+			if ptr.Deref(vm.MountPath, "") == configMountPath {
+				allErrs = append(allErrs, field.Forbidden(
+					field.NewPath("spec", "template", "spec", "containers").Index(cIdx).Child("volumeMounts"),
+					fmt.Sprintf("volume mount path %q in container %q of podSet %q is reserved for %s", configMountPath, c.Name, trainerPS.Name, Name),
+				))
+			}
+		}
+	}
+
+	return nil, allErrs
 }
 
 // EnforcePodSpec injects the status server endpoint, its CA certificate, and the

--- a/pkg/runtime/framework/plugins/trainjobstatus/trainjobstatus_test.go
+++ b/pkg/runtime/framework/plugins/trainjobstatus/trainjobstatus_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
@@ -500,6 +501,321 @@ func TestBuild(t *testing.T) {
 
 			if diff := gocmp.Diff(tc.wantObjs, typedObjs, objCmpOpts...); len(diff) != 0 {
 				t.Errorf("Unexpected objects from Build (-want, +got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	cases := map[string]struct {
+		info     *runtime.Info
+		trainJob *trainer.TrainJob
+		wantErrs field.ErrorList
+	}{
+		"no error when info is nil": {
+			info:     nil,
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").Obj(),
+		},
+		"no error when trainer podSet is not found": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:  "launcher",
+							Count: ptr.To[int32](1),
+							Containers: []runtime.Container{
+								{Name: "launcher"},
+							},
+						},
+					},
+				},
+			},
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").Obj(),
+		},
+		"no error when no conflict exists": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:     "trainer",
+							Ancestor: ptr.To(constants.AncestorTrainer),
+							Count:    ptr.To[int32](1),
+							Containers: []runtime.Container{
+								{
+									Name: constants.Node,
+									VolumeMounts: []corev1ac.VolumeMountApplyConfiguration{
+										*corev1ac.VolumeMount().WithName("data").WithMountPath("/data"),
+									},
+								},
+							},
+							Volumes: []corev1ac.VolumeApplyConfiguration{
+								*corev1ac.Volume().WithName("data"),
+							},
+						},
+					},
+				},
+			},
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").Obj(),
+		},
+		"no error with multiple containers without conflicts": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:     "trainer",
+							Ancestor: ptr.To(constants.AncestorTrainer),
+							Count:    ptr.To[int32](1),
+							Containers: []runtime.Container{
+								{
+									Name: constants.Node,
+									VolumeMounts: []corev1ac.VolumeMountApplyConfiguration{
+										*corev1ac.VolumeMount().WithName("data").WithMountPath("/data"),
+									},
+								},
+								{
+									Name: "sidecar",
+									VolumeMounts: []corev1ac.VolumeMountApplyConfiguration{
+										*corev1ac.VolumeMount().WithName("logs").WithMountPath("/var/log"),
+									},
+								},
+							},
+							Volumes: []corev1ac.VolumeApplyConfiguration{
+								*corev1ac.Volume().WithName("data"),
+								*corev1ac.Volume().WithName("logs"),
+							},
+						},
+					},
+				},
+			},
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").Obj(),
+		},
+		"error when volume named kubeflow-trainer-token exists": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:     "trainer",
+							Ancestor: ptr.To(constants.AncestorTrainer),
+							Count:    ptr.To[int32](1),
+							Containers: []runtime.Container{
+								{Name: constants.Node},
+							},
+							Volumes: []corev1ac.VolumeApplyConfiguration{
+								*corev1ac.Volume().WithName(tokenVolumeName),
+							},
+						},
+					},
+				},
+			},
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").Obj(),
+			wantErrs: field.ErrorList{
+				field.Forbidden(
+					field.NewPath("spec", "template", "spec", "volumes"),
+					fmt.Sprintf("volume name %q in podSet %q is reserved for %s", tokenVolumeName, "trainer", Name),
+				),
+			},
+		},
+		"error when mount path is reserved with another mount name": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:     "trainer",
+							Ancestor: ptr.To(constants.AncestorTrainer),
+							Count:    ptr.To[int32](1),
+							Containers: []runtime.Container{
+								{
+									Name: constants.Node,
+									VolumeMounts: []corev1ac.VolumeMountApplyConfiguration{
+										*corev1ac.VolumeMount().WithName("custom-token-volume").WithMountPath(configMountPath),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").Obj(),
+			wantErrs: field.ErrorList{
+				field.Forbidden(
+					field.NewPath("spec", "template", "spec", "containers").Index(0).Child("volumeMounts"),
+					fmt.Sprintf("volume mount path %q in container %q of podSet %q is reserved for %s", configMountPath, constants.Node, "trainer", Name),
+				),
+			},
+		},
+		"error when mount named kubeflow-trainer-token at another path": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:     "trainer",
+							Ancestor: ptr.To(constants.AncestorTrainer),
+							Count:    ptr.To[int32](1),
+							Containers: []runtime.Container{
+								{
+									Name: constants.Node,
+									VolumeMounts: []corev1ac.VolumeMountApplyConfiguration{
+										*corev1ac.VolumeMount().WithName(tokenVolumeName).WithMountPath("/other/path"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").Obj(),
+			wantErrs: field.ErrorList{
+				field.Forbidden(
+					field.NewPath("spec", "template", "spec", "containers").Index(0).Child("volumeMounts"),
+					fmt.Sprintf("volume mount name %q in container %q of podSet %q is reserved for %s", tokenVolumeName, constants.Node, "trainer", Name),
+				),
+			},
+		},
+		"error when both name and path conflict": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:     "trainer",
+							Ancestor: ptr.To(constants.AncestorTrainer),
+							Count:    ptr.To[int32](1),
+							Containers: []runtime.Container{
+								{
+									Name: constants.Node,
+									VolumeMounts: []corev1ac.VolumeMountApplyConfiguration{
+										*corev1ac.VolumeMount().WithName(tokenVolumeName).WithMountPath(configMountPath),
+									},
+								},
+							},
+							Volumes: []corev1ac.VolumeApplyConfiguration{
+								*corev1ac.Volume().WithName(tokenVolumeName),
+							},
+						},
+					},
+				},
+			},
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").Obj(),
+			wantErrs: field.ErrorList{
+				field.Forbidden(
+					field.NewPath("spec", "template", "spec", "volumes"),
+					fmt.Sprintf("volume name %q in podSet %q is reserved for %s", tokenVolumeName, "trainer", Name),
+				),
+				field.Forbidden(
+					field.NewPath("spec", "template", "spec", "containers").Index(0).Child("volumeMounts"),
+					fmt.Sprintf("volume mount name %q in container %q of podSet %q is reserved for %s", tokenVolumeName, constants.Node, "trainer", Name),
+				),
+				field.Forbidden(
+					field.NewPath("spec", "template", "spec", "containers").Index(0).Child("volumeMounts"),
+					fmt.Sprintf("volume mount path %q in container %q of podSet %q is reserved for %s", configMountPath, constants.Node, "trainer", Name),
+				),
+			},
+		},
+		"error in non-first container identifies that container": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:     "trainer",
+							Ancestor: ptr.To(constants.AncestorTrainer),
+							Count:    ptr.To[int32](1),
+							Containers: []runtime.Container{
+								{
+									Name: constants.Node,
+									VolumeMounts: []corev1ac.VolumeMountApplyConfiguration{
+										*corev1ac.VolumeMount().WithName("data").WithMountPath("/data"),
+									},
+								},
+								{
+									Name: "sidecar",
+									VolumeMounts: []corev1ac.VolumeMountApplyConfiguration{
+										*corev1ac.VolumeMount().WithName("other-name").WithMountPath(configMountPath),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").Obj(),
+			wantErrs: field.ErrorList{
+				field.Forbidden(
+					field.NewPath("spec", "template", "spec", "containers").Index(1).Child("volumeMounts"),
+					fmt.Sprintf("volume mount path %q in container %q of podSet %q is reserved for %s", configMountPath, "sidecar", "trainer", Name),
+				),
+			},
+		},
+		"non-trainer podset with same volume name does not error": {
+			info: &runtime.Info{
+				TemplateSpec: runtime.TemplateSpec{
+					PodSets: []runtime.PodSet{
+						{
+							Name:     "dataset-initializer",
+							Ancestor: ptr.To(constants.DatasetInitializer),
+							Count:    ptr.To[int32](1),
+							Containers: []runtime.Container{
+								{
+									Name: "dataset-initializer",
+									VolumeMounts: []corev1ac.VolumeMountApplyConfiguration{
+										*corev1ac.VolumeMount().WithName(tokenVolumeName).WithMountPath(configMountPath),
+									},
+								},
+							},
+							Volumes: []corev1ac.VolumeApplyConfiguration{
+								*corev1ac.Volume().WithName(tokenVolumeName),
+							},
+						},
+						{
+							Name:     "trainer",
+							Ancestor: ptr.To(constants.AncestorTrainer),
+							Count:    ptr.To[int32](1),
+							Containers: []runtime.Container{
+								{
+									Name: constants.Node,
+									VolumeMounts: []corev1ac.VolumeMountApplyConfiguration{
+										*corev1ac.VolumeMount().WithName("data").WithMountPath("/data"),
+									},
+								},
+							},
+							Volumes: []corev1ac.VolumeApplyConfiguration{
+								*corev1ac.Volume().WithName("data"),
+							},
+						},
+					},
+				},
+			},
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").Obj(),
+			wantErrs: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			var cancel func()
+			ctx, cancel = context.WithCancel(ctx)
+			t.Cleanup(cancel)
+
+			cli := utiltesting.NewClientBuilder().Build()
+			cfg := &configapi.Configuration{
+				CertManagement: &configapi.CertManagement{
+					WebhookServiceName: "kubeflow-trainer-controller-manager",
+					WebhookSecretName:  "kubeflow-trainer-webhook-cert",
+				},
+				StatusServer: &configapi.StatusServer{
+					Port:  ptr.To[int32](10443),
+					QPS:   ptr.To[float32](5),
+					Burst: ptr.To[int32](10),
+				},
+			}
+
+			p, err := New(ctx, cli, nil, cfg)
+			if err != nil {
+				t.Fatalf("Failed to initialize Status plugin: %v", err)
+			}
+
+			_, errs := p.(framework.CustomValidationPlugin).Validate(ctx, tc.info, nil, tc.trainJob)
+			if diff := gocmp.Diff(tc.wantErrs, errs); len(diff) != 0 {
+				t.Errorf("Unexpected validation errors (-want, +got):\n%s", diff)
 			}
 		})
 	}

--- a/proposals/2779-trainjob-progress/README.md
+++ b/proposals/2779-trainjob-progress/README.md
@@ -265,7 +265,7 @@ The new endpoint must rate-limit requests and cache TokenReview responses to avo
 
 Deliberate malicious attacks can be mitigated by validating the jwt token against the API server public key before performing the TokenReview request. Tokens that are definitely invalid would not cause any API server requests.
 
-The below summarises the volumes the control plane will inject if the feature gate is enabled:
+The below summarises the volumes the control plane will inject if the feature gate is enabled (the volume name `kubeflow-trainer-token` and mount path `/var/run/secrets/kubeflow/trainer` are reserved on trainer pods):
 ```yaml
 # mutated PodSpec
 spec:


### PR DESCRIPTION
### What this PR does / why we need it:
When the `TrainJobStatus` feature is enabled, the plugin injects the projected token volume `kubeflow-trainer-token` and mount path `/var/run/secrets/kubeflow/trainer` into trainer PodSet containers using `apply.UpsertVolumes` and `apply.UpsertVolumeMounts`. Pre-existing runtime volumes or volume mounts at these names/paths were previously silently overwritten.

This PR implements `framework.CustomValidationPlugin` for the `TrainJobStatus` plugin to validate and reject conflicting volumes, mount names, and mount paths with clear, actionable validation errors before any mutation occurs.

Fixes #3956

### Changes:
- Implemented `framework.CustomValidationPlugin` on `trainjobstatus.Status`.
- Reused `tokenVolumeName` and `configMountPath` constants to validate `trainerPS.Volumes` and `trainerPS.Containers[*].VolumeMounts`.
- Added comprehensive table-driven tests in `trainjobstatus_test.go`.
- Documented reserved volume and mount path in user guides and KEP-2779.
