### PR TITLE
fix(framework): clean up Volcano PodGroup when TrainJob transitions to Failed

### DIFF
--- a/charts/kubeflow-trainer/templates/rbac/clusterrole.yaml
+++ b/charts/kubeflow-trainer/templates/rbac/clusterrole.yaml
@@ -97,6 +97,7 @@ rules:
   - podgroups
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/manifests/base/rbac/role.yaml
+++ b/manifests/base/rbac/role.yaml
@@ -106,6 +106,7 @@ rules:
   - podgroups
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -128,6 +128,12 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	deadlineResult := r.reconcileDeadline(ctx, &trainJob)
 
+	if trainjob.IsTrainJobFinished(&trainJob) && runtime != nil {
+		if cleanUpErr := runtime.TerminalCleanup(ctx, &trainJob); cleanUpErr != nil {
+			err = errors.Join(err, cleanUpErr)
+		}
+	}
+
 	if !equality.Semantic.DeepEqual(trainJob.Status, prevTrainJob.Status) {
 		// TODO(astefanutti): Consider using SSA once controller-runtime client has SSA support
 		// for sub-resources. See: https://github.com/kubernetes-sigs/controller-runtime/issues/3183

--- a/pkg/controller/trainjob_controller_test.go
+++ b/pkg/controller/trainjob_controller_test.go
@@ -25,14 +25,21 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2/ktesting"
 	clocktesting "k8s.io/utils/clock/testing"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
+	jobruntimes "github.com/kubeflow/trainer/v2/pkg/runtime"
 	utiltesting "github.com/kubeflow/trainer/v2/pkg/util/testing"
 )
 
@@ -213,3 +220,122 @@ func TestReconcileDeadline(t *testing.T) {
 		})
 	}
 }
+
+type fakeRuntime struct {
+	cleanedUp bool
+	status    *trainer.TrainJobStatus
+}
+
+var _ jobruntimes.Runtime = (*fakeRuntime)(nil)
+
+func (f *fakeRuntime) NewObjects(context.Context, *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
+	return nil, nil
+}
+func (f *fakeRuntime) RuntimeInfo(*trainer.TrainJob, any, *trainer.MLPolicy, *trainer.PodGroupPolicy) (*jobruntimes.Info, error) {
+	return nil, nil
+}
+func (f *fakeRuntime) TrainJobStatus(context.Context, *trainer.TrainJob) (*trainer.TrainJobStatus, error) {
+	return f.status, nil
+}
+func (f *fakeRuntime) EventHandlerRegistrars() []jobruntimes.ReconcilerBuilder {
+	return nil
+}
+func (f *fakeRuntime) ValidateObjects(context.Context, *trainer.TrainJob, *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
+	return nil, nil
+}
+func (f *fakeRuntime) TerminalCleanup(context.Context, *trainer.TrainJob) error {
+	f.cleanedUp = true
+	return nil
+}
+
+func TestReconcile_TerminalCleanup(t *testing.T) {
+	runtimeGVK := schema.GroupVersionKind{
+		Group:   trainer.GroupVersion.Group,
+		Version: trainer.GroupVersion.Version,
+		Kind:    trainer.TrainingRuntimeKind,
+	}
+	runtimeKey := jobruntimes.RuntimeRefToRuntimeRegistryKey(trainer.RuntimeRef{
+		APIGroup: &runtimeGVK.Group,
+		Kind:     &runtimeGVK.Kind,
+		Name:     "test-runtime",
+	})
+
+	cases := map[string]struct {
+		trainJob      *trainer.TrainJob
+		runtimeStatus *trainer.TrainJobStatus
+		wantCleanedUp bool
+	}{
+		"trainJob is failed by condition": {
+			trainJob: func() *trainer.TrainJob {
+				tj := utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "failed-job").
+					RuntimeRef(runtimeGVK, "test-runtime").
+					Obj()
+				tj.Status.Conditions = []metav1.Condition{
+					{
+						Type:   trainer.TrainJobFailed,
+						Status: metav1.ConditionTrue,
+					},
+				}
+				return tj
+			}(),
+			wantCleanedUp: true,
+		},
+		"trainJob is complete by condition": {
+			trainJob: func() *trainer.TrainJob {
+				tj := utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "complete-job").
+					RuntimeRef(runtimeGVK, "test-runtime").
+					Obj()
+				tj.Status.Conditions = []metav1.Condition{
+					{
+						Type:   trainer.TrainJobComplete,
+						Status: metav1.ConditionTrue,
+					},
+				}
+				return tj
+			}(),
+			wantCleanedUp: true,
+		},
+		"trainJob is active and not finished": {
+			trainJob: func() *trainer.TrainJob {
+				return utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "active-job").
+					RuntimeRef(runtimeGVK, "test-runtime").
+					Obj()
+			}(),
+			wantCleanedUp: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			t.Cleanup(cancel)
+
+			fakeRT := &fakeRuntime{status: tc.runtimeStatus}
+			cli := utiltesting.NewClientBuilder().WithObjects(tc.trainJob).Build()
+
+			r := &TrainJobReconciler{
+				client:   cli,
+				recorder: events.NewFakeRecorder(10),
+				runtimes: map[string]jobruntimes.Runtime{
+					runtimeKey: fakeRT,
+				},
+			}
+
+			_, err := r.Reconcile(ctx, ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: tc.trainJob.Namespace,
+					Name:      tc.trainJob.Name,
+				},
+			})
+			if err != nil {
+				t.Fatalf("Unexpected reconcile error: %v", err)
+			}
+
+			if fakeRT.cleanedUp != tc.wantCleanedUp {
+				t.Errorf("TerminalCleanup called = %v, want %v", fakeRT.cleanedUp, tc.wantCleanedUp)
+			}
+		})
+	}
+}
+

