### PR TITLE
fix(cache): migrate data cache image to Debian bookworm

### DIFF
--- a/cmd/data_cache/Dockerfile
+++ b/cmd/data_cache/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust:1.98-bullseye AS builder
+FROM rust:1.98-bookworm AS builder
 
 WORKDIR /workspace
 
@@ -20,7 +20,7 @@ ENV RUST_LOG=info
 
 # Install system dependencies
 RUN apt-get update && \
-    apt-get -y install libssl-dev openssl zlib1g zlib1g-dev libpq-dev cmake protobuf-compiler netcat curl && \
+    apt-get -y install libssl-dev openssl zlib1g zlib1g-dev libpq-dev cmake protobuf-compiler netcat-openbsd curl && \
     rm -rf /var/lib/apt/lists/*
 
 # Install cargo-chef for better caching


### PR DESCRIPTION
Debian 11 (bullseye) hit LTS EOL on 2026-08-31 and its bullseye-security
Release file expired on 2026-09-07, so `apt-get update` now fails in the
data cache builder stage and the image build has been red on every PR since.
This moves the builder to bookworm, which also aligns it with the glibc of
the existing `debian:bookworm-slim` runtime stage.

_This PR was created using AI tools._