### PR TITLE
fix(controller): scope RuntimeClass handler lookups by namespace

### DIFF
--- a/pkg/runtime/framework/plugins/coscheduling/coscheduling.go
+++ b/pkg/runtime/framework/plugins/coscheduling/coscheduling.go
@@ -18,7 +18,6 @@ package coscheduling
 
 import (
 	"context"
-	"slices"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -184,7 +183,10 @@ func (h *PodGroupRuntimeClassHandler) queueSuspendedTrainJobs(ctx context.Contex
 	var trainJobs []trainer.TrainJob
 	for _, trainingRuntime := range trainingRuntimes.Items {
 		var trainJobsWithTrainingRuntime trainer.TrainJobList
-		err := h.client.List(ctx, &trainJobsWithTrainingRuntime, client.MatchingFields{indexer.TrainJobRuntimeRefKey: trainingRuntime.Name})
+		err := h.client.List(ctx, &trainJobsWithTrainingRuntime,
+			client.InNamespace(trainingRuntime.Namespace),
+			client.MatchingFields{indexer.TrainJobRuntimeRefKey: trainingRuntime.Name},
+		)
 		if err != nil {
 			return err
 		}
@@ -198,13 +200,17 @@ func (h *PodGroupRuntimeClassHandler) queueSuspendedTrainJobs(ctx context.Contex
 		}
 		trainJobs = append(trainJobs, trainJobsWithClTrainingRuntime.Items...)
 	}
-	trainJobs = slices.CompactFunc(trainJobs, func(a, b trainer.TrainJob) bool {
-		return a.Name == b.Name
-	})
+	queuedTrainJobs := make(map[client.ObjectKey]struct{}, len(trainJobs))
 	for _, trainJob := range trainJobs {
-		if ptr.Deref(trainJob.Spec.Suspend, false) {
-			q.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&trainJob)})
+		if !ptr.Deref(trainJob.Spec.Suspend, false) {
+			continue
 		}
+		key := client.ObjectKeyFromObject(&trainJob)
+		if _, queued := queuedTrainJobs[key]; queued {
+			continue
+		}
+		q.Add(reconcile.Request{NamespacedName: key})
+		queuedTrainJobs[key] = struct{}{}
 	}
 	return nil
 }

--- a/pkg/runtime/framework/plugins/coscheduling/runtimeclass_handler_test.go
+++ b/pkg/runtime/framework/plugins/coscheduling/runtimeclass_handler_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coscheduling
+
+import (
+	"context"
+	"testing"
+
+	nodev1 "k8s.io/api/node/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	"github.com/kubeflow/trainer/v2/pkg/runtime/indexer"
+	utiltesting "github.com/kubeflow/trainer/v2/pkg/util/testing"
+)
+
+func TestPodGroupRuntimeClassHandlerScopesNamespacedTrainingRuntime(t *testing.T) {
+	cases := map[string]struct {
+		jobAName           string
+		jobBName           string
+		runtimeClass       string
+		wantNamespacedName client.ObjectKey
+	}{
+		"does not enqueue a TrainJob from another namespace": {
+			jobAName:           "job-a",
+			jobBName:           "job-b",
+			runtimeClass:       "class-a",
+			wantNamespacedName: client.ObjectKey{Namespace: "ns-a", Name: "job-a"},
+		},
+		"distinguishes same-named TrainJobs across namespaces": {
+			jobAName:           "job",
+			jobBName:           "job",
+			runtimeClass:       "class-b",
+			wantNamespacedName: client.ObjectKey{Namespace: "ns-b", Name: "job"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			runtimeA := utiltesting.MakeTrainingRuntimeWrapper("ns-a", "runtime").Obj()
+			runtimeA.Spec.Template.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.RuntimeClassName = new("class-a")
+			runtimeB := utiltesting.MakeTrainingRuntimeWrapper("ns-b", "runtime").Obj()
+			runtimeB.Spec.Template.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.RuntimeClassName = new("class-b")
+			jobA := utiltesting.MakeTrainJobWrapper("ns-a", tc.jobAName).
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "runtime").
+				Suspend(true).
+				Obj()
+			jobB := utiltesting.MakeTrainJobWrapper("ns-b", tc.jobBName).
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "runtime").
+				Suspend(true).
+				Obj()
+
+			builder := utiltesting.NewClientBuilder().WithObjects(runtimeA, runtimeB, jobA, jobB)
+			builder.WithIndex(&trainer.TrainingRuntime{}, indexer.TrainingRuntimeContainerRuntimeClassKey, indexer.IndexTrainingRuntimeContainerRuntimeClass)
+			builder.WithIndex(&trainer.ClusterTrainingRuntime{}, indexer.ClusterTrainingRuntimeContainerRuntimeClassKey, indexer.IndexClusterTrainingRuntimeContainerRuntimeClass)
+			builder.WithIndex(&trainer.TrainJob{}, indexer.TrainJobRuntimeRefKey, indexer.IndexTrainJobTrainingRuntime)
+			builder.WithIndex(&trainer.TrainJob{}, indexer.TrainJobClusterRuntimeRefKey, indexer.IndexTrainJobClusterTrainingRuntime)
+			handler := &PodGroupRuntimeClassHandler{client: builder.Build()}
+			queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+			t.Cleanup(queue.ShutDown)
+
+			if err := handler.queueSuspendedTrainJobs(context.Background(), &nodev1.RuntimeClass{ObjectMeta: metav1.ObjectMeta{Name: tc.runtimeClass}}, queue); err != nil {
+				t.Fatalf("queueSuspendedTrainJobs() error = %v", err)
+			}
+			if got := queue.Len(); got != 1 {
+				t.Fatalf("queued requests = %d, want 1", got)
+			}
+			request, _ := queue.Get()
+			if request.NamespacedName != tc.wantNamespacedName {
+				t.Errorf("queued request = %v, want %v", request.NamespacedName, tc.wantNamespacedName)
+			}
+		})
+	}
+}

--- a/pkg/runtime/framework/plugins/volcano/runtimeclass_handler_test.go
+++ b/pkg/runtime/framework/plugins/volcano/runtimeclass_handler_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volcano
+
+import (
+	"context"
+	"testing"
+
+	nodev1 "k8s.io/api/node/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
+	"github.com/kubeflow/trainer/v2/pkg/runtime/indexer"
+	utiltesting "github.com/kubeflow/trainer/v2/pkg/util/testing"
+)
+
+func TestPodGroupRuntimeClassHandlerScopesNamespacedTrainingRuntime(t *testing.T) {
+	cases := map[string]struct {
+		jobAName           string
+		jobBName           string
+		runtimeClass       string
+		wantNamespacedName client.ObjectKey
+	}{
+		"does not enqueue a TrainJob from another namespace": {
+			jobAName:           "job-a",
+			jobBName:           "job-b",
+			runtimeClass:       "class-a",
+			wantNamespacedName: client.ObjectKey{Namespace: "ns-a", Name: "job-a"},
+		},
+		"distinguishes same-named TrainJobs across namespaces": {
+			jobAName:           "job",
+			jobBName:           "job",
+			runtimeClass:       "class-b",
+			wantNamespacedName: client.ObjectKey{Namespace: "ns-b", Name: "job"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			runtimeA := utiltesting.MakeTrainingRuntimeWrapper("ns-a", "runtime").Obj()
+			runtimeA.Spec.Template.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.RuntimeClassName = new("class-a")
+			runtimeB := utiltesting.MakeTrainingRuntimeWrapper("ns-b", "runtime").Obj()
+			runtimeB.Spec.Template.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.RuntimeClassName = new("class-b")
+			jobA := utiltesting.MakeTrainJobWrapper("ns-a", tc.jobAName).
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "runtime").
+				Suspend(true).
+				Obj()
+			jobB := utiltesting.MakeTrainJobWrapper("ns-b", tc.jobBName).
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "runtime").
+				Suspend(true).
+				Obj()
+
+			builder := utiltesting.NewClientBuilder().WithObjects(runtimeA, runtimeB, jobA, jobB)
+			builder.WithIndex(&trainer.TrainingRuntime{}, indexer.TrainingRuntimeContainerRuntimeClassKey, indexer.IndexTrainingRuntimeContainerRuntimeClass)
+			builder.WithIndex(&trainer.ClusterTrainingRuntime{}, indexer.ClusterTrainingRuntimeContainerRuntimeClassKey, indexer.IndexClusterTrainingRuntimeContainerRuntimeClass)
+			builder.WithIndex(&trainer.TrainJob{}, indexer.TrainJobRuntimeRefKey, indexer.IndexTrainJobTrainingRuntime)
+			builder.WithIndex(&trainer.TrainJob{}, indexer.TrainJobClusterRuntimeRefKey, indexer.IndexTrainJobClusterTrainingRuntime)
+			handler := &PodGroupRuntimeClassHandler{client: builder.Build()}
+			queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+			t.Cleanup(queue.ShutDown)
+
+			if err := handler.queueSuspendedTrainJobs(context.Background(), &nodev1.RuntimeClass{ObjectMeta: metav1.ObjectMeta{Name: tc.runtimeClass}}, queue); err != nil {
+				t.Fatalf("queueSuspendedTrainJobs() error = %v", err)
+			}
+			if got := queue.Len(); got != 1 {
+				t.Fatalf("queued requests = %d, want 1", got)
+			}
+			request, _ := queue.Get()
+			if request.NamespacedName != tc.wantNamespacedName {
+				t.Errorf("queued request = %v, want %v", request.NamespacedName, tc.wantNamespacedName)
+			}
+		})
+	}
+}