--- a/pkg/runtime/core/clustertrainingruntime.go
+++ b/pkg/runtime/core/clustertrainingruntime.go
@@ -92,6 +92,10 @@ func (r *ClusterTrainingRuntime) TrainJobStatus(ctx context.Context, trainJob *t
 	return r.TrainingRuntime.TrainJobStatus(ctx, trainJob)
 }
 
+func (r *ClusterTrainingRuntime) TerminalCleanup(ctx context.Context, trainJob *trainer.TrainJob) error {
+	return r.TrainingRuntime.TerminalCleanup(ctx, trainJob)
+}
+
 func (r *ClusterTrainingRuntime) EventHandlerRegistrars() []runtime.ReconcilerBuilder {
 	return nil
 }

--- a/pkg/runtime/core/trainingruntime.go
+++ b/pkg/runtime/core/trainingruntime.go
@@ -301,6 +301,10 @@ func (r *TrainingRuntime) TrainJobStatus(ctx context.Context, trainJob *trainer.
 	return r.framework.RunTrainJobStatusPlugin(ctx, trainJob)
 }
 
+func (r *TrainingRuntime) TerminalCleanup(ctx context.Context, trainJob *trainer.TrainJob) error {
+	return r.framework.RunTerminalCleanupPlugins(ctx, trainJob)
+}
+
 func (r *TrainingRuntime) EventHandlerRegistrars() []runtime.ReconcilerBuilder {
 	var builders []runtime.ReconcilerBuilder
 	for _, ex := range r.framework.WatchExtensionPlugins() {

--- a/pkg/runtime/framework/core/framework.go
+++ b/pkg/runtime/framework/core/framework.go
@@ -46,6 +46,7 @@ type Framework struct {
 	preComponentBuilderPlugins   []framework.PreComponentBuilderPlugin
 	componentBuilderPlugins      []framework.ComponentBuilderPlugin
 	trainJobStatusPlugin         framework.TrainJobStatusPlugin
+	terminalCleanupPlugins       []framework.TerminalCleanupPlugin
 }
 
 func New(ctx context.Context, c client.Client, r fwkplugins.Registry, indexer client.FieldIndexer, cfg *configapi.Configuration) (*Framework, error) {
@@ -89,6 +90,9 @@ func New(ctx context.Context, c client.Client, r fwkplugins.Registry, indexer cl
 				return nil, errorTooManyTrainJobStatusPlugin
 			}
 			f.trainJobStatusPlugin = p
+		}
+		if p, ok := plugin.(framework.TerminalCleanupPlugin); ok {
+			f.terminalCleanupPlugins = append(f.terminalCleanupPlugins, p)
 		}
 	}
 	f.plugins = plugins
@@ -177,6 +181,16 @@ func (f *Framework) RunTrainJobStatusPlugin(ctx context.Context, trainJob *train
 		return f.trainJobStatusPlugin.Status(ctx, trainJob)
 	}
 	return nil, nil
+}
+
+func (f *Framework) RunTerminalCleanupPlugins(ctx context.Context, trainJob *trainer.TrainJob) error {
+	var errs error
+	for _, plugin := range f.terminalCleanupPlugins {
+		if err := plugin.TerminalCleanup(ctx, trainJob); err != nil {
+			errs = errors.Join(errs, err)
+		}
+	}
+	return errs
 }
 
 func (f *Framework) WatchExtensionPlugins() []framework.WatchExtensionPlugin {

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -129,6 +130,9 @@ func TestNew(t *testing.T) {
 					&mpi.MPI{},
 				},
 				trainJobStatusPlugin: &jobset.JobSet{},
+				terminalCleanupPlugins: []framework.TerminalCleanupPlugin{
+					&volcano.Volcano{},
+				},
 			},
 		},
 		"indexer key for trainingRuntime and runtimeClass is an empty": {
@@ -2676,3 +2680,65 @@ func TestRunPreComponentBuilderPlugins(t *testing.T) {
 		})
 	}
 }
