### PR TITLE
fix(framework): stop Flux appending the Runtime args to the training command

### DIFF
--- a/pkg/runtime/core/trainingruntime_test.go
+++ b/pkg/runtime/core/trainingruntime_test.go
@@ -2239,3 +2239,98 @@ func TestRuntimeInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestTrainingRuntimeNewObjectsFluxTrainerArgs(t *testing.T) {
+	cases := map[string]struct {
+		trainerSpec *trainer.Trainer
+		wantCommand []string
+	}{
+		"the Runtime args are wrapped into the Flux entrypoint": {
+			wantCommand: []string{
+				"/bin/bash", "/etc/flux-config/entrypoint.sh", "runtime-cmd runtime-arg",
+			},
+		},
+		"the TrainJob args are wrapped into the Flux entrypoint": {
+			trainerSpec: testingutil.MakeTrainJobTrainerWrapper().
+				Container("test:trainjob", []string{"job-cmd"}, []string{"job-arg"}, nil).
+				Obj(),
+			wantCommand: []string{
+				"/bin/bash", "/etc/flux-config/entrypoint.sh", "job-cmd job-arg",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			t.Cleanup(cancel)
+
+			trainingRuntime := testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "flux-runtime").RuntimeSpec(
+				testingutil.MakeTrainingRuntimeSpecWrapper(
+					testingutil.MakeTrainingRuntimeWrapper(metav1.NamespaceDefault, "flux-runtime").Spec).
+					WithMLPolicy(
+						testingutil.MakeMLPolicyWrapper().
+							WithNumNodes(1).
+							WithMLPolicySource(*testingutil.MakeMLPolicySourceWrapper().FluxPolicy(ptr.To[int32](1)).Obj()).
+							Obj(),
+					).
+					Container(constants.Node, constants.Node, "test:runtime", []string{"runtime-cmd"}, []string{"runtime-arg"}, nil).
+					Obj(),
+			).Obj()
+
+			trainJob := testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "flux-job").
+				UID("uid").
+				RuntimeRef(trainer.SchemeGroupVersion.WithKind(trainer.TrainingRuntimeKind), "flux-runtime")
+			if tc.trainerSpec != nil {
+				trainJob = trainJob.Trainer(tc.trainerSpec)
+			}
+
+			clientBuilder := testingutil.NewClientBuilder().WithObjects(trainingRuntime)
+			c := clientBuilder.Build()
+			runtimeInstance, err := NewTrainingRuntime(ctx, c, testingutil.AsIndex(clientBuilder), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			objs, err := runtimeInstance.NewObjects(ctx, trainJob.Obj())
+			if err != nil {
+				t.Fatal(err)
+			}
+			resultObjs, err := testingutil.ToObject(c.Scheme(), objs...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			nodeContainer := findFluxTrainerContainer(t, resultObjs)
+			if diff := cmp.Diff(tc.wantCommand, nodeContainer.Command); len(diff) != 0 {
+				t.Errorf("Unexpected trainer container command (-want,+got):\n%s", diff)
+			}
+			// The entrypoint already carries the args, so the container must not receive them again.
+			if len(nodeContainer.Args) != 0 {
+				t.Errorf("Unexpected trainer container args: got %v, want none", nodeContainer.Args)
+			}
+		})
+	}
+}
+
+func findFluxTrainerContainer(t *testing.T, objs []runtime.Object) corev1.Container {
+	t.Helper()
+	for _, obj := range objs {
+		jobSet, ok := obj.(*jobsetv1alpha2.JobSet)
+		if !ok {
+			continue
+		}
+		for _, rJob := range jobSet.Spec.ReplicatedJobs {
+			if rJob.Name != constants.Node {
+				continue
+			}
+			for _, container := range rJob.Template.Spec.Template.Spec.Containers {
+				if container.Name == constants.Node {
+					return container
+				}
+			}
+		}
+	}
+	t.Fatalf("JobSet does not have the %s container in the %s replicated job", constants.Node, constants.Node)
+	return corev1.Container{}
+}

--- a/pkg/runtime/framework/plugins/flux/flux.go
+++ b/pkg/runtime/framework/plugins/flux/flux.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -142,7 +143,10 @@ func (f *Flux) EnforceMLPolicy(info *runtime.Info, trainJob *trainer.TrainJob) e
 		trainJob.Spec.Trainer = &trainer.Trainer{}
 	}
 	trainJob.Spec.Trainer.Command = []string{"/bin/bash", "/etc/flux-config/entrypoint.sh", originalCmd}
