### PR TITLE
fix(cache): give workers with no data files a readiness path

### DIFF
--- a/pkg/data_cache/src/head/head.rs
+++ b/pkg/data_cache/src/head/head.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::config::config::CacheConfig;
-use crate::head::provider::DataFileTableProvider;
-use crate::head::writer::DistributedWriterExec;
+use crate::head::provider::{DataFileTableProvider, empty_assignment};
+use crate::head::writer::{DistributedWriterExec, ExecutorClient};
 use arrow::array::UInt64Array;
 use arrow_schema::SchemaRef;
 use datafusion::datasource::MemTable;
@@ -25,7 +25,7 @@ use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::prelude::SessionContext;
 use datafusion::sql::TableReference;
 use futures::StreamExt;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tracing::{error, info};
 
@@ -168,6 +168,52 @@ impl Distributor {
         let _ = execute_stream(Arc::new(plan), self.ctx.task_ctx())?
             .collect::<Vec<_>>()
             .await;
+        self.assign_empty_partitions().await?;
+        Ok(())
+    }
+
+    /// Sends an empty assignment to every worker that was given no data files.
+    ///
+    /// `distribute_data_files` routes each assignment by the `worker_ids` column of
+    /// the batch that carries it, so a worker that holds no data files is never a
+    /// destination. Such a worker never handles a `do_put`, never registers its
+    /// memtable and therefore fails its readiness probe for the lifetime of the pod,
+    /// which keeps the LeaderWorkerSet from ever becoming available. Telling it
+    /// explicitly that it owns nothing lets it register an empty memtable and report
+    /// ready.
+    async fn assign_empty_partitions(&self) -> Result<()> {
+        let batches = self
+            .ctx
+            .sql(&format!("SELECT worker_ids FROM {}", self.mem_table_name))
+            .await?
+            .collect()
+            .await?;
+
+        let mut assigned: HashSet<u64> = HashSet::new();
+        for batch in &batches {
+            let worker_ids = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .ok_or_else(|| {
+                    DataFusionError::Execution("Failed to downcast to UInt64Array".to_string())
+                })?;
+            assigned.extend(worker_ids.values().iter().copied());
+        }
+
+        for worker_id in 0..self.num_workers as u64 {
+            if assigned.contains(&worker_id) {
+                continue;
+            }
+            info!("Worker {worker_id} was assigned no data files, sending empty assignment");
+
+            let addr = self.worker_map.get(&worker_id.to_string()).ok_or_else(|| {
+                DataFusionError::Execution(format!("Worker {} not found in worker map", worker_id))
+            })?;
+            let batch = empty_assignment(worker_id, self.total_row_count)?;
+            let mut client = ExecutorClient::try_new(addr, self.config.connect_timeout).await?;
+            client.send_batch(batch.schema(), vec![Ok(batch)]).await?;
+        }
         Ok(())
     }
 }

--- a/pkg/data_cache/src/head/provider.rs
+++ b/pkg/data_cache/src/head/provider.rs
@@ -318,6 +318,17 @@ impl RecordBatchBuilder {
         Ok(())
     }
 
+    /// Records an assignment for a worker that was given no data files.
+    ///
+    /// The row carries an empty file list and a degenerate row range, so the
+    /// worker loads an empty memtable and claims no rows.
+    fn add_empty_task(&mut self, index: usize, start_index: u64) {
+        self.file_paths.push(Vec::new());
+        self.row_start_indexes.push(start_index);
+        self.row_end_indexes.push(start_index);
+        self.worker_ids.push(index as u64);
+    }
+
     fn build(self) -> Result<RecordBatch> {
         let worker_ids: ArrayRef = Arc::new(UInt64Array::from(self.worker_ids));
         let row_start_indexes: ArrayRef = Arc::new(UInt64Array::from(self.row_start_indexes));
@@ -345,6 +356,22 @@ impl RecordBatchBuilder {
         ])?;
         Ok(rb)
     }
