### PR TITLE
fix(cache): correct IndexableMemTable index arithmetic

### DIFF
--- a/pkg/data_cache/src/worker/indexable_mem_table.rs
+++ b/pkg/data_cache/src/worker/indexable_mem_table.rs
@@ -79,6 +79,16 @@ impl IndexableMemTable {
         let _ = stream
             .map_ok(|batch| {
                 let num_rows = batch.num_rows() as u64;
+
+                // A scan can yield an empty batch, for example when every row of a
+                // data file is dropped by an Iceberg delete file. An empty batch owns
+                // no rows and so has no index range: recording one would underflow
+                // `current_end` and leave the index vectors unsorted, which breaks the
+                // binary searches in `fetch_partitions`.
+                if num_rows == 0 {
+                    return;
+                }
+
                 let current_end = current_start + num_rows - 1;
 
                 start_indices.push(current_start);
@@ -117,10 +127,16 @@ async fn fetch_partitions(
         return vec![];
     }
 
+    // Find the number of batches that start at or before the query end
+    let starting_within_range = start_indices.partition_point(|&batch_start| batch_start <= end);
+
+    // If no batch starts at or before the query end, no overlap
+    if starting_within_range == 0 {
+        return vec![];
+    }
+
     // Find LAST batch where batch_start <= end
-    let last = start_indices
-        .partition_point(|&batch_start| batch_start <= end)
-        .saturating_sub(1);
+    let last = starting_within_range - 1;
 
     // Verify we have valid range
     if first > last {
@@ -404,6 +420,70 @@ mod tests {
         let result = fetch_partitions(batches, &[0, 4], &[3, 7], 2, 5).await;
 
         assert_eq!(result.len(), 2, "Expected both batches for boundary query");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_load_skips_leading_empty_batch() -> Result<(), Box<dyn std::error::Error>> {
+        let schema = create_schema();
+        let mut batches = vec![RecordBatch::new_empty(schema.clone())];
+        batches.extend(create_test_batches()?);
+
+        let ctx = SessionContext::new();
+        let mem_table = MemTable::try_new(schema.clone(), vec![batches])?;
+        let table = IndexableMemTable::load(Arc::new(mem_table), None, &ctx.state(), 0).await?;
+
+        assert_eq!(table.batches.len(), 2, "empty batch should not be indexed");
+        assert_eq!(table.start_indices, vec![0, 4]);
+        assert_eq!(table.end_indices, vec![3, 7]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_load_skips_interleaved_empty_batch() -> Result<(), Box<dyn std::error::Error>> {
+        let schema = create_schema();
+        let populated = create_test_batches()?;
+        let batches = vec![
+            populated[0].clone(),
+            RecordBatch::new_empty(schema.clone()),
+            populated[1].clone(),
+        ];
+
+        let ctx = SessionContext::new();
+        let mem_table = MemTable::try_new(schema.clone(), vec![batches])?;
+        let table = IndexableMemTable::load(Arc::new(mem_table), None, &ctx.state(), 10).await?;
+
+        assert_eq!(table.batches.len(), 2, "empty batch should not be indexed");
+        assert_eq!(table.start_indices, vec![10, 14]);
+        assert_eq!(table.end_indices, vec![13, 17]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_fetch_partitions_query_below_all_batches()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Batches hold global rows 10-13 and 14-17, the query asks for rows 0-5.
+        let batches = create_test_batches()?;
+        let result = fetch_partitions(batches, &[10, 14], &[13, 17], 0, 5).await;
+
+        assert!(
+            result.is_empty(),
+            "a query below every batch must not select any batch"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_fetch_partitions_query_above_all_batches()
+    -> Result<(), Box<dyn std::error::Error>> {
+        // Batches hold global rows 10-13 and 14-17, the query asks for rows 20-25.
+        let batches = create_test_batches()?;
+        let result = fetch_partitions(batches, &[10, 14], &[13, 17], 20, 25).await;
+
+        assert!(
+            result.is_empty(),
+            "a query above every batch must not select any batch"
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes two index-arithmetic defects in `IndexableMemTable`.

**`load` underflowed on an empty batch.** Each batch's inclusive end index was computed as `current_start + num_rows - 1`. A scan that yields an empty batch makes that expression underflow: with overflow checks on it panics, and in the `--release` build the image ships (`cmd/data_cache/Dockerfile:42`) it wraps to `u64::MAX`, `current_start` wraps back to 0, and `end_indices` is left unsorted:

```
debug   -> panicked at 'attempt to subtract with overflow'
release -> start_indices = [0, 0, 4]
           end_indices   = [18446744073709551615, 3, 7]
```

`fetch_partitions` binary searches those vectors with `partition_point`, so once they are unsorted the worker serves arbitrary row ranges with no error anywhere. An empty batch owns no rows, so it is now skipped instead of being given an index range. Empty batches do reach this loop — `RowNumberStream` passes them straight through (`worker_datasource.rs:481-499`), and Iceberg delete-file filtering can empty a batch.

**`fetch_partitions` could return a batch that does not overlap the query.** The last matching batch was derived with `partition_point(..).saturating_sub(1)`. When no batch starts at or below `end`, `partition_point` returns 0 and the clamp turns that into "batch 0 qualifies", so the `first > last` guard passes and batch 0 is returned even though it lies entirely outside the requested range. Because `supports_filters_pushdown` reports `Inexact`, DataFusion still discards the extra rows today, so the cost is wasted work rather than wrong results — but that stops holding as soon as pushdown is tightened to `Exact`. The function now returns no batches when nothing starts at or below the query end.

Four regression tests are added, each of which fails on `master`:

- `test_load_skips_leading_empty_batch`
- `test_load_skips_interleaved_empty_batch`
- `test_fetch_partitions_query_below_all_batches`
- `test_fetch_partitions_query_above_all_batches`

Verified with `cargo test --lib --bins --manifest-path ./pkg/data_cache/Cargo.toml` (21 passed) and `cargo fmt -- --check`.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #4056

**Checklist:**

- [x] Docs included if any changes are user facing