+
+type fakeTerminalCleanupPlugin struct {
+	err error
+}
+
+var _ framework.TerminalCleanupPlugin = (*fakeTerminalCleanupPlugin)(nil)
+
+const fakeTerminalCleanupPluginName = "fake-terminal-cleanup"
+
+func (f *fakeTerminalCleanupPlugin) Name() string { return fakeTerminalCleanupPluginName }
+func (f *fakeTerminalCleanupPlugin) TerminalCleanup(context.Context, *trainer.TrainJob) error {
+	return f.err
+}
+
+func TestRunTerminalCleanupPlugins(t *testing.T) {
+	errCleanupFailed := errors.New("cleanup failed")
+	cases := map[string]struct {
+		registry  fwkplugins.Registry
+		trainJob  *trainer.TrainJob
+		wantError error
+	}{
+		"terminal cleanup plugin succeeds": {
+			registry: fwkplugins.Registry{
+				fakeTerminalCleanupPluginName: func(context.Context, client.Client, client.FieldIndexer, *configapi.Configuration) (framework.Plugin, error) {
+					return &fakeTerminalCleanupPlugin{err: nil}, nil
+				},
+			},
+			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").Obj(),
+		},
+		"terminal cleanup plugin fails": {
+			registry: fwkplugins.Registry{
+				fakeTerminalCleanupPluginName: func(context.Context, client.Client, client.FieldIndexer, *configapi.Configuration) (framework.Plugin, error) {
+					return &fakeTerminalCleanupPlugin{err: errCleanupFailed}, nil
+				},
+			},
+			trainJob:  testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").Obj(),
+			wantError: errCleanupFailed,
+		},
+		"empty registry": {
+			registry: fwkplugins.Registry{},
+			trainJob: testingutil.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").Obj(),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			var cancel func()
+			ctx, cancel = context.WithCancel(ctx)
+			t.Cleanup(cancel)
+			cliBuilder := testingutil.NewClientBuilder()
+			fwk, err := New(ctx, cliBuilder.Build(), tc.registry, testingutil.AsIndex(cliBuilder), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = fwk.RunTerminalCleanupPlugins(ctx, tc.trainJob)
+			if diff := cmp.Diff(tc.wantError, err, cmpopts.EquateErrors()); len(diff) != 0 {
+				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+

--- a/pkg/runtime/framework/interface.go
+++ b/pkg/runtime/framework/interface.go
@@ -82,3 +82,10 @@ type TrainJobStatusPlugin interface {
 	Plugin
 	Status(ctx context.Context, trainJob *trainer.TrainJob) (*trainer.TrainJobStatus, error)
 }
+
+// TerminalCleanupPlugin cleans up auxiliary or side resources associated with a TrainJob
+// when it reaches a terminal condition (such as Failed).
+type TerminalCleanupPlugin interface {
+	Plugin
+	TerminalCleanup(ctx context.Context, trainJob *trainer.TrainJob) error
+}

--- a/pkg/runtime/framework/plugins/volcano/volcano.go
+++ b/pkg/runtime/framework/plugins/volcano/volcano.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -65,10 +66,11 @@ type Volcano struct {
 var _ framework.EnforcePodGroupPolicyPlugin = (*Volcano)(nil)
 var _ framework.ComponentBuilderPlugin = (*Volcano)(nil)
 var _ framework.WatchExtensionPlugin = (*Volcano)(nil)
+var _ framework.TerminalCleanupPlugin = (*Volcano)(nil)
 
 const Name = "Volcano"
 
-// +kubebuilder:rbac:groups=scheduling.volcano.sh,resources=podgroups,verbs=create;get;list;watch;update;patch
+// +kubebuilder:rbac:groups=scheduling.volcano.sh,resources=podgroups,verbs=create;get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=node.k8s.io,resources=runtimeclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=limitranges,verbs=get;list;watch
 
@@ -209,6 +211,20 @@ func (v *Volcano) Build(ctx context.Context, info *runtime.Info, trainJob *train
 		WithBlockOwnerDeletion(true))
 
 	return []apiruntime.ApplyConfiguration{pg}, nil
+}
+
+func (v *Volcano) TerminalCleanup(ctx context.Context, trainJob *trainer.TrainJob) error {
+	if trainJob == nil || !meta.IsStatusConditionTrue(trainJob.Status.Conditions, trainer.TrainJobFailed) {
+		return nil
+	}
+	podGroup := &volcanov1beta1.PodGroup{}
+	if err := v.client.Get(ctx, client.ObjectKeyFromObject(trainJob), podGroup); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	if metav1.IsControlledBy(podGroup, trainJob) {
+		return client.IgnoreNotFound(v.client.Delete(ctx, podGroup))
+	}
+	return nil
 }
 
 type PodGroupRuntimeClassHandler struct {

--- a/pkg/runtime/framework/plugins/volcano/volcano_test.go
+++ b/pkg/runtime/framework/plugins/volcano/volcano_test.go
@@ -28,6 +28,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
@@ -524,3 +525,129 @@ func TestValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestVolcano_TerminalCleanup(t *testing.T) {
+	trainJob := utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+		UID("test-uid").
+		Obj()
+
+	failedTrainJob := utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+		UID("test-uid").
+		Obj()
+	failedTrainJob.Status.Conditions = []metav1.Condition{
+		{
+			Type:   trainer.TrainJobFailed,
+			Status: metav1.ConditionTrue,
+		},
+	}
+
+	completeTrainJob := utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-job").
+		UID("test-uid").
+		Obj()
+	completeTrainJob.Status.Conditions = []metav1.Condition{
+		{
+			Type:   trainer.TrainJobComplete,
+			Status: metav1.ConditionTrue,
+		},
+	}
+
+	controlledPodGroup := &volcanov1beta1.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: metav1.NamespaceDefault,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: trainer.GroupVersion.String(),
+					Kind:       trainer.TrainJobKind,
+					Name:       "test-job",
+					UID:        "test-uid",
+					Controller: ptr.To(true),
+				},
+			},
+		},
+	}
+
+	uncontrolledPodGroup := &volcanov1beta1.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-job",
+			Namespace: metav1.NamespaceDefault,
+		},
+	}
+
+	cases := map[string]struct {
+		trainJob     *trainer.TrainJob
+		existingObjs []client.Object
+		wantDeleted  bool
+		wantErr      error
+	}{
+		"trainjob is nil": {
+			trainJob: nil,
+		},
+		"trainjob is not failed (no conditions)": {
+			trainJob:     trainJob,
+			existingObjs: []client.Object{controlledPodGroup},
+			wantDeleted:  false,
+		},
+		"trainjob is complete (not failed)": {
+			trainJob:     completeTrainJob,
+			existingObjs: []client.Object{controlledPodGroup},
+			wantDeleted:  false,
+		},
+		"trainjob is failed but podgroup does not exist": {
+			trainJob:     failedTrainJob,
+			existingObjs: nil,
+			wantDeleted:  false,
+		},
+		"trainjob is failed and podgroup exists and is controlled": {
+			trainJob:     failedTrainJob,
+			existingObjs: []client.Object{controlledPodGroup.DeepCopy()},
+			wantDeleted:  true,
+		},
+		"trainjob is failed but podgroup is not controlled by trainjob": {
+			trainJob:     failedTrainJob,
+			existingObjs: []client.Object{uncontrolledPodGroup.DeepCopy()},
+			wantDeleted:  false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			t.Cleanup(cancel)
+
+			clientBuilder := utiltesting.NewClientBuilder().WithObjects(tc.existingObjs...)
+			cli := clientBuilder.Build()
+
+			v, err := New(ctx, cli, nil, nil)
+			if err != nil {
+				t.Fatalf("failed to init Volcano plugin: %v", err)
+			}
+
+			cleanupPlugin, ok := v.(framework.TerminalCleanupPlugin)
+			if !ok {
+				t.Fatalf("Volcano does not implement framework.TerminalCleanupPlugin")
+			}
+
+			err = cleanupPlugin.TerminalCleanup(ctx, tc.trainJob)
+			if diff := gocmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+			}
+
+			if tc.trainJob != nil {
+				var pg volcanov1beta1.PodGroup
+				getErr := cli.Get(ctx, client.ObjectKey{Namespace: tc.trainJob.Namespace, Name: tc.trainJob.Name}, &pg)
+				if tc.wantDeleted {
+					if !apierrors.IsNotFound(getErr) {
+						t.Errorf("expected PodGroup to be deleted, got err: %v", getErr)
+					}
+				} else if len(tc.existingObjs) > 0 {
+					if getErr != nil {
+						t.Errorf("expected PodGroup to still exist, got err: %v", getErr)
+					}
+				}
+			}
+		})
+	}
+}
+