-	trainJob.Spec.Trainer.Args = nil
+	// Empty rather than nil: the builder applies args only when they are non-nil, so an empty
+	// slice is what replaces the Runtime-declared ones on the container. A nil would leave them
+	// there for the entrypoint to concatenate onto the command it already wraps.
+	trainJob.Spec.Trainer.Args = []string{}
 
 	// Define the Init Container. This has a spack view with flux pre-built, and we add to an emptyDir
 	// with configuration that is then accessible to the application. The OS/version should match.
@@ -378,6 +382,7 @@ func getOriginalCommand(trainJob *trainer.TrainJob, info *runtime.Info) string {
 	trainerContainer := info.FindContainerByPodSetAncestorContainerName(constants.AncestorTrainer, constants.Node)
 	if trainerContainer != nil {
 		command = trainerContainer.Command
+		args = trainerContainer.Args
 	}
 
 	// Override if user defined them in the top-level Trainer spec
@@ -390,8 +395,9 @@ func getOriginalCommand(trainJob *trainer.TrainJob, info *runtime.Info) string {
 		}
 	}
 
-	// Combine into a single string for the shell script
-	fullCommand := strings.Join(append(command, args...), " ")
+	// Combine into a single string for the shell script. Concat rather than append: command and
+	// args alias the PodSet container's own slices.
+	fullCommand := strings.Join(slices.Concat(command, args), " ")
 	return strings.TrimSpace(fullCommand)
 }
 

