### PR TITLE
chore(docs): improve website outline and framework guide intros

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Developer Guide
+# Contributing Guide
 
 This guide explains how to contribute to the Kubeflow Trainer V2 project.
 For the Kubeflow Trainer documentation, please check [the official Kubeflow documentation](https://trainer.kubeflow.org/en/latest/overview/index.html).
@@ -123,7 +123,7 @@ Make sure to install [pre-commit](https://pre-commit.com/) (`pip install pre-com
 
 The pre-commit hooks ensure code quality and consistency. They are executed in CI. PRs that fail to comply with the hooks will not be able to pass the corresponding CI gate. The hooks are only executed against staged files unless you run `pre-commit run --all`, in which case, they'll be executed against every file in the repository.
 
-Specific programmatically generated files listed in the `exclude` field in [.pre-commit-config.yaml](../../.pre-commit-config.yaml) are deliberately excluded from the hooks.
+Specific programmatically generated files listed in the `exclude` field in [.pre-commit-config.yaml](https://github.com/kubeflow/trainer/blob/master/.pre-commit-config.yaml) are deliberately excluded from the hooks.
 
 ## Best Practices
 
@@ -135,7 +135,7 @@ The PR titles are used to generated changelog for releases.
 PR titles must:
 
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
-- Have an appropriate [type and scope](./.github/workflows/check-pr-title.yaml)
+- Have an appropriate [type and scope](https://github.com/kubeflow/trainer/blob/master/.github/workflows/check-pr-title.yaml)
 
 Examples:
 
@@ -149,7 +149,7 @@ For any significant features or enhancement for Kubeflow Trainer project we foll
 [Kubeflow Enhancement Proposal process](https://github.com/kubeflow/community/tree/master/proposals).
 
 If you want to submit a significant change to the Kubeflow Trainer, please submit a new KEP under
-[./proposals](./proposals/) directory.
+[./proposals](https://github.com/kubeflow/trainer/tree/master/proposals) directory.
 
 ### Go Development
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
 # Contributing Guide
 
-This guide explains how to contribute to the Kubeflow Trainer V2 project.
-For the Kubeflow Trainer documentation, please check [the official Kubeflow documentation](https://trainer.kubeflow.org/en/latest/overview/index.html).
+This guide explains how to contribute to [the Kubeflow Trainer project](https://trainer.kubeflow.org/en/latest/).
 
 ## AI Assistant Tooling
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
 
 Latest News 🔥
 
+- [2026/08] Kubeflow Trainer v2.3.0 is officially released with the runtime snapshot mechanism for
+  decoupled runtime lifecycle, enhanced MPI support, and proposal Megatron-LM examples. Check out
+  [the GitHub release notes](https://github.com/kubeflow/trainer/releases/tag/v2.3.0).
 - [2026/03] Kubeflow Trainer v2.2 is officially released with support for JAX and XGBoost
   Training Runtimes, enhanced observability with metrics propagation to TrainJob status,
   and Flux Framework integration for HPC and MPI workloads. Check out

--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ Latest News 🔥
 
 ## Overview
 
+<!-- overview-start -->
+
 Kubeflow Trainer is a Kubernetes-native distributed AI platform for scalable large language model
 (LLM) fine-tuning and training of AI models across a wide range of frameworks, including
-PyTorch, MLX, HuggingFace, DeepSpeed, JAX, XGBoost, and more.
+PyTorch, MLX, HuggingFace, DeepSpeed, Megatron-LM, JAX, XGBoost, and more.
 
 Kubeflow Trainer brings MPI to Kubernetes, orchestrating multi-node, multi-GPU distributed
 jobs efficiently across high-performance computing (HPC) clusters. This enables high-throughput
@@ -52,8 +54,13 @@ ultra-fast synchronization between GPUs nodes.
 
 Kubeflow Trainer seamlessly integrates with the Cloud Native AI ecosystem, including
 [Kueue](https://kueue.sigs.k8s.io/docs/tasks/run/trainjobs/) for topology-aware scheduling and
-multi-cluster job dispatching, as well as [JobSet](https://github.com/kubernetes-sigs/jobset) and
-[LeaderWorkerSet](https://github.com/kubernetes-sigs/lws) for AI workload orchestration.
+multi-cluster job dispatching, [Slurm Bridge](https://github.com/SlinkyProject/slurm-bridge) for
+scheduling on hybrid Kubernetes and Slurm clusters, and [KAI Scheduler](https://github.com/NVIDIA/KAI-Scheduler) for
+GPU aware scheduling.
+
+Kubeflow Trainer reuses existing Kubernetes-native building blocks like
+[JobSet](https://github.com/kubernetes-sigs/jobset) and [LeaderWorkerSet](https://github.com/kubernetes-sigs/lws)
+for AI workload orchestration.
 
 Kubeflow Trainer provides a distributed data cache designed to stream large-scale data with zero-copy
 transfer directly to GPU nodes. This ensures memory-efficient training jobs while maximizing
@@ -61,6 +68,8 @@ GPU utilization.
 
 With [the Kubeflow Python SDK](https://github.com/kubeflow/sdk), AI practitioners can effortlessly
 develop and fine-tune LLMs while leveraging the Kubeflow Trainer APIs: TrainJob and Runtimes.
+
+<!-- overview-end -->
 
 <h1 align="center">
     <img src="./docs/images/trainer-tech-stack.drawio.svg" alt="logo" width="500">

--- a/README.md
+++ b/README.md
@@ -85,11 +85,18 @@ to install and get started with Kubeflow Trainer.
 
 ## Community
 
-The following links provide information on how to get involved in the community:
+<!-- community-start -->
+
+The following links provide information on how to get involved with the Kubeflow Trainer community:
 
 - Join our [`#kubeflow-trainer` Slack channel](https://www.kubeflow.org/docs/about/community/#kubeflow-slack).
-- Attend [the bi-weekly AutoML and Training Working Group](https://bit.ly/2PWVCkV) community meeting.
-- Check out [who is using Kubeflow Trainer](ADOPTERS.md).
+- Attend [the bi-weekly Kubeflow Trainer and Katib call](https://bit.ly/kf-trainer-meeting).
+- If you use Kubeflow Trainer, add yourself to [the ADOPTERS file](https://github.com/kubeflow/trainer/blob/master/ADOPTERS.md).
+
+Kubeflow Trainer is a Kubeflow subproject. Refer to
+[the Kubeflow community page](https://www.kubeflow.org/docs/about/community/) for more information.
+
+<!-- community-end -->
 
 ## Contributing
 

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -268,13 +268,13 @@ li::marker {
 }
 
 /* Sidebar: always expand the User Guides and Operator Guides sections */
-.sidebar-tree .toctree-l1 > .toctree-checkbox[aria-label$="of User Guides"] ~ ul,
-.sidebar-tree .toctree-l1 > .toctree-checkbox[aria-label$="of Operator Guides"] ~ ul {
+.sidebar-tree .toctree-l1 > .toctree-checkbox[aria-label*="User Guides"] ~ ul,
+.sidebar-tree .toctree-l1 > .toctree-checkbox[aria-label*="Operator Guides"] ~ ul {
     display: block;
 }
 
-.sidebar-tree .toctree-l1 > .toctree-checkbox[aria-label$="of User Guides"] ~ label,
-.sidebar-tree .toctree-l1 > .toctree-checkbox[aria-label$="of Operator Guides"] ~ label {
+.sidebar-tree .toctree-l1 > .toctree-checkbox[aria-label*="User Guides"] ~ label,
+.sidebar-tree .toctree-l1 > .toctree-checkbox[aria-label*="Operator Guides"] ~ label {
     display: none;
 }
 

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -267,6 +267,17 @@ li::marker {
     font-size: 0.9rem;
 }
 
+/* Sidebar: always expand the User Guides and Operator Guides sections */
+.sidebar-tree .toctree-l1 > .toctree-checkbox[aria-label$="of User Guides"] ~ ul,
+.sidebar-tree .toctree-l1 > .toctree-checkbox[aria-label$="of Operator Guides"] ~ ul {
+    display: block;
+}
+
+.sidebar-tree .toctree-l1 > .toctree-checkbox[aria-label$="of User Guides"] ~ label,
+.sidebar-tree .toctree-l1 > .toctree-checkbox[aria-label$="of Operator Guides"] ~ label {
+    display: none;
+}
+
 /* Sidebar: make it stick while scrolling */
 @media (min-width: 67em) {
     .sidebar-drawer {

--- a/docs/contributor-guides/community.md
+++ b/docs/contributor-guides/community.md
@@ -2,17 +2,8 @@
 
 Get involved with the Kubeflow Trainer community.
 
-Community information is maintained in the repository README to avoid drift between
-the docs site and the source of truth.
-
-## Canonical source
-
-- [Community section in the Kubeflow Trainer README](https://github.com/kubeflow/trainer#community)
-- [ADOPTERS.md](https://github.com/kubeflow/trainer/blob/master/ADOPTERS.md)
-
-## Quick links
-
-- **Slack**: [#kubeflow-trainer](https://app.slack.com/client/T08PSQ7BQ/C0742LDFZ4K) on [CNCF Slack](https://slack.cncf.io/)
-- **Meetings**: [AutoML and Training Working Group](https://zoom-lfx.platform.linuxfoundation.org/meetings/kubeflow)
-- **Contributing**: [Contributing Guide](contributing.md)
-- **Changelog**: [CHANGELOG.md on GitHub](https://github.com/kubeflow/trainer/blob/master/CHANGELOG.md)
+```{include} ../../README.md
+:start-after: <!-- community-start -->
+:end-before: <!-- community-end -->
+:relative-docs: docs/
+```

--- a/docs/contributor-guides/contributing.md
+++ b/docs/contributor-guides/contributing.md
@@ -1,16 +1,4 @@
-# Contributing Guide
-
-This page links to the canonical contributing guide for Kubeflow Trainer.
-
-The full guide is maintained in the repository and includes development setup,
-Makefile targets, testing requirements, and pull request guidelines.
-
-## Canonical source
-
-- [CONTRIBUTING.md on GitHub](https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md)
-
-## Quick links
-
-- [GitHub repository](https://github.com/kubeflow/trainer)
-- [Community guide](community.md)
-- [Kubeflow contributor guide](https://www.kubeflow.org/docs/about/contributing/)
+```{include} ../../CONTRIBUTING.md
+:relative-docs: docs/
+:relative-images:
+```

--- a/docs/contributor-guides/index.md
+++ b/docs/contributor-guides/index.md
@@ -1,8 +1,8 @@
 # Contributor Guides
 
-*Documentation for Kubeflow Trainer contributors*
+_Documentation for Kubeflow Trainer contributors_
 
-----
+---
 
 :::::{grid} 1 1 2 2
 :gutter: 3
@@ -18,17 +18,17 @@ How to contribute to the Kubeflow Trainer project
 :link: community
 :link-type: doc
 
-Join the Kubeflow community, meetings, and communication channels
+Join the Kubeflow Trainer community, meetings, and communication channels
 ::::
 
 :::::
 
-----
+---
 
 ```{toctree}
 :hidden:
 :maxdepth: 1
 
-contributing
+Contributing Guide <contributing>
 community
 ```

--- a/docs/operator-guides/index.md
+++ b/docs/operator-guides/index.md
@@ -78,7 +78,7 @@ Understand the plugin-based extension architecture
 :link: job-scheduling/index
 :link-type: doc
 
-Integrate with Volcano, Kueue, Coscheduling, KAI Scheduler, and Slurm Bridge
+Integrate with Kueue, Slurm Bridge, KAI Scheduler, Coscheduling, and Volcano
 ::::
 
 :::::

--- a/docs/operator-guides/job-scheduling/index.md
+++ b/docs/operator-guides/job-scheduling/index.md
@@ -11,7 +11,28 @@ Configure gang scheduling and integrate Kubeflow Trainer with Kubernetes schedul
 :link: overview
 :link-type: doc
 
-Introduction to gang scheduling and PodGroupPolicy
+Supported scheduling integrations and the PodGroupPolicy API
+::::
+
+::::{grid-item-card} Kueue
+:link: https://kueue.sigs.k8s.io/docs/tasks/run/trainjobs/
+:link-type: url
+
+Job queueing and resource management with Kueue
+::::
+
+::::{grid-item-card} Slurm Bridge
+:link: slurm-bridge
+:link-type: doc
+
+Schedule TrainJobs on hybrid Kubernetes and Slurm clusters
+::::
+
+::::{grid-item-card} KAI Scheduler
+:link: kai
+:link-type: doc
+
+Gang scheduling with NVIDIA KAI Scheduler
 ::::
 
 ::::{grid-item-card} Coscheduling
@@ -28,27 +49,6 @@ Gang scheduling with the Coscheduling plugin
 Advanced batch scheduling with Volcano
 ::::
 
-::::{grid-item-card} Kueue
-:link: https://kueue.sigs.k8s.io/docs/tasks/run/trainjobs/
-:link-type: url
-
-Job queueing and resource management with Kueue
-::::
-
-::::{grid-item-card} KAI Scheduler
-:link: kai
-:link-type: doc
-
-Gang scheduling with NVIDIA KAI Scheduler
-::::
-
-::::{grid-item-card} Slurm Bridge
-:link: slurm-bridge
-:link-type: doc
-
-Schedule TrainJobs on hybrid Kubernetes and Slurm clusters
-::::
-
 :::::
 
 ----
@@ -58,9 +58,9 @@ Schedule TrainJobs on hybrid Kubernetes and Slurm clusters
 :maxdepth: 1
 
 overview
+Kueue <https://kueue.sigs.k8s.io/docs/tasks/run/trainjobs/>
+slurm-bridge
+kai
 coscheduling
 volcano
-Kueue <https://kueue.sigs.k8s.io/docs/tasks/run/trainjobs/>
-kai
-slurm-bridge
 ```

--- a/docs/operator-guides/job-scheduling/overview.md
+++ b/docs/operator-guides/job-scheduling/overview.md
@@ -33,10 +33,10 @@ represents plugin configuration to enable gang scheduling using that specific in
 specify one of the supported policies in the `PodGroupPolicy` API to enable gang scheduling with
 supported plugins.
 
-The `coscheduling` and `volcano` policies are supported. The other integrations do not use the
-`PodGroupPolicy` API: Kueue admits the TrainJob with its own quota and suspend mechanism, KAI
-Scheduler creates its PodGroup with the `podgrouper` component, and Slurm Bridge schedules the
-PodGroup that the `coscheduling` policy creates.
+The `coscheduling` and `volcano` policies are direct `PodGroupPolicy` sources. Slurm Bridge requires
+the `coscheduling` policy to create a PodGroup for gang scheduling. Kueue and KAI Scheduler use
+different mechanisms: Kueue admits the TrainJob with its own quota and suspend mechanism, and KAI
+Scheduler creates its PodGroup with the `podgrouper` component.
 
 ## Next Steps
 

--- a/docs/operator-guides/job-scheduling/overview.md
+++ b/docs/operator-guides/job-scheduling/overview.md
@@ -1,11 +1,24 @@
 # Overview
 
-This guide describes how to enable gang scheduling with Kubeflow Trainer. It ensures that a group of
-related training nodes (e.g. Pods), only start when all required resources are available. Having
+Kubeflow Trainer integrates with Kubernetes schedulers and queueing systems to control when and
+where the TrainJob nodes run. These integrations enable gang scheduling, which ensures that a group
+of related training nodes (e.g. Pods), only start when all required resources are available. Having
 this is crucial when working with expensive and limited GPU accelerators.
 
 Before exploring this guide, make sure to follow [the Runtime guide](../runtime.md)
 to understand the basics of Kubeflow Trainer Runtimes.
+
+## Supported Integrations
+
+Kubeflow Trainer integrates with the following frameworks for job scheduling:
+
+| Framework | Capabilities | Configuration |
+| --------- | ------------ | ------------- |
+| [Kueue](https://kueue.sigs.k8s.io/docs/tasks/run/trainjobs/) | Job queueing, quota-based admission, workload priorities | `kueue.x-k8s.io/queue-name` label on the TrainJob |
+| [Slurm Bridge](slurm-bridge.md) | Scheduling on hybrid Kubernetes and Slurm clusters | `PodGroupPolicy` in the runtime |
+| [KAI Scheduler](kai.md) | Gang scheduling, queue-based resource management | `schedulerName` in the runtime |
+| [Coscheduling](coscheduling.md) | Gang scheduling | `PodGroupPolicy` in the runtime |
+| [Volcano Scheduler](volcano.md) | Gang scheduling, queue-based resource management, network topology-aware scheduling | `PodGroupPolicy` in the runtime |
 
 ## PodGroupPolicy Overview
 
@@ -20,10 +33,15 @@ represents plugin configuration to enable gang scheduling using that specific in
 specify one of the supported policies in the `PodGroupPolicy` API to enable gang scheduling with
 supported plugins.
 
+The `coscheduling` and `volcano` policies are supported. The other integrations do not use the
+`PodGroupPolicy` API: Kueue admits the TrainJob with its own quota and suspend mechanism, KAI
+Scheduler creates its PodGroup with the `podgrouper` component, and Slurm Bridge schedules the
+PodGroup that the `coscheduling` policy creates.
+
 ## Next Steps
 
+- Learn how to configure job queueing and resource management with [Kueue](https://kueue.sigs.k8s.io/docs/tasks/run/trainjobs/).
+- Learn how to schedule TrainJobs with [Slurm Bridge](slurm-bridge.md).
+- Learn how to configure gang scheduling with [KAI Scheduler](kai.md).
 - Learn how to enable gang scheduling with the [Coscheduling plugin](coscheduling.md).
 - Learn how to configure advanced scheduling with [Volcano Scheduler](volcano.md).
-- Learn how to configure job queueing and resource management with [Kueue](https://kueue.sigs.k8s.io/docs/tasks/run/trainjobs/).
-- Learn how to configure gang scheduling with [KAI Scheduler](kai.md).
-- Learn how to schedule TrainJobs with [Slurm Bridge](slurm-bridge.md).

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -1,22 +1,14 @@
 # Overview
 
-Kubeflow Trainer is a **Kubernetes-native distributed AI platform** for scalable large language model (LLM) fine-tuning and training of AI models across a wide range of frameworks, including PyTorch, MLX, HuggingFace, DeepSpeed, JAX, XGBoost, and more.
+This guide gives an overview for Kubeflow Trainer project.
 
-## What is Kubeflow Trainer?
+## What is Kubeflow Trainer
 
-Kubeflow Trainer brings **MPI to Kubernetes** for multi-node, multi-GPU distributed jobs across HPC clusters. It integrates seamlessly with the Cloud Native AI ecosystem through tools like:
-
-- **[Kueue](https://kueue.sigs.k8s.io/)** for topology-aware scheduling and multi-cluster dispatch
-- **[Slurm Bridge](https://github.com/SlinkyProject/slurm-bridge)** for scheduling on hybrid Kubernetes and Slurm clusters
-- **[JobSet](https://github.com/kubernetes-sigs/jobset)** and **[LeaderWorkerSet](https://github.com/kubernetes-sigs/lws)** for orchestration
-- **[Coscheduling](https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/pkg/coscheduling/README.md)** for gang scheduling with the Kubernetes scheduler
-- **[Volcano](https://volcano.sh/en/)** for batch scheduling
-- **[YuniKorn](https://yunikorn.apache.org/docs/)** for resource optimization
-- **[KAI Scheduler](https://github.com/NVIDIA/KAI-Scheduler)** for GPU-aware gang scheduling
-
-The platform features **distributed data caching** using [Apache Arrow](https://arrow.apache.org/) and [Apache DataFusion](https://datafusion.apache.org/) for zero-copy tensor streaming directly to GPU nodes, maximizing training performance.
-
-![Kubeflow Trainer Tech Stack](../images/trainer-tech-stack.drawio.svg)
+```{include} ../../README.md
+:start-after: <!-- overview-start -->
+:end-before: <!-- overview-end -->
+:relative-docs: docs/
+```
 
 ## Who is This For?
 
@@ -29,6 +21,7 @@ Kubeflow Trainer documentation is organized around three key personas:
 ML engineers and data scientists who use the **Kubeflow Python SDK** and **TrainJob APIs** to train and fine-tune models at scale.
 
 **What you'll find:**
+
 - Training guides for PyTorch, JAX, DeepSpeed, MLX
 - LLM fine-tuning blueprints with TorchTune
 - Local execution backends for development
@@ -38,6 +31,7 @@ ML engineers and data scientists who use the **Kubeflow Python SDK** and **Train
 DevOps engineers and cluster operators who **deploy and manage** Kubeflow Trainer on Kubernetes clusters.
 
 **What you'll find:**
+
 - Installation and configuration guides
 - Runtime and policy management
 - Integration with schedulers (Kueue, Slurm Bridge, Volcano)
@@ -48,6 +42,7 @@ DevOps engineers and cluster operators who **deploy and manage** Kubeflow Traine
 Open source developers who want to **contribute** to the Kubeflow Trainer project.
 
 **What you'll find:**
+
 - Architecture documentation
 - Development workflow
 - Contributing guidelines
@@ -102,8 +97,6 @@ Watch the **KubeCon + CloudNativeCon 2024** introduction to Kubeflow Trainer:
   </iframe>
 </div>
 ```
-
-
 
 ## Next Steps
 

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -7,6 +7,7 @@ Kubeflow Trainer is a **Kubernetes-native distributed AI platform** for scalable
 Kubeflow Trainer brings **MPI to Kubernetes** for multi-node, multi-GPU distributed jobs across HPC clusters. It integrates seamlessly with the Cloud Native AI ecosystem through tools like:
 
 - **[Kueue](https://kueue.sigs.k8s.io/)** for topology-aware scheduling and multi-cluster dispatch
+- **[Slurm Bridge](https://github.com/SlinkyProject/slurm-bridge)** for scheduling on hybrid Kubernetes and Slurm clusters
 - **[JobSet](https://github.com/kubernetes-sigs/jobset)** and **[LeaderWorkerSet](https://github.com/kubernetes-sigs/lws)** for orchestration
 - **[Coscheduling](https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/pkg/coscheduling/README.md)** for gang scheduling with the Kubernetes scheduler
 - **[Volcano](https://volcano.sh/en/)** for batch scheduling
@@ -39,7 +40,7 @@ DevOps engineers and cluster operators who **deploy and manage** Kubeflow Traine
 **What you'll find:**
 - Installation and configuration guides
 - Runtime and policy management
-- Integration with schedulers (Kueue, Volcano)
+- Integration with schedulers (Kueue, Slurm Bridge, Volcano)
 - Extension framework architecture
 
 ### Contributors
@@ -81,6 +82,8 @@ Kubeflow Trainer seamlessly integrates with Kubernetes ecosystem projects like
 [Kueue](https://kueue.sigs.k8s.io/),
 [Coscheduling](https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/pkg/coscheduling/README.md),
 [Volcano](https://volcano.sh/en/), or [YuniKorn](https://yunikorn.apache.org/docs/).
+With [Slurm Bridge](https://github.com/SlinkyProject/slurm-bridge), TrainJobs can also be scheduled
+by Slurm on hybrid Kubernetes and Slurm clusters.
 
 ![AI Lifecycle with Kubeflow Trainer](../images/ai-lifecycle-trainer.drawio.svg)
 

--- a/docs/user-guides/deepspeed.md
+++ b/docs/user-guides/deepspeed.md
@@ -1,6 +1,7 @@
 # DeepSpeed Guide
 
-This guide describes how to use TrainJob to train or fine-tune AI models with [DeepSpeed](https://www.deepspeed.ai/).
+This guide describes how to run [DeepSpeed](https://www.deepspeed.ai/) on Kubernetes with TrainJob
+to train or fine-tune AI models.
 
 ## Prerequisites
 

--- a/docs/user-guides/flux.md
+++ b/docs/user-guides/flux.md
@@ -1,6 +1,7 @@
 # Flux Guide
 
-This guide describes how to use TrainJob to train or fine-tune AI models with a [Flux Framework](https://flux-framework.org) High Performance Computing (HPC) cluster.
+This guide describes how to run a [Flux Framework](https://flux-framework.org) High Performance
+Computing (HPC) cluster on Kubernetes with TrainJob to train or fine-tune AI models.
 
 ## Prerequisites
 

--- a/docs/user-guides/jax-tpu.md
+++ b/docs/user-guides/jax-tpu.md
@@ -1,7 +1,7 @@
 # JAX on TPU Guide
 
-This guide describes how to use TrainJob to train or fine-tune AI models with
-[JAX](https://jax.readthedocs.io/) on Cloud TPU on Google Kubernetes Engine (GKE).
+This guide describes how to run [JAX](https://jax.readthedocs.io/) on Cloud TPU on Google Kubernetes
+Engine (GKE) with TrainJob to train or fine-tune AI models.
 
 ---
 

--- a/docs/user-guides/jax.md
+++ b/docs/user-guides/jax.md
@@ -1,7 +1,7 @@
 # JAX Guide
 
-This guide describes how to use TrainJob to train or fine-tune AI models with
-[JAX](https://jax.readthedocs.io/).
+This guide describes how to run [JAX](https://jax.readthedocs.io/) on Kubernetes with TrainJob to
+train or fine-tune AI models.
 
 ---
 

--- a/docs/user-guides/megatron.md
+++ b/docs/user-guides/megatron.md
@@ -1,7 +1,7 @@
 # Megatron Guide
 
-This guide describes how to use TrainJob to train AI models with
-[Megatron-Core](https://github.com/NVIDIA/Megatron-LM) and Tensor Parallelism.
+This guide describes how to run [Megatron-Core](https://github.com/NVIDIA/Megatron-LM) on Kubernetes
+with TrainJob to train AI models with Tensor Parallelism.
 
 ## Prerequisites
 
@@ -18,12 +18,12 @@ is NVIDIA's library for training large transformer models efficiently across mul
 It provides production-grade implementations of parallelism strategies:
 
 - **Tensor Parallelism (TP)**: Splits individual layer weight matrices across GPUs. Each GPU holds
- a slice of every layer, so you can train models whose layers are too large for a single GPU's
- memory. This is the parallelism strategy covered in this guide.
+  a slice of every layer, so you can train models whose layers are too large for a single GPU's
+  memory. This is the parallelism strategy covered in this guide.
 - **Pipeline Parallelism (PP)**: Assigns different layers to different GPUs and overlaps computation
- with micro-batch pipelining.
+  with micro-batch pipelining.
 - **Data Parallelism (DP)**: Replicates the full model on each GPU and splits the data across them.
- Megatron-Core includes `DistributedDataParallel` for gradient synchronization.
+  Megatron-Core includes `DistributedDataParallel` for gradient synchronization.
 
 Since Megatron-Core uses `torchrun` as its distributed launcher, it works natively with the
 existing `torch-distributed` ClusterTrainingRuntime. No dedicated Megatron runtime is needed.
@@ -369,10 +369,10 @@ training with frameworks that create several NCCL communicators.
 When configuring your TrainJob, the relationship between `num_nodes`, `gpu` per node, and
 `TP_SIZE` matters:
 
-| Configuration | `num_nodes` | `gpu` | `TP_SIZE` | Pods | How it works |
-|---|---|---|---|---|---|
-| Multi-GPU single node | 1 | 2 | 2 | 1 | 2 workers in 1 pod, each gets a CUDA device |
-| Multi-node | 2 | 1 | 2 | 2 | 1 worker per pod, TP across nodes via NCCL |
+| Configuration         | `num_nodes` | `gpu` | `TP_SIZE` | Pods | How it works                                |
+| --------------------- | ----------- | ----- | --------- | ---- | ------------------------------------------- |
+| Multi-GPU single node | 1           | 2     | 2         | 1    | 2 workers in 1 pod, each gets a CUDA device |
+| Multi-node            | 2           | 1     | 2         | 2    | 1 worker per pod, TP across nodes via NCCL  |
 
 Both configurations give you `WORLD_SIZE=2` and `TP_SIZE=2`. Multi-GPU on a single node is
 faster (GPU-to-GPU NVLink/PCIe instead of network), but multi-node lets you scale beyond the

--- a/docs/user-guides/mlx.md
+++ b/docs/user-guides/mlx.md
@@ -1,6 +1,7 @@
 # MLX Guide
 
-This guide describes how to use TrainJob to train or fine-tune AI models with [MLX](https://ml-explore.github.io/mlx/build/html/index.html).
+This guide describes how to run [MLX](https://ml-explore.github.io/mlx/build/html/index.html) on
+Kubernetes with TrainJob to train or fine-tune AI models.
 
 ## Prerequisites
 

--- a/docs/user-guides/pytorch-rocm.md
+++ b/docs/user-guides/pytorch-rocm.md
@@ -1,7 +1,7 @@
 # PyTorch on AMD ROCm Guide
 
-This guide describes how to use TrainJob to train or fine-tune AI models with
-[PyTorch](https://pytorch.org/) on AMD ROCm GPUs on Kubernetes.
+This guide describes how to run [PyTorch](https://pytorch.org/) on AMD ROCm GPUs on Kubernetes with
+TrainJob to train or fine-tune AI models.
 
 ---
 

--- a/docs/user-guides/pytorch.md
+++ b/docs/user-guides/pytorch.md
@@ -1,6 +1,7 @@
 # PyTorch Guide
 
-This guide describes how to use TrainJob to train or fine-tune AI models with [PyTorch](https://pytorch.org/).
+This guide describes how to run [PyTorch](https://pytorch.org/) on Kubernetes with TrainJob to
+train or fine-tune AI models.
 
 ## Prerequisites
 

--- a/docs/user-guides/xgboost.md
+++ b/docs/user-guides/xgboost.md
@@ -1,7 +1,7 @@
 # XGBoost Guide
 
-This guide describes how to use TrainJob to run distributed
-[XGBoost](https://xgboost.readthedocs.io/) training on Kubernetes.
+This guide describes how to run distributed [XGBoost](https://xgboost.readthedocs.io/) training on
+Kubernetes with TrainJob.
 
 ## Prerequisites
 


### PR DESCRIPTION
The scheduling guides were hard to find: the sidebar collapsed every section, so
readers had to open User Guides or Operator Guides before seeing anything under
them, and the Job Scheduling overview never said which schedulers Trainer
actually integrates with. This keeps those two sections always expanded, adds a
Supported Integrations table to the overview, applies one consistent scheduler
order (Kueue, Slurm Bridge, KAI Scheduler, Coscheduling, Volcano), and rewords
the ML framework guide intros to lead with running the framework on Kubernetes
with TrainJob.

Ref: #3951

_This PR was created using AI tools._