--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -37,4 +37,5 @@ type Runtime interface {
 	TrainJobStatus(ctx context.Context, trainJob *trainer.TrainJob) (*trainer.TrainJobStatus, error)
 	EventHandlerRegistrars() []ReconcilerBuilder
 	ValidateObjects(ctx context.Context, old, new *trainer.TrainJob) (admission.Warnings, field.ErrorList)
+	TerminalCleanup(ctx context.Context, trainJob *trainer.TrainJob) error
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When a Volcano-scheduled TrainJob transitions to the `Failed` condition (or reaches a terminal state), its associated `scheduling.volcano.sh/v1beta1 PodGroup` object was never deleted or cleaned up. Consequently, orphaned PodGroups remained in the cluster indefinitely, reserving `minResources` in Volcano scheduler queues and starving pending jobs.

This PR addresses the issue cleanly and modularly:
1. **Runtime Framework Extensibility:** Introduced the `TerminalCleanupPlugin` interface (`TerminalCleanup(ctx, trainJob) error`) in `pkg/runtime/framework` so schedulers can clean up gang-scheduling resources on job completion without polluting the reconciler with vendor-specific logic.
2. **Volcano Plugin Implementation:** Implemented `TerminalCleanup` in the Volcano plugin (`pkg/runtime/framework/plugins/volcano`). It looks up the PodGroup corresponding to the TrainJob, validates ownership via `metav1.IsControlledBy(podGroup, trainJob)`, and deletes it idempotently (`client.IgnoreNotFound`).
3. **Controller Lifecycle Integration:** Invoked `r.Runtime.TerminalCleanup(ctx, &trainJob)` in `TrainJobReconciler.Reconcile()` once `trainjob.IsTrainJobFinished(&trainJob)` is true.
4. **RBAC Updates:** Added `delete` verb for `scheduling.volcano.sh/podgroups` in RBAC role definitions (`manifests/base/rbac/role.yaml` and `charts/kubeflow-trainer/templates/rbac/clusterrole.yaml`).
5. **Unit Tests:** Added extensive unit tests across the Volcano plugin (`TestVolcano_TerminalCleanup` covering 6 test cases), Framework core (`TestRunTerminalCleanupPlugins`), and TrainJob reconciler (`TestReconcile_TerminalCleanup` verifying terminal cleanup on Failed and Complete jobs).

**Which issue(s) this PR fixes**:
Fixes #4033

**Checklist:**

- [x] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing (internal controller gang-scheduling cleanup; no user-facing API schema changes)

/assign @kuizhiqing @robert-bell
/cc @kuizhiqing @robert-bell
