### PR TITLE
feat(cache): install data cache namespace RBAC from the Helm chart

### DIFF
--- a/charts/kubeflow-trainer/README.md
+++ b/charts/kubeflow-trainer/README.md
@@ -129,6 +129,7 @@ manager:
 | manager.config.statusServer.burst | int | `10` | Burst rate limit for the TrainJob Status Server api client |
 | webhook.failurePolicy | string | `"Fail"` | Specifies how unrecognized errors are handled. Available options are `Ignore` or `Fail`. |
 | dataCache.enabled | bool | `false` | Enable/disable data cache support (LWS dependency, ClusterRole). Set to `true` to install data cache components. |
+| dataCache.namespaces | list | `[]` | Namespaces to create the cache initializer ServiceAccount and RoleBinding in. The namespaces must already exist. |
 | dataCache.lws.install | bool | `true` | Whether to install LeaderWorkerSet as a dependency. Set to `false` if LeaderWorkerSet is already installed in the cluster. |
 | dataCache.lws.fullnameOverride | string | `"lws"` | String to fully override LeaderWorkerSet release name. |
 | dataCache.cacheImage.registry | string | `"ghcr.io"` | Data cache image registry |

--- a/charts/kubeflow-trainer/templates/data-cache/namespace-rbac.yaml
+++ b/charts/kubeflow-trainer/templates/data-cache/namespace-rbac.yaml
@@ -1,0 +1,44 @@
+{{- /*
+Copyright The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/ -}}
+
+{{- if .Values.dataCache.enabled }}
+{{- range $namespace := .Values.dataCache.namespaces }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeflow-trainer-cache-initializer
+  namespace: {{ $namespace | quote }}
+  labels:
+    {{- include "trainer.labels" $ | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubeflow-trainer-cache-initializer
+  namespace: {{ $namespace | quote }}
+  labels:
+    {{- include "trainer.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeflow-trainer-cache-initializer
+subjects:
+  - kind: ServiceAccount
+    name: kubeflow-trainer-cache-initializer
+    namespace: {{ $namespace | quote }}
+{{- end }}
+{{- end }}

--- a/charts/kubeflow-trainer/tests/data-cache/namespace_rbac_test.yaml
+++ b/charts/kubeflow-trainer/tests/data-cache/namespace_rbac_test.yaml
@@ -1,0 +1,104 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+suite: Test data-cache namespace RBAC
+templates:
+  - templates/data-cache/namespace-rbac.yaml
+release:
+  name: kubeflow-trainer
+  namespace: kubeflow-system
+tests:
+  - it: Should not render RBAC when dataCache.enabled is false
+    set:
+      dataCache:
+        enabled: false
+        namespaces:
+          - default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should not render RBAC when dataCache.namespaces is empty
+    set:
+      dataCache:
+        enabled: true
+        namespaces: []
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should render a ServiceAccount and a RoleBinding per namespace
+    set:
+      dataCache:
+        enabled: true
+        namespaces:
+          - default
+          - team-a
+    asserts:
+      - hasDocuments:
+          count: 4
+      - documentIndex: 0
+        isKind:
+          of: ServiceAccount
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: kubeflow-trainer-cache-initializer
+      - documentIndex: 0
+        equal:
+          path: metadata.namespace
+          value: default
+      - documentIndex: 2
+        isKind:
+          of: ServiceAccount
+      - documentIndex: 2
+        equal:
+          path: metadata.namespace
+          value: team-a
+      - documentIndex: 3
+        isKind:
+          of: RoleBinding
+      - documentIndex: 3
+        equal:
+          path: metadata.namespace
+          value: team-a
+
+  - it: Should bind the namespace ServiceAccount to the cache initializer ClusterRole
+    set:
+      dataCache:
+        enabled: true
+        namespaces:
+          - default
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: RoleBinding
+      - documentIndex: 1
+        equal:
+          path: metadata.name
+          value: kubeflow-trainer-cache-initializer
+      - documentIndex: 1
+        equal:
+          path: roleRef
+          value:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: kubeflow-trainer-cache-initializer
+      - documentIndex: 1
+        contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: kubeflow-trainer-cache-initializer
+            namespace: default

--- a/charts/kubeflow-trainer/values.yaml
+++ b/charts/kubeflow-trainer/values.yaml
@@ -165,6 +165,10 @@ dataCache:
   # -- Enable/disable data cache support (LWS dependency, ClusterRole).
   # Set to `true` to install data cache components.
   enabled: false
+  # -- Namespaces to create the cache initializer ServiceAccount and RoleBinding in.
+  # The namespaces must already exist.
+  namespaces: []
+  # - default
   lws:
     # -- Whether to install LeaderWorkerSet as a dependency.
     # Set to `false` if LeaderWorkerSet is already installed in the cluster.

--- a/docs/user-guides/data-cache.md
+++ b/docs/user-guides/data-cache.md
@@ -65,10 +65,15 @@ Alternatively, you can install the data cache resources using Helm charts:
 ```bash
 helm install kubeflow-trainer oci://ghcr.io/kubeflow/charts/kubeflow-trainer \
     --set dataCache.enabled=true \
+    --set dataCache.runtimes.torchDistributedWithCache.enabled=true \
+    --set 'dataCache.namespaces={default}' \
     --namespace kubeflow-system \
     --create-namespace \
     --version ${VERSION#v}
 ```
+
+`dataCache.namespaces` lists the existing namespaces where TrainJobs with data cache run. The chart
+creates the initializer ServiceAccount and RoleBinding in each of them.
 
 For the available Helm values to configure data cache, see the
 [kubeflow-trainer Helm chart documentation](https://github.com/kubeflow/trainer/tree/master/charts/kubeflow-trainer).
@@ -81,14 +86,11 @@ in your cluster.
 
 :::
 
-:::{warning}
+:::{note}
 
-Helm charts don't install RBAC in the user namespace. You have to deploy RBAC separately
-in each namespace where you want to create TrainJobs:
-
-```bash
-kubectl apply  --server-side -n <NAMESPACE> -k "https://github.com/kubeflow/trainer.git/manifests/overlays/data-cache/namespace-rbac"
-```
+Add namespaces later with `helm upgrade` and the extended `dataCache.namespaces` list. Applying
+`manifests/overlays/data-cache/namespace-rbac` by hand instead leaves those resources outside the
+Helm release, and a later upgrade that lists the same namespace fails on ownership.
 
 :::
 


### PR DESCRIPTION
## Summary

The cache initializer pod runs as `kubeflow-trainer-cache-initializer` in the TrainJob's namespace, but the chart ships only the ClusterRole. A Helm install of data cache is therefore incomplete, and the user guide has to send Helm users to the kustomize overlay to create the ServiceAccount and RoleBinding by hand.

## Change

- Create the initializer ServiceAccount and RoleBinding in each namespace listed in the new `dataCache.namespaces`.
- Point the data cache guide at that value, and enable the runtime its verification step looks for.

The list is empty by default, so existing installs are unchanged. Adding a namespace later becomes a `helm upgrade`, which keeps the RBAC inside the release rather than in an overlay the release does not own.

Independent of #3945, which fixes the rules of the same ClusterRole.

**Checklist:**

- [x] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing

Generated with [Claude Code](https://claude.com/claude-code)