+}
+
+/// Builds the assignment RecordBatch for a worker that was given no data files.
+///
+/// `partition_tasks` balances the table's data files across all workers, so a table
+/// with fewer data files than the cache has workers leaves the surplus workers
+/// without an assignment. A worker registers its memtable only while handling a
+/// `do_put`, so it has to be told that it owns nothing; otherwise its readiness
+/// probe fails for the lifetime of the pod.
+///
+/// `start_index` is the first row index past the end of the cached data, which
+/// gives the worker a range that matches no row.
+pub(crate) fn empty_assignment(worker_id: u64, start_index: u64) -> Result<RecordBatch> {
+    let mut builder = RecordBatchBuilder::new();
+    builder.add_empty_task(worker_id as usize, start_index);
+    builder.build()
 }
 
 /// Groups of file scan tasks assigned to a specific worker node in the distributed system.
@@ -418,12 +445,15 @@ async fn partition_tasks(
         groups[min_group_index].tasks.push(task);
     }
 
-    let mut end = 0;
-    for (i, elem) in groups.iter_mut().enumerate() {
-        let start = end;
-        end += group_sizes[i];
-        elem.start_index = start;
-        elem.end_index = if end > 0 { end - 1 } else { 0 };
+    let mut next_start = 0;
+    for (group, group_size) in groups.iter_mut().zip(group_sizes.iter()) {
+        group.start_index = next_start;
+        // `end_index` is inclusive, so a group that was assigned no rows cannot be
+        // described by `next_start - 1`: that places `end_index` one below
+        // `start_index`. Such a group keeps a degenerate `start_index == end_index`
+        // range and is identified by its empty task list.
+        group.end_index = next_start + group_size.saturating_sub(1);
+        next_start += group_size;
     }
     Ok(Arc::new(groups))
 }
