### PR TITLE
fix(runtimes): guard nil NumProcPerNode dereference in Flux plugin

### DIFF
--- a/pkg/runtime/framework/plugins/flux/flux.go
+++ b/pkg/runtime/framework/plugins/flux/flux.go
@@ -416,7 +416,10 @@ func (f *Flux) generateFluxEntrypoint(trainJob *trainer.TrainJob, info *runtime.
 	if jobTrainer := trainJob.Spec.Trainer; jobTrainer != nil && jobTrainer.NumProcPerNode != nil {
 		tasks = *jobTrainer.NumProcPerNode
 	} else {
-		tasks = *info.RuntimePolicy.MLPolicySource.Flux.NumProcPerNode
+		// NumProcPerNode defaults to 1 via the FluxMLPolicySource CRD schema, but that default
+		// is only applied by the API server. Objects built without going through it (unit
+		// tests, or a runtime read before the default existed) may still have it unset.
+		tasks = ptr.Deref(info.RuntimePolicy.MLPolicySource.Flux.NumProcPerNode, 1)
 	}
 	flags = fmt.Sprintf("-N %d -n %d", numNodes, tasks*numNodes)
 

--- a/pkg/runtime/framework/plugins/flux/flux_test.go
+++ b/pkg/runtime/framework/plugins/flux/flux_test.go
@@ -525,6 +525,11 @@ func TestOptionalTrainerFields(t *testing.T) {
 	cases := map[string]struct {
 		podSetCount int32
 		jobTrainer  *trainer.Trainer
+		// runtimeNumProcPerNode defaults to ptr.To[int32](1) when nil, matching the
+		// FluxMLPolicySource CRD default. Set explicitly to nil to test a runtime
+		// template that was never defaulted (e.g. built without going through the
+		// API server).
+		runtimeNumProcPerNode *int32
 		// wantCommand is only asserted when set.
 		wantCommand []string
 		wantFlags   string
@@ -533,16 +538,18 @@ func TestOptionalTrainerFields(t *testing.T) {
 		wantHostlist  string
 	}{
 		"trainer is not set": {
-			podSetCount:  3,
-			wantCommand:  []string{"/bin/bash", "/etc/flux-config/entrypoint.sh", "python train.py"},
-			wantFlags:    "-N 3 -n 3",
-			wantHostlist: "test-job-node-0-[0-2]",
+			podSetCount:           3,
+			runtimeNumProcPerNode: ptr.To[int32](1),
+			wantCommand:           []string{"/bin/bash", "/etc/flux-config/entrypoint.sh", "python train.py"},
+			wantFlags:             "-N 3 -n 3",
+			wantHostlist:          "test-job-node-0-[0-2]",
 		},
 		"num nodes is not set": {
-			podSetCount:  2,
-			jobTrainer:   utiltesting.MakeTrainJobTrainerWrapper().Container("image", []string{"python", "train.py"}, nil, nil).Obj(),
-			wantFlags:    "-N 2 -n 2",
-			wantHostlist: "test-job-node-0-[0-1]",
+			podSetCount:           2,
+			jobTrainer:            utiltesting.MakeTrainJobTrainerWrapper().Container("image", []string{"python", "train.py"}, nil, nil).Obj(),
+			runtimeNumProcPerNode: ptr.To[int32](1),
+			wantFlags:             "-N 2 -n 2",
+			wantHostlist:          "test-job-node-0-[0-1]",
 		},
 		"env and num proc per node from the TrainJob are applied": {
 			podSetCount: 3,
@@ -550,9 +557,19 @@ func TestOptionalTrainerFields(t *testing.T) {
 				NumProcPerNode(2).
 				Env(corev1.EnvVar{Name: "FLUX_VIEW_IMAGE", Value: "example.com/flux-view:test"}).
 				Obj(),
-			wantFlags:     "-N 3 -n 6",
-			wantViewImage: "example.com/flux-view:test",
-			wantHostlist:  "test-job-node-0-[0-2]",
+			runtimeNumProcPerNode: ptr.To[int32](1),
+			wantFlags:             "-N 3 -n 6",
+			wantViewImage:         "example.com/flux-view:test",
+			wantHostlist:          "test-job-node-0-[0-2]",
+		},
+		// Regression test: a runtime template built without going through API server
+		// defaulting (e.g. constructed directly, as in this test) leaves NumProcPerNode
+		// nil. generateFluxEntrypoint must fall back to the documented default of 1
+		// instead of dereferencing the nil pointer.
+		"runtime num proc per node is not set": {
+			podSetCount:  2,
+			wantFlags:    "-N 2 -n 2",
+			wantHostlist: "test-job-node-0-[0-1]",
 		},
 	}
 
@@ -569,7 +586,7 @@ func TestOptionalTrainerFields(t *testing.T) {
 				RuntimePolicy: runtime.RuntimePolicy{
 					MLPolicySource: &trainer.MLPolicySource{
 						Flux: &trainer.FluxMLPolicySource{
-							NumProcPerNode: ptr.To[int32](1),
+							NumProcPerNode: tc.runtimeNumProcPerNode,
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

`generateFluxEntrypoint` in `pkg/runtime/framework/plugins/flux/flux.go` unconditionally dereferenced `info.RuntimePolicy.MLPolicySource.Flux.NumProcPerNode`. That field carries a `+kubebuilder:default=1` CRD marker, but that default is only applied by the API server; objects constructed without going through it (unit tests, or a runtime snapshot read before the default existed) leave the field nil, causing a nil pointer dereference panic.

This PR replaces the bare dereference with `ptr.Deref(..., 1)` so the code falls back to the documented default of 1 when the field is unset, and adds a regression test case ("runtime num proc per node is not set") to `TestOptionalTrainerFields` that reproduces the panic before the fix and passes cleanly after it.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #4053

**Checklist:**

- [x] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing — not applicable, this is an internal bug fix with no user-facing behavior or API change.

Note: This contribution was developed with AI assistance (Claude), in accordance with the Kubeflow AI Policy.
