### PR TITLE
feat(framework): clean up Volcano PodGroup on TrainJob terminal or suspended state

### DIFF
--- a/charts/kubeflow-trainer/templates/rbac/clusterrole.yaml
+++ b/charts/kubeflow-trainer/templates/rbac/clusterrole.yaml
@@ -92,6 +92,17 @@ rules:
   - watch
 - apiGroups:
   - scheduling.volcano.sh
+  resources:
+  - podgroups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - scheduling.x-k8s.io
   resources:
   - podgroups

--- a/manifests/base/rbac/role.yaml
+++ b/manifests/base/rbac/role.yaml
@@ -101,6 +101,17 @@ rules:
   - watch
 - apiGroups:
   - scheduling.volcano.sh
+  resources:
+  - podgroups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - scheduling.x-k8s.io
   resources:
   - podgroups

--- a/pkg/controller/trainjob_controller.go
+++ b/pkg/controller/trainjob_controller.go
@@ -105,7 +105,7 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if !ok {
 		err = fmt.Errorf("unsupported runtime: %s", runtimeRefGK)
 		setFailedCondition(&trainJob, fmt.Sprintf("unsupported runtime: %s", runtimeRefGK), trainer.TrainJobRuntimeNotSupportedReason)
-	} else if !trainjob.IsTrainJobFinished(&trainJob) {
+	} else {
 		err = r.reconcileObjects(ctx, runtime, &trainJob)
 		if err != nil {
 			// TODO (astefanutti): the error should be surfaced in the TrainJob status to indicate
@@ -141,12 +141,28 @@ func (r *TrainJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 }
 
 func (r *TrainJobReconciler) reconcileObjects(ctx context.Context, runtime jobruntimes.Runtime, trainJob *trainer.TrainJob) error {
-	objects, err := runtime.NewObjects(ctx, trainJob)
+	if !trainjob.IsTrainJobFinished(trainJob) {
+		objects, err := runtime.NewObjects(ctx, trainJob)
+		if err != nil {
+			return err
+		}
+		for _, object := range objects {
+			if err := r.client.Apply(ctx, object, client.FieldOwner("trainer"), client.ForceOwnership); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Runs regardless of whether the TrainJob is finished, so that plugins can also clean
+	// up objects that outlive a suspension rather than only a terminal condition (e.g. a
+	// gang-scheduling PodGroup, which would otherwise keep reserving scheduler queue
+	// capacity for a suspended TrainJob indefinitely).
+	toDelete, err := runtime.DeleteObjects(ctx, trainJob)
 	if err != nil {
 		return err
 	}
-	for _, object := range objects {
-		if err := r.client.Apply(ctx, object, client.FieldOwner("trainer"), client.ForceOwnership); err != nil {
+	for _, object := range toDelete {
+		if err := client.IgnoreNotFound(r.client.Delete(ctx, object)); err != nil {
 			return err
 		}
 	}
@@ -173,6 +189,9 @@ func (r *TrainJobReconciler) reconcileDeadline(ctx context.Context, trainJob *tr
 			"startTime", startTime,
 			"deadline", deadline)
 		setFailedCondition(trainJob, constants.TrainJobDeadlineExceededMessage, trainer.TrainJobDeadlineExceededReason)
+		// TODO(#3833): this direct deletion predates ComponentDeleterPlugin and does not
+		// retry on transient errors; consider migrating it to a JobSet Delete()
+		// implementation once that pattern is established.
 		jobSet := &jobsetv1alpha2.JobSet{
 			ObjectMeta: metav1.ObjectMeta{Name: trainJob.Name, Namespace: trainJob.Namespace},
 		}

--- a/pkg/controller/trainjob_controller_test.go
+++ b/pkg/controller/trainjob_controller_test.go
@@ -23,16 +23,21 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2/ktesting"
 	clocktesting "k8s.io/utils/clock/testing"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	jobsetv1alpha2 "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
 	"github.com/kubeflow/trainer/v2/pkg/constants"
+	jobruntimes "github.com/kubeflow/trainer/v2/pkg/runtime"
 	utiltesting "github.com/kubeflow/trainer/v2/pkg/util/testing"
 )
 
@@ -209,6 +214,112 @@ func TestReconcileDeadline(t *testing.T) {
 				t.Errorf("Expected the child JobSet to be preserved, got error: %v", gotJobSetErr)
 			case !tc.wantJobSet && !apierrors.IsNotFound(gotJobSetErr):
 				t.Errorf("Expected the child JobSet to be absent, got error: %v", gotJobSetErr)
+			}
+		})
+	}
+}
+
+// fakeRuntime is a minimal jobruntimes.Runtime stub that records whether NewObjects and
+// DeleteObjects were invoked, without needing a real TrainingRuntime/ClusterTrainingRuntime
+// or plugin registry.
+type fakeRuntime struct {
+	objsToDelete []client.Object
+
+	newObjectsCalled    bool
+	deleteObjectsCalled bool
+}
+
+func (f *fakeRuntime) NewObjects(context.Context, *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error) {
+	f.newObjectsCalled = true
+	return nil, nil
+}
+
+func (f *fakeRuntime) DeleteObjects(context.Context, *trainer.TrainJob) ([]client.Object, error) {
+	f.deleteObjectsCalled = true
+	return f.objsToDelete, nil
+}
+
+func (f *fakeRuntime) RuntimeInfo(*trainer.TrainJob, any, *trainer.MLPolicy, *trainer.PodGroupPolicy) (*jobruntimes.Info, error) {
+	return nil, nil
+}
+
+func (f *fakeRuntime) TrainJobStatus(context.Context, *trainer.TrainJob) (*trainer.TrainJobStatus, error) {
+	return nil, nil
+}
+
+func (f *fakeRuntime) EventHandlerRegistrars() []jobruntimes.ReconcilerBuilder {
+	return nil
+}
+
+func (f *fakeRuntime) ValidateObjects(context.Context, *trainer.TrainJob, *trainer.TrainJob) (admission.Warnings, field.ErrorList) {
+	return nil, nil
+}
+
+var _ jobruntimes.Runtime = (*fakeRuntime)(nil)
+
+// TestReconcileObjects covers the branch between materializing new objects and cleaning up
+// stale ones in isolation, independently of any concrete plugin.
+func TestReconcileObjects(t *testing.T) {
+	runningTrainJob := utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-trainjob").Obj()
+	failedTrainJob := utiltesting.MakeTrainJobWrapper(metav1.NamespaceDefault, "test-trainjob").
+		Conditions(metav1.Condition{Type: trainer.TrainJobFailed, Status: metav1.ConditionTrue}).
+		Obj()
+
+	cases := map[string]struct {
+		trainJob          *trainer.TrainJob
+		objsToDelete      []client.Object
+		seedObjs          []client.Object
+		wantNewObjsCalled bool
+		wantDeleted       bool
+	}{
+		"running TrainJob still materializes new objects": {
+			trainJob:          runningTrainJob,
+			wantNewObjsCalled: true,
+		},
+		"failed TrainJob skips materializing new objects but still cleans up": {
+			trainJob: failedTrainJob,
+			objsToDelete: []client.Object{
+				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "to-delete", Namespace: metav1.NamespaceDefault}},
+			},
+			seedObjs: []client.Object{
+				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "to-delete", Namespace: metav1.NamespaceDefault}},
+			},
+			wantDeleted: true,
+		},
+		"cleanup tolerates an object that is already gone": {
+			trainJob: failedTrainJob,
+			objsToDelete: []client.Object{
+				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "already-gone", Namespace: metav1.NamespaceDefault}},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			t.Cleanup(cancel)
+
+			cli := utiltesting.NewClientBuilder().WithObjects(tc.seedObjs...).Build()
+			fr := &fakeRuntime{objsToDelete: tc.objsToDelete}
+			r := &TrainJobReconciler{client: cli}
+
+			if err := r.reconcileObjects(ctx, fr, tc.trainJob); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			// DeleteObjects must run on every call, regardless of the TrainJob's status.
+			if !fr.deleteObjectsCalled {
+				t.Error("Expected DeleteObjects to be called")
+			}
+			if fr.newObjectsCalled != tc.wantNewObjsCalled {
+				t.Errorf("NewObjects called = %v, want %v", fr.newObjectsCalled, tc.wantNewObjsCalled)
+			}
+			for _, obj := range tc.objsToDelete {
+				err := cli.Get(ctx, client.ObjectKeyFromObject(obj), &corev1.ConfigMap{})
+				if tc.wantDeleted && !apierrors.IsNotFound(err) {
+					t.Errorf("Expected %s to be deleted, got error: %v", obj.GetName(), err)
+				}
 			}
 		})
 	}

--- a/pkg/runtime/core/clustertrainingruntime.go
+++ b/pkg/runtime/core/clustertrainingruntime.go
@@ -82,6 +82,27 @@ func (r *ClusterTrainingRuntime) NewObjects(ctx context.Context, trainJob *train
 	return r.framework.RunComponentBuilderPlugins(ctx, info, trainJob)
 }
 
+// DeleteObjects mirrors TrainingRuntime.DeleteObjects but resolves a ClusterTrainingRuntime
+// instead: it cannot simply delegate to the embedded TrainingRuntime, since that would look
+// up the wrong (namespace-scoped) runtime kind.
+func (r *ClusterTrainingRuntime) DeleteObjects(ctx context.Context, trainJob *trainer.TrainJob) ([]client.Object, error) {
+	var clTrainingRuntime trainer.ClusterTrainingRuntime
+	if err := getRuntimeSnapshot(ctx, r.client, trainJob, &clTrainingRuntime); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("getting runtime snapshot: %w", err)
+		}
+		if err := r.client.Get(ctx, client.ObjectKey{Name: trainJob.Spec.RuntimeRef.Name}, &clTrainingRuntime); err != nil {
+			return nil, client.IgnoreNotFound(err)
+		}
+	}
+
+	info, err := r.RuntimeInfo(trainJob, clTrainingRuntime.Spec.Template, clTrainingRuntime.Spec.MLPolicy, clTrainingRuntime.Spec.PodGroupPolicy)
+	if err != nil {
+		return nil, err
+	}
+	return r.framework.RunComponentDeleterPlugins(ctx, info, trainJob)
+}
+
 func (r *ClusterTrainingRuntime) RuntimeInfo(
 	trainJob *trainer.TrainJob, runtimeTemplateSpec any, mlPolicy *trainer.MLPolicy, podGroupPolicy *trainer.PodGroupPolicy,
 ) (*runtime.Info, error) {

--- a/pkg/runtime/core/trainingruntime.go
+++ b/pkg/runtime/core/trainingruntime.go
@@ -112,6 +112,28 @@ func (r *TrainingRuntime) NewObjects(ctx context.Context, trainJob *trainer.Trai
 	return r.framework.RunComponentBuilderPlugins(ctx, info, trainJob)
 }
 
+// DeleteObjects returns the previously materialized objects that should now be removed
+// for the TrainJob. If the referenced TrainingRuntime can no longer be resolved (e.g. it
+// was deleted after the TrainJob finished), there is no PodGroupPolicy left to check
+// plugins against, so it returns no objects rather than an error.
+func (r *TrainingRuntime) DeleteObjects(ctx context.Context, trainJob *trainer.TrainJob) ([]client.Object, error) {
+	var trainingRuntime trainer.TrainingRuntime
+	if err := getRuntimeSnapshot(ctx, r.client, trainJob, &trainingRuntime); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("unable to get runtime snapshot: %w", err)
+		}
+		if err := r.client.Get(ctx, client.ObjectKey{Namespace: trainJob.Namespace, Name: trainJob.Spec.RuntimeRef.Name}, &trainingRuntime); err != nil {
+			return nil, client.IgnoreNotFound(err)
+		}
+	}
+
+	info, err := r.RuntimeInfo(trainJob, trainingRuntime.Spec.Template, trainingRuntime.Spec.MLPolicy, trainingRuntime.Spec.PodGroupPolicy)
+	if err != nil {
+		return nil, err
+	}
+	return r.framework.RunComponentDeleterPlugins(ctx, info, trainJob)
+}
+
 // RuntimeInfo builds the Info object for a TrainJob and consolidates it through the
 // Build Phase extension points, in this order:
 //  1. EnforceMLPolicy, then EnforcePodGroupPolicy, for the parameters declared in the

--- a/pkg/runtime/framework/core/framework.go
+++ b/pkg/runtime/framework/core/framework.go
@@ -45,6 +45,7 @@ type Framework struct {
 	watchExtensionPlugins        []framework.WatchExtensionPlugin
 	preComponentBuilderPlugins   []framework.PreComponentBuilderPlugin
 	componentBuilderPlugins      []framework.ComponentBuilderPlugin
+	componentDeleterPlugins      []framework.ComponentDeleterPlugin
 	trainJobStatusPlugin         framework.TrainJobStatusPlugin
 }
 
@@ -83,6 +84,9 @@ func New(ctx context.Context, c client.Client, r fwkplugins.Registry, indexer cl
 		}
 		if p, ok := plugin.(framework.ComponentBuilderPlugin); ok {
 			f.componentBuilderPlugins = append(f.componentBuilderPlugins, p)
+		}
+		if p, ok := plugin.(framework.ComponentDeleterPlugin); ok {
+			f.componentDeleterPlugins = append(f.componentDeleterPlugins, p)
 		}
 		if p, ok := plugin.(framework.TrainJobStatusPlugin); ok {
 			if f.trainJobStatusPlugin != nil {
@@ -164,6 +168,23 @@ func (f *Framework) RunComponentBuilderPlugins(ctx context.Context, info *runtim
 	var objs []apiruntime.ApplyConfiguration
 	for _, plugin := range f.componentBuilderPlugins {
 		components, err := plugin.Build(ctx, info, trainJob)
+		if err != nil {
+			return nil, err
+		}
+		objs = append(objs, components...)
+	}
+	return objs, nil
+}
+
+// RunComponentDeleterPlugins asks every registered ComponentDeleterPlugin which
+// previously materialized objects should now be removed for the TrainJob, and
+// aggregates their answers. It performs no deletion itself and must be safe to call on
+// every reconcile, independently of RunComponentBuilderPlugins and of the TrainJob's
+// status.
+func (f *Framework) RunComponentDeleterPlugins(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]client.Object, error) {
+	var objs []client.Object
+	for _, plugin := range f.componentDeleterPlugins {
+		components, err := plugin.Delete(ctx, info, trainJob)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/runtime/framework/core/framework_test.go
+++ b/pkg/runtime/framework/core/framework_test.go
@@ -128,6 +128,9 @@ func TestNew(t *testing.T) {
 					&jobset.JobSet{},
 					&mpi.MPI{},
 				},
+				componentDeleterPlugins: []framework.ComponentDeleterPlugin{
+					&volcano.Volcano{},
+				},
 				trainJobStatusPlugin: &jobset.JobSet{},
 			},
 		},
@@ -2276,6 +2279,97 @@ test-job-node-0-1.test-job slots=1
 			}
 
 			if diff := cmp.Diff(tc.wantObjs, resultObjs, cmpOpts...); len(diff) != 0 {
+				t.Errorf("Unexpected objects (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRunComponentDeleterPlugins(t *testing.T) {
+	ownedPodGroup := &volcanov1beta1.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-trainjob",
+			Namespace: metav1.NamespaceDefault,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         trainer.GroupVersion.String(),
+					Kind:               trainer.TrainJobKind,
+					Name:               "test-trainjob",
+					UID:                "1",
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
+		},
+	}
+	failedTrainJob := &trainer.TrainJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-trainjob", Namespace: metav1.NamespaceDefault, UID: "1"},
+		Status: trainer.TrainJobStatus{
+			Conditions: []metav1.Condition{
+				{Type: trainer.TrainJobFailed, Status: metav1.ConditionTrue},
+			},
+		},
+	}
+	runningTrainJob := &trainer.TrainJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-trainjob", Namespace: metav1.NamespaceDefault, UID: "1"},
+	}
+
+	volcanoInfo := &runtime.Info{
+		RuntimePolicy: runtime.RuntimePolicy{
+			PodGroupPolicy: &trainer.PodGroupPolicy{
+				PodGroupPolicySource: trainer.PodGroupPolicySource{
+					Volcano: &trainer.VolcanoPodGroupPolicySource{},
+				},
+			},
+		},
+	}
+
+	cases := map[string]struct {
+		registry  fwkplugins.Registry
+		info      *runtime.Info
+		objs      []client.Object
+		trainJob  *trainer.TrainJob
+		wantObjs  []client.Object
+		wantError error
+	}{
+		"empty registry returns nothing": {
+			registry: fwkplugins.Registry{},
+			info:     volcanoInfo,
+			trainJob: failedTrainJob,
+			wantObjs: nil,
+		},
+		"failed trainjob: volcano returns its PodGroup": {
+			registry: fwkplugins.NewRegistry(),
+			info:     volcanoInfo,
+			objs:     []client.Object{ownedPodGroup},
+			trainJob: failedTrainJob,
+			wantObjs: []client.Object{ownedPodGroup},
+		},
+		"running trainjob: nothing to delete": {
+			registry: fwkplugins.NewRegistry(),
+			info:     volcanoInfo,
+			objs:     []client.Object{ownedPodGroup},
+			trainJob: runningTrainJob,
+			wantObjs: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			clientBuilder := testingutil.NewClientBuilder().WithObjects(tc.objs...)
+			fwk, err := New(ctx, clientBuilder.Build(), tc.registry, testingutil.AsIndex(clientBuilder), nil)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			gotObjs, err := fwk.RunComponentDeleterPlugins(ctx, tc.info, tc.trainJob)
+			if diff := cmp.Diff(tc.wantError, err, cmpopts.EquateErrors()); len(diff) != 0 {
+				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantObjs, gotObjs, cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")); len(diff) != 0 {
 				t.Errorf("Unexpected objects (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/runtime/framework/interface.go
+++ b/pkg/runtime/framework/interface.go
@@ -21,6 +21,7 @@ import (
 
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	trainer "github.com/kubeflow/trainer/v2/pkg/apis/trainer/v1alpha1"
@@ -76,6 +77,19 @@ type PreComponentBuilderPlugin interface {
 type ComponentBuilderPlugin interface {
 	Plugin
 	Build(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]apiruntime.ApplyConfiguration, error)
+}
+
+// ComponentDeleterPlugin identifies previously materialized objects that should now be
+// removed for a TrainJob (e.g. a gang-scheduling PodGroup once the TrainJob is finished
+// or suspended, so it stops reserving scheduler queue capacity). It runs on every
+// reconcile regardless of the TrainJob's status, so implementations must decide for
+// themselves whether an object should currently exist, and must be idempotent. The
+// caller performs the actual deletion. It receives the same consolidated Info object as
+// ComponentBuilderPlugin.Build, so a plugin can check whether its policy is even enabled
+// for this TrainJob before doing any work.
+type ComponentDeleterPlugin interface {
+	Plugin
+	Delete(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]client.Object, error)
 }
 
 type TrainJobStatusPlugin interface {

--- a/pkg/runtime/framework/plugins/volcano/volcano.go
+++ b/pkg/runtime/framework/plugins/volcano/volcano.go
@@ -27,6 +27,7 @@ import (
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -53,6 +54,7 @@ import (
 	"github.com/kubeflow/trainer/v2/pkg/runtime"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/framework"
 	"github.com/kubeflow/trainer/v2/pkg/runtime/indexer"
+	"github.com/kubeflow/trainer/v2/pkg/util/trainjob"
 )
 
 type Volcano struct {
@@ -64,11 +66,12 @@ type Volcano struct {
 
 var _ framework.EnforcePodGroupPolicyPlugin = (*Volcano)(nil)
 var _ framework.ComponentBuilderPlugin = (*Volcano)(nil)
+var _ framework.ComponentDeleterPlugin = (*Volcano)(nil)
 var _ framework.WatchExtensionPlugin = (*Volcano)(nil)
 
 const Name = "Volcano"
 
-// +kubebuilder:rbac:groups=scheduling.volcano.sh,resources=podgroups,verbs=create;get;list;watch;update;patch
+// +kubebuilder:rbac:groups=scheduling.volcano.sh,resources=podgroups,verbs=create;get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=node.k8s.io,resources=runtimeclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=limitranges,verbs=get;list;watch
 
@@ -143,7 +146,17 @@ func (v *Volcano) Build(ctx context.Context, info *runtime.Info, trainJob *train
 		return nil, nil
 	}
 
-	// Do not update the PodGroup if it already exists and the TrainJob is not suspended
+	// While suspended, Delete() owns the PodGroup's lifecycle entirely: never (re)create
+	// it here. Otherwise, recreating it once Delete() has removed it would race with
+	// Delete() removing it again on the next reconcile, for as long as the TrainJob stays
+	// suspended.
+	if ptr.Deref(trainJob.Spec.Suspend, false) {
+		return nil, nil
+	}
+
+	// Do not update the PodGroup if it already exists: minMember, minResources,
+	// priorityClassName and networkTopology are all derived from the runtime template and
+	// pod requests, none of which change once the TrainJob is running.
 	oldPodGroup := &volcanov1beta1.PodGroup{}
 	if err := v.client.Get(ctx, client.ObjectKeyFromObject(trainJob), oldPodGroup); err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -151,7 +164,7 @@ func (v *Volcano) Build(ctx context.Context, info *runtime.Info, trainJob *train
 		}
 		oldPodGroup = nil
 	}
-	if oldPodGroup != nil && !ptr.Deref(trainJob.Spec.Suspend, false) {
+	if oldPodGroup != nil {
 		return nil, nil
 	}
 
@@ -209,6 +222,40 @@ func (v *Volcano) Build(ctx context.Context, info *runtime.Info, trainJob *train
 		WithBlockOwnerDeletion(true))
 
 	return []apiruntime.ApplyConfiguration{pg}, nil
+}
+
+// Delete returns the PodGroup that should now be removed for the TrainJob, once it is no
+// longer running: either because it reached a Failed or Complete condition, or because it
+// is currently suspended. A suspended TrainJob runs no Pods, so its PodGroup would
+// otherwise keep reserving `minResources` capacity in the Volcano queue indefinitely.
+func (v *Volcano) Delete(ctx context.Context, info *runtime.Info, trainJob *trainer.TrainJob) ([]client.Object, error) {
+	if info == nil || info.RuntimePolicy.PodGroupPolicy == nil || info.RuntimePolicy.PodGroupPolicy.Volcano == nil || trainJob == nil || !shouldDeletePodGroup(trainJob) {
+		return nil, nil
+	}
+
+	podGroup := &volcanov1beta1.PodGroup{}
+	if err := v.client.Get(ctx, client.ObjectKeyFromObject(trainJob), podGroup); err != nil {
+		// Mirrors the guard in Build(): a cluster where the Volcano CRD isn't installed
+		// would otherwise fail this Get() client-side with a RESTMapper error rather than
+		// an apiserver NotFound. The info check above already keeps this from being
+		// reached for TrainJobs that don't use Volcano; this is defense in depth for a
+		// misconfigured cluster where one does but the CRD is missing anyway.
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if !metav1.IsControlledBy(podGroup, trainJob) {
+		return nil, nil
+	}
+	return []client.Object{podGroup}, nil
+}
+
+// shouldDeletePodGroup reports whether a TrainJob's PodGroup should be removed: once the
+// TrainJob is Failed, Complete, or suspended, no Pods are scheduled to run, so its
+// PodGroup no longer needs to hold gang-scheduling capacity in the Volcano queue.
+func shouldDeletePodGroup(trainJob *trainer.TrainJob) bool {
+	return trainjob.IsTrainJobFinished(trainJob) || ptr.Deref(trainJob.Spec.Suspend, false)
 }
 
 type PodGroupRuntimeClassHandler struct {

--- a/pkg/runtime/framework/plugins/volcano/volcano_test.go
+++ b/pkg/runtime/framework/plugins/volcano/volcano_test.go
@@ -28,6 +28,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
@@ -215,7 +216,7 @@ func TestVolcano(t *testing.T) {
 			expectEnforcePodGroupError: nil,
 			expectBuildError:           nil,
 		},
-		"PodGroup exists but trainjob suspended": {
+		"PodGroup exists and trainjob suspended": {
 			trainJob: &trainer.TrainJob{
 				ObjectMeta: metav1.ObjectMeta{Name: "job-update", Namespace: "test-ns", UID: "2"},
 				Spec:       trainer.TrainJobSpec{Suspend: ptr.To(true)},
@@ -265,6 +266,87 @@ func TestVolcano(t *testing.T) {
 					},
 				},
 			},
+			// Build() defers entirely to Delete() while suspended (see the comment in
+			// Build() on the oscillation this avoids), so it must not (re)apply the
+			// PodGroup here even though one already exists.
+			expectObjs:                 nil,
+			expectEnforcePodGroupError: nil,
+			expectBuildError:           nil,
+		},
+		"PodGroup does not exist and trainjob suspended": {
+			trainJob: &trainer.TrainJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "job-suspended-new", Namespace: "test-ns", UID: "4"},
+				Spec:       trainer.TrainJobSpec{Suspend: ptr.To(true)},
+			},
+			info: &runtime.Info{
+				TemplateSpec: createBaseInfo.TemplateSpec,
+				RuntimePolicy: runtime.RuntimePolicy{
+					PodGroupPolicy: &trainer.PodGroupPolicy{
+						PodGroupPolicySource: trainer.PodGroupPolicySource{
+							Volcano: &trainer.VolcanoPodGroupPolicySource{},
+						},
+					},
+				},
+				Scheduler: &runtime.Scheduler{},
+			},
+			objs: nil,
+			expectInfo: &runtime.Info{
+				TemplateSpec: createBaseInfo.TemplateSpec,
+				RuntimePolicy: runtime.RuntimePolicy{
+					PodGroupPolicy: &trainer.PodGroupPolicy{
+						PodGroupPolicySource: trainer.PodGroupPolicySource{
+							Volcano: &trainer.VolcanoPodGroupPolicySource{},
+						},
+					},
+				},
+				Scheduler: &runtime.Scheduler{
+					PodAnnotations: map[string]string{
+						volcanov1beta1.KubeGroupNameAnnotationKey: "job-suspended-new",
+					},
+				},
+			},
+			// Regression guard for the create/delete oscillation: a suspended TrainJob
+			// whose PodGroup was already removed (e.g. by Delete()) must not have it
+			// recreated on the next reconcile while still suspended.
+			expectObjs:                 nil,
+			expectEnforcePodGroupError: nil,
+			expectBuildError:           nil,
+		},
+		"PodGroup does not exist and trainjob resumed from suspend": {
+			trainJob: &trainer.TrainJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "job-resumed", Namespace: "test-ns", UID: "5"},
+				Spec:       trainer.TrainJobSpec{Suspend: ptr.To(false)},
+			},
+			info: &runtime.Info{
+				TemplateSpec: createBaseInfo.TemplateSpec,
+				RuntimePolicy: runtime.RuntimePolicy{
+					PodGroupPolicy: &trainer.PodGroupPolicy{
+						PodGroupPolicySource: trainer.PodGroupPolicySource{
+							Volcano: &trainer.VolcanoPodGroupPolicySource{},
+						},
+					},
+				},
+				Scheduler: &runtime.Scheduler{},
+			},
+			objs: nil,
+			expectInfo: &runtime.Info{
+				TemplateSpec: createBaseInfo.TemplateSpec,
+				RuntimePolicy: runtime.RuntimePolicy{
+					PodGroupPolicy: &trainer.PodGroupPolicy{
+						PodGroupPolicySource: trainer.PodGroupPolicySource{
+							Volcano: &trainer.VolcanoPodGroupPolicySource{},
+						},
+					},
+				},
+				Scheduler: &runtime.Scheduler{
+					PodAnnotations: map[string]string{
+						volcanov1beta1.KubeGroupNameAnnotationKey: "job-resumed",
+					},
+				},
+			},
+			// Once resumed, Build() must recreate the PodGroup exactly as if this were
+			// a first-time create: no state carries over from before it was deleted
+			// while suspended.
 			expectObjs: []apiruntime.Object{
 				&volcanov1beta1.PodGroup{
 					TypeMeta: metav1.TypeMeta{
@@ -272,14 +354,14 @@ func TestVolcano(t *testing.T) {
 						Kind:       "PodGroup",
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "job-update",
+						Name:      "job-resumed",
 						Namespace: "test-ns",
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion:         trainer.GroupVersion.String(),
 								Kind:               trainer.TrainJobKind,
-								Name:               "job-update",
-								UID:                types.UID(strconv.Itoa(2)),
+								Name:               "job-resumed",
+								UID:                types.UID(strconv.Itoa(5)),
 								Controller:         ptr.To(true),
 								BlockOwnerDeletion: ptr.To(true),
 							},
@@ -291,12 +373,7 @@ func TestVolcano(t *testing.T) {
 							corev1.ResourceCPU:    resource.MustParse("2300m"),
 							corev1.ResourceMemory: resource.MustParse("3Gi"),
 						},
-						Queue:             "q1",
 						PriorityClassName: "high-priority",
-						NetworkTopology: &volcanov1beta1.NetworkTopologySpec{
-							Mode:               volcanov1beta1.HardNetworkTopologyMode,
-							HighestTierAllowed: ptr.To(1),
-						},
 					},
 				},
 			},
@@ -392,6 +469,191 @@ func TestVolcano(t *testing.T) {
 			}
 			if diff := gocmp.Diff(c.expectObjs, typedObjs, objCmpOpts...); len(diff) != 0 {
 				t.Errorf("Unexpected objects from Build (-want, +got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestVolcano_Delete(t *testing.T) {
+	errorGetPodGroup := errors.New("error when getting existing PodGroup")
+
+	ownedPodGroup := &volcanov1beta1.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-trainjob",
+			Namespace: "test-ns",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         trainer.GroupVersion.String(),
+					Kind:               trainer.TrainJobKind,
+					Name:               "test-trainjob",
+					UID:                types.UID("1"),
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
+		},
+	}
+	notOwnedPodGroup := &volcanov1beta1.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-trainjob", Namespace: "test-ns"},
+	}
+
+	failedTrainJob := &trainer.TrainJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-trainjob", Namespace: "test-ns", UID: "1"},
+		Status: trainer.TrainJobStatus{
+			Conditions: []metav1.Condition{
+				{Type: trainer.TrainJobFailed, Status: metav1.ConditionTrue},
+			},
+		},
+	}
+
+	volcanoInfo := &runtime.Info{
+		RuntimePolicy: runtime.RuntimePolicy{
+			PodGroupPolicy: &trainer.PodGroupPolicy{
+				PodGroupPolicySource: trainer.PodGroupPolicySource{
+					Volcano: &trainer.VolcanoPodGroupPolicySource{},
+				},
+			},
+		},
+	}
+
+	cases := map[string]struct {
+		info          *runtime.Info
+		trainJob      *trainer.TrainJob
+		objs          []client.Object
+		withError     bool
+		withNoKindErr bool
+		wantObjs      []client.Object
+	}{
+		"nil info": {
+			info:     nil,
+			trainJob: failedTrainJob,
+			objs:     []client.Object{ownedPodGroup},
+			wantObjs: nil,
+		},
+		"nil trainjob": {
+			info:     volcanoInfo,
+			trainJob: nil,
+			objs:     []client.Object{ownedPodGroup},
+			wantObjs: nil,
+		},
+		"runtime not configured for Volcano is left alone": {
+			info:     &runtime.Info{},
+			trainJob: failedTrainJob,
+			objs:     []client.Object{ownedPodGroup},
+			wantObjs: nil,
+		},
+		"running trainjob is not touched": {
+			info: volcanoInfo,
+			trainJob: &trainer.TrainJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-trainjob", Namespace: "test-ns", UID: "1"},
+			},
+			objs:     []client.Object{ownedPodGroup},
+			wantObjs: nil,
+		},
+		"complete trainjob returns its PodGroup": {
+			info: volcanoInfo,
+			trainJob: &trainer.TrainJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-trainjob", Namespace: "test-ns", UID: "1"},
+				Status: trainer.TrainJobStatus{
+					Conditions: []metav1.Condition{
+						{Type: trainer.TrainJobComplete, Status: metav1.ConditionTrue},
+					},
+				},
+			},
+			objs:     []client.Object{ownedPodGroup},
+			wantObjs: []client.Object{ownedPodGroup},
+		},
+		"failed trainjob returns its PodGroup": {
+			info:     volcanoInfo,
+			trainJob: failedTrainJob,
+			objs:     []client.Object{ownedPodGroup},
+			wantObjs: []client.Object{ownedPodGroup},
+		},
+		"suspended trainjob returns its PodGroup": {
+			info: volcanoInfo,
+			trainJob: &trainer.TrainJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-trainjob", Namespace: "test-ns", UID: "1"},
+				Spec:       trainer.TrainJobSpec{Suspend: ptr.To(true)},
+			},
+			objs:     []client.Object{ownedPodGroup},
+			wantObjs: []client.Object{ownedPodGroup},
+		},
+		"suspend field nil defaults to not-suspended": {
+			info: volcanoInfo,
+			trainJob: &trainer.TrainJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-trainjob", Namespace: "test-ns", UID: "1"},
+			},
+			objs:     []client.Object{ownedPodGroup},
+			wantObjs: nil,
+		},
+		"PodGroup already deleted is idempotent": {
+			info:     volcanoInfo,
+			trainJob: failedTrainJob,
+			objs:     nil,
+			wantObjs: nil,
+		},
+		"PodGroup not controlled by this trainjob is left alone": {
+			info:     volcanoInfo,
+			trainJob: failedTrainJob,
+			objs:     []client.Object{notOwnedPodGroup},
+			wantObjs: nil,
+		},
+		"Get error is propagated": {
+			info:      volcanoInfo,
+			trainJob:  failedTrainJob,
+			objs:      []client.Object{ownedPodGroup},
+			withError: true,
+			wantObjs:  nil,
+		},
+		"Volcano CRD not installed is tolerated like NotFound": {
+			info:          volcanoInfo,
+			trainJob:      failedTrainJob,
+			objs:          []client.Object{ownedPodGroup},
+			withNoKindErr: true,
+			wantObjs:      nil,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			t.Cleanup(cancel)
+
+			clientBuilder := utiltesting.NewClientBuilder().WithObjects(c.objs...)
+			switch {
+			case c.withError:
+				clientBuilder.WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, cli client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						return errorGetPodGroup
+					},
+				})
+			case c.withNoKindErr:
+				clientBuilder.WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, cli client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						return &apimeta.NoKindMatchError{GroupKind: volcanov1beta1.SchemeGroupVersion.WithKind("PodGroup").GroupKind()}
+					},
+				})
+			}
+			cli := clientBuilder.Build()
+			plugin, err := New(ctx, cli, utiltesting.AsIndex(clientBuilder), nil)
+			if err != nil {
+				t.Fatalf("Failed to create plugin: %v", err)
+			}
+
+			gotObjs, err := plugin.(framework.ComponentDeleterPlugin).Delete(ctx, c.info, c.trainJob)
+
+			var wantErr error
+			if c.withError {
+				wantErr = errorGetPodGroup
+			}
+			if diff := gocmp.Diff(wantErr, err, cmpopts.EquateErrors()); len(diff) != 0 {
+				t.Errorf("Unexpected error from Delete (-want, +got): %s", diff)
+			}
+			if diff := gocmp.Diff(c.wantObjs, gotObjs,
+				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
+			); len(diff) != 0 {
+				t.Errorf("Unexpected objects from Delete (-want, +got): %s", diff)
 			}
 		})
 	}

--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -33,6 +33,10 @@ type ReconcilerBuilder func(*builder.Builder, client.Client, cache.Cache) *build
 
 type Runtime interface {
 	NewObjects(ctx context.Context, trainJob *trainer.TrainJob) ([]runtime.ApplyConfiguration, error)
+	// DeleteObjects returns the previously materialized objects that should now be
+	// removed for the TrainJob. It must be safe to call on every reconcile, regardless
+	// of the TrainJob's status, and must be idempotent.
+	DeleteObjects(ctx context.Context, trainJob *trainer.TrainJob) ([]client.Object, error)
 	RuntimeInfo(trainJob *trainer.TrainJob, runtimeTemplateSpec any, mlPolicy *trainer.MLPolicy, podGroupPolicy *trainer.PodGroupPolicy) (*Info, error)
 	TrainJobStatus(ctx context.Context, trainJob *trainer.TrainJob) (*trainer.TrainJobStatus, error)
 	EventHandlerRegistrars() []ReconcilerBuilder


### PR DESCRIPTION
**TL;DR**: new `ComponentDeleterPlugin` interface, mirrors `ComponentBuilderPlugin`. Volcano uses it to delete its `PodGroup` once a TrainJob is `Failed`, `Complete`, or suspended.

Opening as a draft, per the discussion in #4033. Thanks to @robert-bell for working through the design there with me. This is a starting point, not a finished ask, so feel free to pick it apart.

**What this PR does / why we need it**:

Right now, when a Volcano-scheduled TrainJob (`podGroupPolicy.volcano`) goes `Failed`, `Complete`, or gets suspended, its `scheduling.volcano.sh/v1beta1 PodGroup` just sits there. It keeps holding `minResources` in the Volcano queue forever. Other TrainJobs sharing that queue can end up stuck `Pending` even when nodes have plenty of free capacity.

```mermaid
flowchart LR
    A["TrainJob reconcile"] --> B{"IsTrainJobFinished?"}
    B -->|"false"| C["NewObjects → Build()\n(unchanged)"]
    A --> D["DeleteObjects → Delete()\n(new, runs every reconcile)"]
    D --> E{"Failed / Complete /\nSuspend?"}
    E -->|"yes"| F["PodGroup removed"]
    E -->|"no, Running"| G["left alone"]

    style D fill:#d4edda,stroke:#155724
    style F fill:#d4edda,stroke:#155724
```

The new interface is deliberately shaped like `Build()`: a plugin hands back the objects it wants gone, the reconciler does the actual `client.Delete()`. It runs every reconcile no matter the TrainJob's status, so the plugin just answers "should this object exist right now" each time rather than reacting to a one-shot transition.

Volcano implements `Delete()` to remove its `PodGroup` on `Failed`/`Complete`/suspend. `Build()` also changes slightly: it now skips (re)creating the `PodGroup` while suspended, otherwise it would just fight with `Delete()` on every suspended reconcile and you'd get a create/delete loop.

No existing plugin interface changes. `ComponentDeleterPlugin` is opt-in the same way `EnforcePodGroupPolicyPlugin`/`WatchExtensionPlugin` already are, `framework.New()` just checks for it with a type assertion.

**Scope notes**:
- Only Volcano implements this for now. `CoScheduling` has basically the same PodGroup lifecycle issue, but I left it alone on purpose since the existing integration tests assert its PodGroup survives `Complete`/`Failed`, and changing that felt like its own conversation.
- `reconcileDeadline()` still deletes the child JobSet directly (that's the pre-existing code tied to #3833). Left a TODO there instead of folding two migrations into one PR.
- RBAC needed a `delete` verb on `scheduling.volcano.sh/podgroups` that was never there. Got it from `controller-gen`, not hand-edited. The `scheduling.volcano.sh`/`scheduling.x-k8s.io` rule that used to be shared now splits into two, since their verbs no longer match.

**How this was tested**:
- New unit tests in `volcano_test.go` for `Delete()` (nil info/trainjob, Failed, Complete, Suspend, PodGroup already gone, ownership mismatch, Get error, Volcano CRD not installed) and for `Build()` (suspend no longer recreates the PodGroup, plus a regression test for the create/delete oscillation). Also new tests in `framework_test.go` and `trainjob_controller_test.go`.
- `make test` and `make test-integration` pass, including the existing CoScheduling tests that check its PodGroup survives Complete/Failed, so I know that path is untouched.
- Ran it end to end on a real Kind cluster with Volcano v1.12.1 (not just envtest): PodGroup gets deleted on Failed and Complete, deleted on suspend, comes back clean on resume with no oscillation, and stays put while the job is actually Running.

Fixes #4033

**Checklist:**

- [x] [Docs](https://trainer.kubeflow.org/en/latest/) included if any changes are user facing (n/a, internal controller/plugin behavior only)