@@ -431,8 +461,10 @@ async fn partition_tasks(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::ListArray;
     use arrow::datatypes::{DataType, Field, Schema};
     use datafusion::prelude::SessionContext;
+    use futures::TryStreamExt;
     use iceberg::spec::DataFileFormat;
 
     fn create_test_schema() -> SchemaRef {
@@ -649,5 +681,98 @@ mod tests {
         }
 
         Ok(())
+    }
+    #[tokio::test]
+    async fn test_partition_tasks_with_fewer_files_than_workers()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use futures::stream;
+
+        // Two data files spread over three workers leaves the third worker empty.
+        let tasks = vec![
+            create_test_file_scan_task_with_record_count(100, "/test/file1.parquet"),
+            create_test_file_scan_task_with_record_count(50, "/test/file2.parquet"),
+        ];
+        let stream = stream::iter(tasks.into_iter().map(Ok));
+        let result = partition_tasks(Box::pin(stream), 3).await?;
+
+        assert_eq!(result.len(), 3);
+        for (worker, group) in result.iter().enumerate() {
+            assert!(
+                group.start_index <= group.end_index,
+                "worker {} got an inverted range: start_index={} end_index={}",
+                worker,
+                group.start_index,
+                group.end_index
+            );
+        }
+
+        assert_eq!((result[0].start_index, result[0].end_index), (0, 99));
+        assert_eq!((result[1].start_index, result[1].end_index), (100, 149));
+
+        // The empty group keeps a degenerate range one past the end of the data.
+        assert!(result[2].tasks.is_empty());
+        assert_eq!((result[2].start_index, result[2].end_index), (150, 150));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_empty_group_produces_no_assignment_row() -> Result<(), Box<dyn std::error::Error>>
+    {
+        use futures::stream;
+
+        let tasks = vec![create_test_file_scan_task_with_record_count(
+            100,
+            "/test/file1.parquet",
+        )];
+        let stream = stream::iter(tasks.into_iter().map(Ok));
+        let groups = partition_tasks(Box::pin(stream), 2).await?;
+
+        let exec = DataFileTableExec::new(create_test_schema(), groups);
+        let ctx = SessionContext::new();
+
+        // The worker that holds data is routed to by its `worker_ids` row, the other
+        // one produces an empty batch and is handled by `assign_empty_partitions`.
+        let assigned: Vec<RecordBatch> = exec
+            .execute(0, ctx.task_ctx())?
+            .try_collect::<Vec<_>>()
+            .await?;
+        assert_eq!(assigned.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+
+        let unassigned: Vec<RecordBatch> = exec
+            .execute(1, ctx.task_ctx())?
+            .try_collect::<Vec<_>>()
+            .await?;
+        assert_eq!(unassigned.iter().map(|b| b.num_rows()).sum::<usize>(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_assignment_carries_worker_id_and_no_files() -> Result<(), DataFusionError> {
+        let batch = empty_assignment(2, 150)?;
+
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(column_values(&batch, "worker_ids")?, vec![2]);
+        assert_eq!(column_values(&batch, "row_start_indexes")?, vec![150]);
+        assert_eq!(column_values(&batch, "row_end_indexes")?, vec![150]);
+
+        let file_paths = batch
+            .column_by_name("file_paths")
+            .expect("file_paths column")
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("file_paths is a ListArray");
+        assert_eq!(file_paths.value_length(0), 0, "no files should be assigned");
+        Ok(())
+    }
+
+    fn column_values(batch: &RecordBatch, name: &str) -> Result<Vec<u64>, DataFusionError> {
+        Ok(batch
+            .column_by_name(name)
+            .ok_or_else(|| DataFusionError::Execution(format!("{name} column not found")))?
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .ok_or_else(|| DataFusionError::Execution("Failed to downcast".to_string()))?
+            .values()
+            .to_vec())
     }
 }

--- a/pkg/data_cache/src/head/writer.rs
+++ b/pkg/data_cache/src/head/writer.rs
@@ -222,6 +222,12 @@ pub async fn send_record_batch(
     while let Some(item) = stream.next().await {
         match item {
             Ok(rb) => {
+                // A worker that was assigned no data files produces an empty batch,
+                // which carries no worker id to route on. Those workers are told that
+                // they own nothing by `Distributor::assign_empty_partitions`.
+                if rb.num_rows() == 0 {
+                    continue;
+                }
                 info!("sending rb :{:?}", rb);
                 let worker_ids = rb.column_by_name("worker_ids").ok_or_else(|| {
                     DataFusionError::Execution("worker_ids column not found".to_string())
@@ -328,5 +334,81 @@ impl ExecutorClient {
             .await
             .map_err(|e| DataFusionError::Execution(format!("Error calling do_put: {}", e)))?;
         Ok(Box::pin(EmptyRecordBatchStream::new(schema)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::config::DatasetConfig;
+    use arrow::array::ArrayRef;
+    use arrow_schema::{Field, Schema};
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::prelude::SessionContext;
+
+    fn test_config() -> Arc<CacheConfig> {
+        Arc::new(CacheConfig {
+            dataset: DatasetConfig {
+                metadata_loc: String::new(),
+                schema_name: String::new(),
+                table_name: String::new(),
+            },
+            connect_timeout: Duration::from_secs(1),
+        })
+    }
+
+    fn assignment_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![Field::new(
+            "worker_ids",
+            DataType::UInt64,
+            false,
+        )]))
+    }
+
+    /// A worker that was assigned no data files produces an empty batch. Routing on
+    /// it used to fail the whole partition with "No worker ID found", which aborted
+    /// the stream before any batch queued behind it could be delivered.
+    #[tokio::test]
+    async fn test_send_record_batch_skips_empty_batches() -> Result<()> {
+        let schema = assignment_schema();
+        let empty = RecordBatch::new_empty(schema.clone());
+        let input = MemorySourceConfig::try_new_exec(&[vec![empty]], schema.clone(), None)?;
+
+        let ctx = SessionContext::new();
+        let stream = send_record_batch(
+            input,
+            ctx.task_ctx(),
+            0,
+            Arc::new(HashMap::new()),
+            test_config(),
+        )
+        .await?;
+
+        let batches: Vec<RecordBatch> = stream.try_collect().await?;
+        assert!(batches.is_empty());
+        Ok(())
+    }
+
+    /// A non-empty batch still has to be routed, and an unknown worker id is still
+    /// an error rather than something to skip over.
+    #[tokio::test]
+    async fn test_send_record_batch_rejects_unknown_worker() -> Result<()> {
+        let schema = assignment_schema();
+        let worker_ids: ArrayRef = Arc::new(UInt64Array::from(vec![7]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![worker_ids])?;
+        let input = MemorySourceConfig::try_new_exec(&[vec![batch]], schema.clone(), None)?;
+
+        let ctx = SessionContext::new();
+        let result = send_record_batch(
+            input,
+            ctx.task_ctx(),
+            0,
+            Arc::new(HashMap::new()),
+            test_config(),
+        )
+        .await;
+
+        assert!(result.is_err());
+        Ok(())
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

A cache cluster serving an Iceberg table that has fewer data files than it has workers never becomes ready, and the TrainJob hangs in its init container with no error. With the default `cluster_size` of `3` — one head and two workers — a table with a single data file is enough to hit this.

`partition_tasks` balances data files across every worker, so the surplus workers end up with an empty task group. `RecordBatchBuilder::add_task` skips empty groups, so those workers get no row in the head's assignment table, and `send_record_batch` routes assignments by that table's `worker_ids` column. A worker registers its memtable only while handling a `do_put`, so an unassigned worker never registers one, `check_table_ready` keeps failing on the missing table, and `/ready` returns 503 for the lifetime of the pod. The LeaderWorkerSet never reports `Available` and the dataset initializer waits on that condition forever.

This PR makes three changes:

1. **`Distributor::assign_empty_partitions`** tells every worker that received no assignment that it owns nothing, so it registers an empty memtable and reports ready. The worker path already handles an empty file list: `filter_and_create_stream` selects nothing, `load` produces no batches, and the readiness query succeeds against the empty table.
2. **`partition_tasks` no longer produces an inverted range.** `end_index` was computed as `end - 1` where `end` equals `start`, leaving `start_index` one above `end_index`. An empty group now keeps a degenerate `start_index == end_index` range. No consumer reads that range today, since the row never reaches the assignment table, but it is not a range a consumer could reason about.
3. **`send_record_batch` skips empty batches.** An empty group still produces a zero-row batch in `DataFileTableExec::execute`, and routing on it failed the whole partition with `No worker ID found`, aborting the stream before any batch queued behind it could be delivered.

The head's existing queries are deliberately untouched: the empty assignment is delivered out of band rather than added to the assignment table, so `SELECT MAX(row_end_indexes)` and the `get_workers_to_connect` overlap query keep their current semantics.

Five tests are added:

- `test_partition_tasks_with_fewer_files_than_workers` — asserts no group gets an inverted range (fails on `master`)
- `test_empty_group_produces_no_assignment_row` — pins the behaviour that motivates the out-of-band notification
- `test_empty_assignment_carries_worker_id_and_no_files`
- `test_send_record_batch_skips_empty_batches` (fails on `master`)
- `test_send_record_batch_rejects_unknown_worker` — confirms an unknown worker id is still an error rather than something to skip over

Verified with `cargo test --lib --bins --manifest-path ./pkg/data_cache/Cargo.toml` (21 passed) and `cargo fmt -- --check`. `assign_empty_partitions` itself needs a live worker to exercise end to end, so it is not covered by a unit test.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #4055

**Checklist:**

- [x] Docs included if any changes are user facing