--- a/pkg/runtime/framework/plugins/volcano/volcano.go
+++ b/pkg/runtime/framework/plugins/volcano/volcano.go
@@ -19,7 +19,6 @@ package volcano
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -257,7 +256,10 @@ func (h *PodGroupRuntimeClassHandler) queueSuspendedTrainJobs(ctx context.Contex
 	var trainJobs []trainer.TrainJob
 	for _, trainingRuntime := range trainingRuntimes.Items {
 		var trainJobsWithTrainingRuntime trainer.TrainJobList
-		err := h.client.List(ctx, &trainJobsWithTrainingRuntime, client.MatchingFields{indexer.TrainJobRuntimeRefKey: trainingRuntime.Name})
+		err := h.client.List(ctx, &trainJobsWithTrainingRuntime,
+			client.InNamespace(trainingRuntime.Namespace),
+			client.MatchingFields{indexer.TrainJobRuntimeRefKey: trainingRuntime.Name},
+		)
 		if err != nil {
 			return err
 		}
@@ -271,13 +273,17 @@ func (h *PodGroupRuntimeClassHandler) queueSuspendedTrainJobs(ctx context.Contex
 		}
 		trainJobs = append(trainJobs, trainJobsWithClTrainingRuntime.Items...)
 	}
-	trainJobs = slices.CompactFunc(trainJobs, func(a, b trainer.TrainJob) bool {
-		return a.Name == b.Name
-	})
+	queuedTrainJobs := make(map[client.ObjectKey]struct{}, len(trainJobs))
 	for _, trainJob := range trainJobs {
-		if ptr.Deref(trainJob.Spec.Suspend, false) {
-			q.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&trainJob)})
+		if !ptr.Deref(trainJob.Spec.Suspend, false) {
+			continue
 		}
+		key := client.ObjectKeyFromObject(&trainJob)
+		if _, queued := queuedTrainJobs[key]; queued {
+			continue
+		}
+		q.Add(reconcile.Request{NamespacedName: key})
+		queuedTrainJobs[key] = struct{}{}
 	}
 	return nil
 }


### PR DESCRIPTION
### Summary

- scope TrainJob lookups to the namespace of each namespaced `TrainingRuntime`
- deduplicate queued TrainJobs by namespace and name
- cover cross-namespace behavior in both coscheduling and Volcano RuntimeClass handlers

### Why

Same-named `TrainingRuntime` and TrainJob objects can exist in different namespaces. RuntimeClass events previously searched TrainJobs by runtime name cluster-wide and deduplicated by name alone, which could enqueue an unrelated namespace and omit the correct suspended TrainJob.

Fixes #4001.

### Testing

- `go test ./pkg/runtime/framework/plugins/coscheduling ./pkg/runtime/framework/plugins/volcano`
- `go vet ./pkg/runtime/framework/plugins/coscheduling ./pkg/runtime/framework/plugins/volcano`
- `go test ./pkg/runtime/framework/...`
- `go vet ./pkg/runtime/framework/...`
- `pre-commit run --files <changed files>`
- `make generate` attempted; controller and Helm manifest generation ran, but the object-generation step could not resolve `./pkg/apis/...` under Windows/MSYS (`no Go files in D:\trainer-master-scan\pkg\apis`). No generated changes are required or included because this PR does not modify APIs or generation markers.

_AI assistance: Codex assisted with technical drafting and implementation; the contributor reviewed and verified the changes locally._