--- a/pkg/runtime/framework/plugins/flux/flux_test.go
+++ b/pkg/runtime/framework/plugins/flux/flux_test.go
@@ -500,6 +500,34 @@ func TestGetOriginalCommand(t *testing.T) {
 			want: "python train.py --epochs 10",
 		},
 		{
+			name: "the Runtime args are wrapped when the TrainJob overrides neither",
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				Trainer(utiltesting.MakeTrainJobTrainerWrapper().NumNodes(1).Obj()).
+				Obj(),
+			info: runtimeInfoWithTrainerContainer([]string{"train.sh"}, []string{"--epochs", "10"}),
+			want: "train.sh --epochs 10",
+		},
+		{
+			name: "the TrainJob args replace the Runtime ones",
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				Trainer(utiltesting.MakeTrainJobTrainerWrapper().
+					Container("image", nil, []string{"--epochs", "3"}, nil).
+					Obj()).
+				Obj(),
+			info: runtimeInfoWithTrainerContainer([]string{"train.sh"}, []string{"--epochs", "10"}),
+			want: "train.sh --epochs 3",
+		},
+		{
+			name: "the Runtime args survive a TrainJob that overrides only the command",
+			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
+				Trainer(utiltesting.MakeTrainJobTrainerWrapper().
+					Container("image", []string{"job.sh"}, nil, nil).
+					Obj()).
+				Obj(),
+			info: runtimeInfoWithTrainerContainer([]string{"train.sh"}, []string{"--epochs", "10"}),
+			want: "job.sh --epochs 10",
+		},
+		{
 			name: "command and args with extra spaces",
 			trainJob: utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test").
 				Trainer(utiltesting.MakeTrainJobTrainerWrapper().
@@ -518,6 +546,22 @@ func TestGetOriginalCommand(t *testing.T) {
 				t.Errorf("getOriginalCommand() = %q; want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func runtimeInfoWithTrainerContainer(command, args []string) *runtime.Info {
+	return &runtime.Info{
+		TemplateSpec: runtime.TemplateSpec{
+			PodSets: []runtime.PodSet{{
+				Name:     constants.Node,
+				Ancestor: ptr.To(constants.AncestorTrainer),
+				Containers: []runtime.Container{{
+					Name:    constants.Node,
+					Command: command,
+					Args:    args,
+				}},
+			}},
+		},
 	}
 }
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -81,9 +81,12 @@ type PodSet struct {
 }
 
 type Container struct {
-	Name         string
-	Image        string
-	Command      []string
+	Name    string
+	Image   string
+	Command []string
+	// Args is inbound only: unlike Command and Image, the JobSet plugin does not sync it back,
+	// so setting it on a PodSet has no effect on the built JobSet.
+	Args         []string
 	Env          []corev1ac.EnvVarApplyConfiguration
 	Ports        []corev1ac.ContainerPortApplyConfiguration
 	VolumeMounts []corev1ac.VolumeMountApplyConfiguration
@@ -164,6 +167,7 @@ func toPodSetContainer(containerApply ...corev1ac.ContainerApplyConfiguration) i
 				Name:         ptr.Deref(cApply.Name, ""),
 				Image:        ptr.Deref(cApply.Image, ""),
 				Command:      cApply.Command,
+				Args:         cApply.Args,
 				Env:          cApply.Env,
 				Ports:        cApply.Ports,
 				VolumeMounts: cApply.VolumeMounts,

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -428,31 +428,35 @@ func TestNewInfo(t *testing.T) {
 				Scheduler:   &Scheduler{PodLabels: make(map[string]string)},
 			},
 		},
-		"image and command are extracted from containers and init containers": {
+		"image, command and args are extracted from containers and init containers": {
 			infoOpts: []InfoOption{
 				WithPodSet(constants.Node, ptr.To(constants.AncestorTrainer), 2, corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:    constants.Node,
 						Image:   "train:latest",
 						Command: []string{"python", "train.py"},
+						Args:    []string{"--epochs", "10"},
 					}},
 					InitContainers: []corev1.Container{{
 						Name:    "flux-installer",
 						Image:   "flux:v1",
 						Command: []string{"/bin/bash", "/etc/flux-config/init.sh"},
+						Args:    []string{"--verbose"},
 					}},
 				}, corev1ac.PodSpec().
 					WithContainers(
 						corev1ac.Container().
 							WithName(constants.Node).
 							WithImage("train:latest").
-							WithCommand("python", "train.py"),
+							WithCommand("python", "train.py").
+							WithArgs("--epochs", "10"),
 					).
 					WithInitContainers(
 						corev1ac.Container().
 							WithName("flux-installer").
 							WithImage("flux:v1").
-							WithCommand("/bin/bash", "/etc/flux-config/init.sh"),
+							WithCommand("/bin/bash", "/etc/flux-config/init.sh").
+							WithArgs("--verbose"),
 					),
 				),
 			},
@@ -470,11 +474,13 @@ func TestNewInfo(t *testing.T) {
 								Name:    constants.Node,
 								Image:   "train:latest",
 								Command: []string{"python", "train.py"},
+								Args:    []string{"--epochs", "10"},
 							}},
 							InitContainers: []Container{{
 								Name:    "flux-installer",
 								Image:   "flux:v1",
 								Command: []string{"/bin/bash", "/etc/flux-config/init.sh"},
+								Args:    []string{"--verbose"},
 							}},
 							SinglePodRequests: corev1.ResourceList{},
 						},


### PR DESCRIPTION
## Summary

The Flux plugin wraps the training command in its entrypoint so that only the entrypoint controls execution, and clears `.spec.trainer.args` to say so. That only stops the JobSet builder from re-applying the TrainJob's args — the ones the Runtime declares stay on the container, and `entrypoint.sh` collapses every argument it receives onto the command it wraps. A TrainJob asking for `--epochs 3` against a Runtime declaring `--epochs 10` runs with both, the Runtime's value last; no runtime under `examples/flux/` declares args, which is why the path has gone unnoticed.

The same asymmetry drops those args in the other direction: the wrapped command falls back to the Runtime-declared command when the TrainJob overrides nothing, but args were only ever read from the TrainJob.

## Change

Both halves come down to the field-by-field `!= nil` override the builder already applies for every other runtime. Clearing now means an empty rather than nil `.spec.trainer.args`, so the builder replaces the Runtime's args instead of skipping them — the mirror of #3904, which allocates a `Trainer` so that same rule can carry the entrypoint command. Wrapping takes the Runtime's args as its base, so a TrainJob overriding only `command` keeps them.

Reading them needs `Args` on the PodSet `Container`, continuing #3674, which exposed `Image` and `Command` for the same reason. It is inbound only: syncing it back out is #3967's to make, and resolving args into the template there needs the empty value this PR introduces.

`slices.Concat` replaces `append`, which could otherwise write into the PodSet container's own backing array now that command and args both come from there.

**Checklist:**

- [ ] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing