### PR TITLE
fix(runtime): Apply trainer overrides to all node containers

### DIFF
--- a/pkg/runtime/framework/plugins/jobset/builder.go
+++ b/pkg/runtime/framework/plugins/jobset/builder.go
@@ -122,13 +122,19 @@ func (b *Builder) Trainer(info *runtime.Info, trainJob *trainer.TrainJob) *Build
 			// REF: https://github.com/kubeflow/trainer/issues/2318
 			b.Spec.ReplicatedJobs[i].Replicas = ptr.To[int32](1)
 			// Update values for the Trainer container.
-			for j, container := range rJob.Template.Spec.Template.Spec.Containers {
-				if *container.Name == constants.Node {
-					// Update values from the TrainJob trainer.
-					if jobTrainer := trainJob.Spec.Trainer; jobTrainer != nil {
-						if image := jobTrainer.Image; image != nil {
-							b.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.Containers[j].Image = image
-						}
+		}
+
+		for j, container := range rJob.Template.Spec.Template.Spec.Containers {
+			if *container.Name != constants.Node {
+				continue
+			}
+			// Update values from the TrainJob trainer.
+			if ancestor == constants.AncestorTrainer || ancestor == "" {
+				if jobTrainer := trainJob.Spec.Trainer; jobTrainer != nil {
+					if image := jobTrainer.Image; image != nil {
+						b.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.Containers[j].Image = image
+					}
+					if ancestor == constants.AncestorTrainer {
 						if command := jobTrainer.Command; command != nil {
 							b.Spec.ReplicatedJobs[i].Template.Spec.Template.Spec.Containers[j].Command = command
 						}

--- a/pkg/runtime/framework/plugins/jobset/builder_test.go
+++ b/pkg/runtime/framework/plugins/jobset/builder_test.go
@@ -478,6 +478,48 @@ func TestBuilderTrainer(t *testing.T) {
 				},
 			},
 		},
+		"MPI worker node receives Image but not Command without ancestor label": {
+			jobSet: makeJobSet("", constants.Node, 4, "worker"),
+			trainJob: &trainer.TrainJob{
+				Spec: trainer.TrainJobSpec{
+					Trainer: &trainer.Trainer{
+						Image:   ptr.To("docker.io/my-org/train:latest"),
+						Command: []string{"torchrun", "--nproc_per_node=4"},
+						Args:    []string{"train.py", "--epochs=10"},
+					},
+				},
+			},
+			info: &runtime.Info{},
+			wantJobSet: &jobsetv1alpha2ac.JobSetApplyConfiguration{
+				Spec: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{
+					ReplicatedJobs: []jobsetv1alpha2ac.ReplicatedJobApplyConfiguration{
+						{
+							Template: &batchv1ac.JobTemplateSpecApplyConfiguration{
+								Spec: &batchv1ac.JobSpecApplyConfiguration{
+									Template: &corev1ac.PodTemplateSpecApplyConfiguration{
+										Spec: &corev1ac.PodSpecApplyConfiguration{
+											Containers: []corev1ac.ContainerApplyConfiguration{
+												{
+													Name:  ptr.To(constants.Node),
+													Image: ptr.To("docker.io/my-org/train:latest"),
+												},
+											},
+										},
+									},
+								},
+								ObjectMetaApplyConfiguration: &metav1ac.ObjectMetaApplyConfiguration{
+									Labels: map[string]string{
+										constants.LabelTrainJobAncestor: "",
+									},
+								},
+							},
+							Name:     ptr.To("worker"),
+							Replicas: ptr.To[int32](4),
+						},
+					},
+				},
+			},
+		},
 		"trainer ancestor merges Trainer.Env and upserts duplicate container env keys": {
 			jobSet: &jobsetv1alpha2ac.JobSetApplyConfiguration{
 				Spec: &jobsetv1alpha2ac.JobSetSpecApplyConfiguration{


### PR DESCRIPTION
**What this PR does / why we need it**:

- The TrainJob Image is now applied to any container named node where the ancestor label is either trainer or empty (which applies to the MPI worker).

- The TrainJob Command and Args are strictly applied only if the ancestor label is trainer (the Launcher).


**Which issue(s) this PR fixes** 
Fixes #4030

**Checklist:**

- [x] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing
